### PR TITLE
Framework pivot: Phaser + Colyseus + planck stack (ADR-001)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,19 +8,37 @@ Browser-based multiplayer Worms-style artillery game. Friends visit `mccarrison.
 
 ## Status
 
-**Phase**: Foundation complete (PR #26, merged 2026-04-20). Scaffolding only; no game logic yet.
+**Phase**: Foundation + alignment complete. PR #26 (build scaffolding) + PR #27 (orchestration docs) + PR #28 (plan-time resources) + the pivot PR (Phaser stack + server scaffold) all merged.
 
-**Next**: Epic 3 (port destructible terrain from reference/ to planck.js).
+**Next**: Epic 3 (port destructible terrain algorithm, wrap in a Phaser Scene with planck physics).
 
-See [docs/ROADMAP.md](docs/ROADMAP.md) for full state.
+See [docs/ROADMAP.md](docs/ROADMAP.md) for full state and [docs/decisions/](docs/decisions/) for architecture decision records.
 
 ## Stack
 
+Framework pivot happened 2026-04-20; see [ADR-001](docs/decisions/001-framework-pivot.md) for rationale. Previously planned as hand-rolled Canvas + Socket.IO; now modern indie-game stack:
+
+- **Client framework**: Phaser 3 (batteries-included 2D: sprites, input, scenes, audio, tweens, particles, camera)
+- **Physics**: planck.js (Box2D port). Phaser's default Matter.js is swapped out; we plug planck in.
+- **Multiplayer**: Colyseus (room-based server framework: join-by-code, authoritative state, binary schema, reconnection). Collapses Epic 8-10 into one integration epic.
+- **Art pipeline**: Aseprite -> JSON atlas. Standard indie pixel-art workflow; Phaser loads both natively.
+- **Live tuning**: dat.gui overlay toggled with `` ` `` (backtick) in dev builds. All tunables live in `src/tuning.ts`; no hardcoded magic numbers in game logic.
+- **State machines** (added when needed): xstate for game flow (lobby -> playing -> ended), weapon charge states, etc.
 - **Build**: Vite 6 + TypeScript 5 (strict, bundler resolution) + Biome 1.9
-- **Physics**: planck.js (pure-JS Box2D port). Picked over Rapier (WASM) to avoid cold-load stutter for casual play; bodies are few (few worms + projectiles) so JS perf is fine
-- **Multiplayer** (future): Socket.IO 4, authoritative server on EC2 alongside brain. Lockstep ruled out (reference had it, too fragile at >50ms latency)
-- **Deploy** (future): static frontend at `mccarrison.me/worms`, WebSocket proxied via nginx to Socket.IO server on the same EC2. Same-origin avoids CORS + extra TLS cert
 - **Node**: 20+ (pinned via `.nvmrc`)
+
+**Deploy** (future): client to Cloudflare Pages (static CDN). Server (Colyseus) to Fly.io or co-located on brain's EC2 with nginx proxying `/worms/ws`. See Epic 13.
+
+## Drop-in philosophy
+
+Adding content should be a data file + sprite, not custom code. The stack is chosen so:
+
+- **A new weapon** = one Aseprite sprite + one `src/weapons/<name>.ts` config file (mostly data; maybe 10-30 lines of unique behavior for things like homing missiles). See [docs/guides/adding-a-weapon.md](docs/guides/adding-a-weapon.md).
+- **A new map** = one PNG mask + one JSON config, OR a procedural generator function. See [docs/guides/adding-a-map.md](docs/guides/adding-a-map.md).
+- **A new character (worm skin)** = one Aseprite file with named animation tags. See [docs/guides/adding-a-character.md](docs/guides/adding-a-character.md).
+- **Tuning** = drag a slider, commit the value. Never edit hardcoded magic numbers. See [docs/guides/tuning-physics.md](docs/guides/tuning-physics.md).
+
+**The one custom thing**: destructible terrain. Unlike other entities (one sprite + one body), terrain is a pixel mask + hundreds of static bodies rebuilt on every explosion. Always a custom subsystem; ported algorithmically from the 2013 reference, wrapped as a Phaser GameObject.
 
 ## Origin
 
@@ -64,27 +82,35 @@ When Context7 doesn't have a library or the topic is non-library (game netcode t
 When resuming work after `/clear` or a new session:
 
 1. Read this file
-2. Read `docs/ROADMAP.md` for current phase and open epics
-3. `gh pr list --repo scottmccarrison/worms --state all --limit 5` for recent activity
-4. `git log --oneline -10` for recent commits
-5. Check `docs/plans/` for plans on in-progress epics
-6. Ask user what to work on, or propose based on ROADMAP
+2. Skim `docs/decisions/` for any ADRs that affect the upcoming work
+3. Read `docs/ROADMAP.md` for current phase and open epics
+4. `gh pr list --repo scottmccarrison/worms --state all --limit 5` for recent activity
+5. `git log --oneline -10` for recent commits
+6. Check `docs/plans/` for plans on in-progress epics
+7. Ask user what to work on, or propose based on ROADMAP
 
 ## Key decisions (rationale that isn't obvious from code)
 
-- **Archive, don't delete, legacy code**: keeps port reference in-tree; beats `git show HEAD~50:src/Worm.ts`
-- **planck.js over Rapier**: snappier cold load (no WASM init); casual multiplayer game has few bodies so WASM perf advantage doesn't pay off
-- **Authoritative server over lockstep**: reference's lockstep was brittle; turn-based gameplay means only active player's inputs matter, keeping netcode simple
-- **Room codes in-memory (not DB-backed)**: 4 letters = 456k combos, collisions rare, games ephemeral, no account system needed
+- **Framework pivot (2026-04-20)**: switched from hand-rolled Canvas + Socket.IO to Phaser 3 + Colyseus + planck + Aseprite. Port the algorithms from reference/, not the architecture. See [ADR-001](docs/decisions/001-framework-pivot.md).
+- **Terrain is the one custom subsystem**: every other entity is sprite + body (drop-in data); terrain is a pixel mask + many bodies that don't fit that pattern. Custom by necessity.
+- **Archive, don't delete, legacy code**: keeps port reference in-tree; beats `git show HEAD~50:src/Worm.ts`. Each epic deletes its corresponding reference files in the same PR (port-then-delete).
+- **planck.js over Rapier**: snappier cold load (no WASM init); casual multiplayer game has few bodies so WASM perf advantage doesn't pay off.
+- **Colyseus over hand-rolled Socket.IO**: collapses Epic 8-10 (lobby/netcode/reconnection) into one integration epic. Binary schema, room codes, reconnection all built in.
+- **Authoritative server over lockstep**: reference's lockstep was brittle; turn-based gameplay means only active player's inputs matter, keeping netcode simple.
+- **Room codes in-memory (not DB-backed)**: 4 letters = 456k combos, collisions rare, games ephemeral, no account system needed. Colyseus assigns these as Room ids.
+- **No hardcoded tunables in game logic**: everything tweakable lives in `src/tuning.ts`. Live-editable via dat.gui in dev builds. Makes iteration fast and code grep-friendly.
+- **No AI-generated art** (user preference): CC0/CC-BY from OpenGameArt/Freesound, commission gaps if needed.
 
 ## References by epic
 
 Consult these at plan time. Context7 for library docs; WebFetch for articles. Don't guess from training-cutoff knowledge; these surfaces change.
 
 ### Epic 3 — Destructible terrain
+- **Phaser 3** (via Context7): Scene lifecycle, GameObjects, custom rendering
 - planck.js (via Context7): body construction, collision filtering, polygon fixtures, body destruction
 - [Canvas pixel-mask destructible terrain pattern](https://seblagarde.wordpress.com/2012/01/08/pixel-perfect-2d/) (article; same technique used in reference `Terrain.ts`)
 - Reference: `reference/src/environment/Terrain.ts`, `reference/src/system/Physics.ts`
+- **Note**: implementation wraps the terrain algorithm as a Phaser GameObject; not a raw Canvas loop
 
 ### Epic 4 — Worm physics + movement
 - planck.js (via Context7): distance joint (ninja rope), contact sensors (foot detection), applyForce vs applyImpulse
@@ -103,21 +129,15 @@ Consult these at plan time. Context7 for library docs; WebFetch for articles. Do
 - No external library needed for static maps
 - For map JSON format, reference Tiled map editor conventions as inspiration: [Tiled JSON format](https://doc.mapeditor.org/en/stable/reference/json-map-format/)
 
-### Epic 8 — Lobby UI
-- **Invoke `/frontend-design` skill as a plan step.** Do not write UI directly.
-- Context7: Socket.IO client library for the join/create flow integration point
-- Inspiration references: Hedgewars lobby UX, Jackbox join-by-code pattern
+### Epic 8-10 — Multiplayer (Colyseus integration, collapsed)
 
-### Epic 9 — Authoritative server netcode
-- [Gaffer On Games — Networked Physics](https://gafferongames.com/categories/networked-physics/) — **read before planning**; canonical reference
-- [Gaffer On Games — Introduction to Networked Physics](https://gafferongames.com/post/introduction_to_networked_physics/)
-- [Valve Source Multiplayer Networking](https://developer.valvesoftware.com/wiki/Source_Multiplayer_Networking)
-- Socket.IO (via Context7): rooms, namespaces, adapter, broadcast patterns, ack timeouts
-- Server game loop: `setInterval` or `setImmediate` + accumulator pattern (Gaffer's "Fix Your Timestep")
+Per [ADR-001](docs/decisions/001-framework-pivot.md), Epic 8 (lobby/rooms), Epic 9 (authoritative state), and Epic 10 (reconnection) collapse into one integration epic. Colyseus provides rooms, state sync, and connection recovery out of the box.
 
-### Epic 10 — Reconnection
-- Socket.IO (via Context7): connection state recovery, session persistence
-- [Socket.IO Connection State Recovery docs](https://socket.io/docs/v4/connection-state-recovery)
+- **Colyseus** (via Context7): Room lifecycle, state schema, client-server message flow, binary serialization
+- [Colyseus docs](https://docs.colyseus.io/) - the canonical source
+- [Colyseus examples](https://github.com/colyseus/examples) - turn-based game example patterns
+- [Gaffer On Games — Networked Physics](https://gafferongames.com/categories/networked-physics/) - still useful for understanding trade-offs even though Colyseus handles most of it
+- **Invoke `/frontend-design` skill** for the lobby UI portion — do not write UI directly
 
 ### Epic 11 — Sprites
 - [OpenGameArt.org — filter CC0/CC-BY](https://opengameart.org/art-search-advanced?keys=worm&field_art_type_tid%5B%5D=9&sort_by=count&sort_order=DESC)
@@ -128,10 +148,11 @@ Consult these at plan time. Context7 for library docs; WebFetch for articles. Do
 
 ### Epic 13 — Deploy
 - **Invoke `/security-review` skill before merge.**
-- [Socket.IO Server Deployment guide](https://socket.io/docs/v4/server-deployment/)
+- Client: Cloudflare Pages (static bundle from `npm run build`)
+- Server: [Colyseus Server Deployment guide](https://docs.colyseus.io/deployment/) - Fly.io recommended, or EC2 co-located with brain
 - [Nginx WebSocket reverse proxy](https://nginx.org/en/docs/http/websocket.html)
 - [OWASP — WebSocket security (CSWSH)](https://owasp.org/www-community/attacks/Cross_Site_WebSocket_Hijacking)
-- Same EC2 as brain (100.105.131.123); nginx already terminates TLS for brain
+- If co-locating: same EC2 as brain (100.105.131.123); nginx already terminates TLS
 
 ### Epic 14 — CI/CD
 - [GitHub Actions security hardening (StepSecurity)](https://github.com/step-security/secure-repo)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,25 +2,29 @@
 
 Source of truth: [GitHub issues](https://github.com/scottmccarrison/worms/issues). This file mirrors them with status, PR links, and plan docs.
 
+> **Framework pivot 2026-04-20**: stack is now Phaser 3 + planck + Colyseus + Aseprite. See [ADR-001](decisions/001-framework-pivot.md). Epic descriptions below reflect the new approach; issue bodies were updated with pivot notes.
+
 ## MVP epics
 
-| #  | Epic                                     | Status   | PR   | Plan                                               |
-|----|------------------------------------------|----------|------|----------------------------------------------------|
-| 1  | Modernize build system                   | Done     | #26  | [epic-1-2-foundation](plans/epic-1-2-foundation.md) |
-| 2  | Cleanup dead code                        | Done     | #26  | [epic-1-2-foundation](plans/epic-1-2-foundation.md) |
-| 3  | Port destructible terrain to planck.js   | Todo     | -    | -                                                  |
-| 4  | Port worm physics + movement             | Todo     | -    | -                                                  |
-| 5  | Port turn-based game state + win cond    | Todo     | -    | -                                                  |
-| 6  | Port weapon system (8 + Bazooka)         | Todo     | -    | -                                                  |
-| 7  | Map loading + starter maps               | Todo     | -    | -                                                  |
-| 8  | Room code lobby system                   | Todo     | -    | -                                                  |
-| 9  | Authoritative server netcode             | Todo     | -    | -                                                  |
-| 10 | Reconnection + disconnect handling       | Todo     | -    | -                                                  |
-| 11 | Source original sprite assets            | Todo     | -    | -                                                  |
-| 12 | Source original audio assets             | Todo     | -    | -                                                  |
-| 13 | Deploy pipeline                          | Todo     | -    | -                                                  |
-| 14 | CI/CD                                    | Partial  | #26  | (minimal CI landed in #26; full auto-deploy TBD)   |
-| 15 | Test harness (Vitest)                    | Todo     | -    | -                                                  |
+| #  | Epic                                     | Status   | PR       | Plan                                               |
+|----|------------------------------------------|----------|----------|----------------------------------------------------|
+| 1  | Modernize build system                   | Done     | #26      | [epic-1-2-foundation](plans/epic-1-2-foundation.md) |
+| 2  | Cleanup dead code                        | Done     | #26      | [epic-1-2-foundation](plans/epic-1-2-foundation.md) |
+| 3  | Terrain: port algorithm + Phaser wrapper | Todo     | -        | -                                                  |
+| 4  | Worm entity (Phaser sprite + planck body) | Todo    | -        | -                                                  |
+| 5  | Turn state + win condition (xstate)      | Todo     | -        | -                                                  |
+| 6  | Weapon system (data-driven, 8 + Bazooka) | Todo     | -        | -                                                  |
+| 7  | Map loading + starter maps               | Todo     | -        | -                                                  |
+| 8  | Colyseus integration: lobby + rooms [*]  | Todo     | -        | -                                                  |
+| 9  | Colyseus integration: state schema [*]   | Todo     | -        | -                                                  |
+| 10 | Colyseus integration: reconnection [*]   | Todo     | -        | -                                                  |
+| 11 | Source original sprite assets (Aseprite) | Todo     | -        | -                                                  |
+| 12 | Source original audio assets             | Todo     | -        | -                                                  |
+| 13 | Deploy pipeline (Cloudflare + Fly.io)    | Todo     | -        | -                                                  |
+| 14 | CI/CD                                    | Partial  | #26      | (minimal CI landed in #26; full auto-deploy TBD)   |
+| 15 | Test harness (Vitest)                    | Todo     | -        | -                                                  |
+
+[*] Epic 8/9/10 were originally three separate epics (lobby / netcode / reconnection). Per [ADR-001](decisions/001-framework-pivot.md), Colyseus provides all three out of the box; work now collapses into one integration epic. Issues #8/#9/#10 remain as tracked sub-deliverables.
 
 ## Post-MVP enhancements
 
@@ -40,9 +44,9 @@ Source of truth: [GitHub issues](https://github.com/scottmccarrison/worms/issues
 ## Proposed build order
 
 - **M1 Foundation**: #1, #2 — **DONE** (PR #26)
-- **M2 Single-player playable**: #3 → #4 → #5 → #6 → #7 + #15 (tests along the way) + placeholder assets from #11/#12
-- **M3 Multiplayer local**: #8 → #9 → #10
-- **M4 Shipped**: #13 + #14 done + real assets from #11, #12
+- **M2 Single-player playable** (Phaser + planck): #3 → #4 → #5 → #6 → #7 + #15 (tests along the way) + placeholder assets from #11/#12
+- **M3 Multiplayer** (Colyseus integration, collapsed): #8/#9/#10 in one or two PRs
+- **M4 Shipped**: #13 (Cloudflare Pages + Fly.io/EC2) + #14 done + real assets from #11, #12
 
 Parallelization: assets (#11, #12) and infra (#13, #14) don't block game logic and can run in parallel with core work once foundation is done.
 
@@ -50,4 +54,4 @@ Parallelization: assets (#11, #12) and infra (#13, #14) don't block game logic a
 
 One-line-per-session record. Detailed history: `git log`, PR descriptions, brain-mem.
 
-- **2026-04-20**: Forked repo, triaged and filed 15 epic + 10 enhancement issues, wrote foundation plan, shipped PR #26 (archive legacy under reference/, add Vite+TS5+Biome scaffolding + minimal CI). Also established project docs convention: CLAUDE.md, this roadmap, and `docs/plans/` (separate PR).
+- **2026-04-20**: Forked repo, triaged and filed 15 epic + 10 enhancement issues, wrote foundation plan, shipped PR #26 (archive legacy under reference/, add Vite+TS5+Biome scaffolding + minimal CI). Established project docs convention via PR #27 (CLAUDE.md, ROADMAP.md, docs/plans/), added plan-time resources via PR #28 (Context7 MCP, references-by-epic, mandated skill invocation). Later same day: **framework pivot** (ADR-001) from hand-rolled Canvas + Socket.IO to Phaser 3 + Colyseus + planck + Aseprite. Added `server/` workspace scaffold, drop-in workflow guides in `docs/guides/`.

--- a/docs/decisions/001-framework-pivot.md
+++ b/docs/decisions/001-framework-pivot.md
@@ -1,0 +1,78 @@
+# ADR-001: Framework pivot to Phaser + Colyseus + planck + Aseprite
+
+- **Status**: Accepted
+- **Date**: 2026-04-20
+- **Supersedes**: the initial "port reference architecture 1:1" approach established in PR #26 and the Epic 1-15 roadmap as first written
+- **Related**: Epic 3 (terrain), 8 (lobby), 9 (netcode), 10 (reconnection)
+
+## Context
+
+Initial approach (PRs #26, #27, #28) was to fork CiaranMcCann/Worms-Armageddon-HTML5-Clone (2013, Apache 2.0) and port its code module-by-module. The reference codebase is ~7000 LOC across 74 TypeScript files with custom implementations of nearly every game-engine concern: asset loading, scene management, sprite animation, camera, input, physics wrappers, audio preloading, lockstep netcode, and a leaderboards stack.
+
+Partway through planning Epic 3, we stopped and audited: ~60% of the reference code is game-engine plumbing that modern web game tools (2024-2026) make obsolete; only ~40% is genuine game logic and algorithms worth keeping. Continuing the port would mean rebuilding a 2013-era game engine from scratch in TypeScript, spending most of our effort on infrastructure that tools like Phaser and Colyseus solve out of the box.
+
+The three priorities the user explicitly named:
+
+1. **Casual drop-in-and-play with friends.** Text a code, click a link, play. No accounts, no install, no friction.
+2. **Snappy and intuitive.** Fast cold load, instant input response, smooth framerate, immediate game start.
+3. **Reproducible, data-driven content.** Adding a weapon or map should be a data file + sprite, not custom code. Physics tuning should be a live slider, not a recompile.
+
+Against those priorities, a hand-rolled-from-2013-code approach loses on priority 3 (custom engine = custom everything = not reproducible) and partially on priority 2 (every bespoke piece is another surface to optimize). It ties only priority 1, which any stack can deliver.
+
+## Decision
+
+Adopt the following stack for the worms game:
+
+| Layer | Tool | Why |
+|---|---|---|
+| **Client framework** | Phaser 3 | Batteries-included 2D (sprites, input, scenes, audio, tweens, particles, cameras). Biggest 2D web framework, TypeScript-first, excellent docs. |
+| **Physics** | planck.js | Box2D port, unchanged from original plan. Phaser's default Matter.js is swappable; we plug planck in. |
+| **Multiplayer** | Colyseus | Room-based multiplayer framework designed for this exact shape: join-by-code, authoritative server, reconnection, binary schema. Collapses what would be three epics of hand-rolled netcode into one integration epic. |
+| **Art pipeline** | Aseprite -> JSON atlas | Indie pixel-art standard. Aseprite exports frame data + PNG sprite sheet; Phaser loads both natively. |
+| **Live tuning** | dat.gui | Tiny debug UI toggled with `~` for on-the-fly physics/gameplay constants. Hardcoded-constants are banned; all tunables live in `src/tuning.ts`. |
+| **State machines** | xstate (added when needed) | Game flow (lobby -> playing -> ended), weapon charge states, etc. Not critical day 1. |
+| **Build** | Vite + TypeScript + Biome | Unchanged from PR #26. |
+| **Deploy** | Cloudflare Pages (client) + Fly.io or EC2 (server) | Client: static CDN. Server: regional game server. Both low-cost. |
+
+The reference/ archive remains useful but only as **algorithmic reference** (how destructible terrain works, how turn state is computed, how weapon explosions are modeled) — not architectural reference. The port-then-delete convention still applies per file that gets superseded.
+
+## Alternatives considered
+
+1. **Continue hand-rolled Canvas + Socket.IO (status quo)**. Works but rebuilds engine-level infrastructure for every epic. Estimated 12-15 weeks to MVP with ~30% more custom code owned.
+2. **Pixi.js only (rendering library)**. Gives us modern WebGL sprite batching but we still hand-roll scenes/input/audio. Middle ground that doesn't fully address priority 3.
+3. **Godot 4 with HTML5 export**. World-class visual editor and asset pipeline; loses TypeScript / JS-native workflow; HTML5 export is solid but adds a compile step; multiplayer is not turn-based-friendly out of the box.
+4. **PartyKit (Cloudflare Workers + Durable Objects)**. Modern, serverless, cheap. Less mature than Colyseus for turn-based games; smaller community. Worth revisiting if Colyseus hosting becomes a cost/ops issue.
+5. **Full Unity or Unreal WebGL export**. Massive overkill for a 2D turn-based browser game.
+
+## Consequences
+
+**Immediate (this PR)**:
+- `server/` workspace added for Colyseus scaffold
+- `CLAUDE.md` updated with new stack + drop-in philosophy section
+- `docs/guides/` added with step-by-step workflows for adding weapons, maps, characters; tuning workflow
+- `ROADMAP.md` updated: Epic 8-10 (lobby/netcode/reconnection) collapse under Colyseus integration scope
+- Issue comments on #3, #8, #9, #10 referencing this ADR
+
+**Epic 3 (next)**: Implementation changes, scope same. Terrain algorithm port is unchanged. Demo becomes a Phaser Scene instead of a raw Canvas render loop. Adds Phaser + planck + dat.gui as dependencies.
+
+**Epic 4-7 (core gameplay)**: Much less code. Worm = Phaser Sprite + planck body + Aseprite-animated atlas. Weapons = data files + small behavior functions. Maps = PNG + JSON OR procedural generator. Turn state = xstate machine.
+
+**Epic 8-10 (multiplayer)**: Colyseus collapses these. One epic: "Colyseus integration" covers rooms + join codes + authoritative state + schema + reconnection out of the box. Remaining custom work: lobby UI, game-specific schema, turn-handoff protocol.
+
+**Epic 11-12 (assets)**: Aseprite files in `public/assets/` (characters, weapons, effects, terrain themes). Freesound for audio. Licensing tracked in `NOTICE`.
+
+**Epic 13 (deploy)**: Two-target deploy: Cloudflare Pages for the Vite-built client, Fly.io or EC2 for the Colyseus server. nginx proxy `/worms/ws` -> Colyseus if we co-locate on brain's EC2.
+
+**Bundle size trade**: client gains ~400KB gzipped (Phaser) but that's ~1s extra cold load on broadband. Acceptable cost for what we get.
+
+**What we lose**: the "minimal modern stack" purity of a Vite + TypeScript + nothing-else setup. We gain ~3 dependencies but save weeks of writing engine-level code. Net win per our priorities.
+
+## Open questions (non-blocking)
+
+- **Server colocation vs separate host**: run Colyseus on brain's EC2 via nginx proxy, or Fly.io for game-server-specific features (regional routing, DDoS protection)? Revisit at Epic 13.
+- **State machines library**: xstate, zustand-with-FSM, or hand-rolled? Revisit at Epic 5.
+- **Audio engine**: Phaser's built-in (Howler under the hood) is probably enough; revisit at Epic 12 if we need spatial audio or precise timing.
+
+## How to use this ADR
+
+Future sessions pick this up as "stack is locked; algorithms are ported from reference/; architecture is modern." When writing a plan for any epic, check the References by epic section in CLAUDE.md, verify stack alignment before proposing custom infrastructure, and cite this ADR in any PR that revisits the decision.

--- a/docs/guides/adding-a-character.md
+++ b/docs/guides/adding-a-character.md
@@ -1,0 +1,133 @@
+# Adding a character (worm skin)
+
+A "character" is a worm visual identity — sprite, voice pack, hat options. All characters share the same physics body + game behavior; only visuals differ. Teams pick a character in the lobby.
+
+## 1. Author the Aseprite file
+
+Canvas size: 48x48 per frame (pixel art; sprites scale up in rendering).
+
+**Required animations** (Aseprite tags):
+
+| Tag | Frames | Loop | Notes |
+|---|---|---|---|
+| `idle` | 4 | yes | small idle bob |
+| `walk` | 6 | yes | 2-direction; horizontal flip handled at render time |
+| `jump` | 3 | no | anticipation + airborne + land |
+| `aim` | 4 | no | rotate with aim angle (frames are angle steps) |
+| `fire` | 2 | no | firing pose, plays then transitions back |
+| `damage` | 3 | no | flinch + flash |
+| `death` | 5 | no | knockout animation |
+| `celebrate` | 6 | yes | winner animation |
+
+Each tag is marked in Aseprite's tag panel (bottom-right of the animation timeline). The exporter includes tag metadata in the JSON.
+
+**Export** (`File -> Export Sprite Sheet`):
+
+- Layout: Packed
+- Output File: `ninja.png`
+- JSON Data: `ninja.json` (Array format)
+- Meta: include Tags
+
+Save to:
+
+```
+public/assets/characters/
+  ninja.png
+  ninja.json
+```
+
+## 2. Register
+
+`src/characters/index.ts`:
+
+```ts
+export const CHARACTERS = {
+  ninja: {
+    id: "ninja",
+    name: "Ninja",
+    description: "Dark and mysterious.",
+    atlas: "ninja",
+    voicePack: "ninja",    // see audio guide; optional
+    unlockRule: "default", // or "achievement:first-win" etc.
+  },
+  default: {
+    id: "default",
+    name: "Recruit",
+    atlas: "default",
+    voicePack: "default",
+    unlockRule: "default",
+  },
+} as const;
+
+export type CharacterId = keyof typeof CHARACTERS;
+```
+
+## 3. Loader
+
+`src/loaders/characters.ts`:
+
+```ts
+for (const c of Object.values(CHARACTERS)) {
+  scene.load.atlas(c.atlas, `assets/characters/${c.atlas}.png`, `assets/characters/${c.atlas}.json`);
+}
+```
+
+## 4. Hat / accessory slots
+
+Hats are a separate atlas rendered on top of the character sprite, anchored to a specific frame offset.
+
+```
+public/assets/hats/
+  top-hat.png
+  top-hat.json    # includes anchor offsets per animation frame
+```
+
+Anchors are set in the hat JSON: `{ frame: "walk-0", x: 24, y: 4 }`. The render system places the hat sprite at (character.x + anchor.x, character.y + anchor.y) every frame.
+
+Skip hats in v1; add in Epic 23 (team customization).
+
+## 5. Voice pack (optional; defer to later epic)
+
+`public/assets/voice/ninja/` contains line clips played on events:
+
+- `hello.ogg`, `hit.ogg`, `miss.ogg`, `death.ogg`, `win.ogg`
+
+Voice pack config in `src/characters/voice.ts` maps events to clip names. Optional for MVP.
+
+## 6. Test
+
+```sh
+npm run dev
+```
+
+Start local game, in lobby select your character, start round. Verify all animations play correctly at the right times:
+
+- `idle` when worm is not active
+- `walk` when walking
+- `jump` when jumping
+- `aim` when holding aim
+- `fire` on weapon fire
+- `damage` on hit
+- `death` on elimination
+- `celebrate` on round win
+
+## Reproducibility
+
+Once the character system exists (Epic 4 + 23), adding a new character is:
+
+1. One Aseprite file with named tags
+2. One entry in `CHARACTERS`
+3. Done.
+
+No code changes to game logic — the renderer picks up the new atlas automatically via the registry.
+
+## Checklist
+
+- [ ] Aseprite file with all required animation tags
+- [ ] Exported atlas + JSON at `public/assets/characters/<id>/`
+- [ ] Registered in `src/characters/index.ts`
+- [ ] Tested: all animation states fire on correct events
+- [ ] Voice pack (optional, later)
+- [ ] NOTICE updated if assets are CC-BY
+
+Typical effort: 4-8 hours of pixel art per character + 15 min of config.

--- a/docs/guides/adding-a-map.md
+++ b/docs/guides/adding-a-map.md
@@ -1,0 +1,136 @@
+# Adding a map
+
+Two paths: hand-authored PNG mask, or procedural generator. Both produce a terrain image the `Terrain` class ingests (per Epic 3).
+
+## Path A: hand-authored mask
+
+For distinctive, memorable maps (e.g., "Volcano Island," "Cavern").
+
+### 1. Draw the mask
+
+In any PNG editor: transparent = empty space, opaque = solid terrain. Recommended canvas size: 1920x1080 (larger than the viewport; the camera pans).
+
+Color the opaque pixels however you want — the mask only cares about alpha. The visible fill color is what the player sees (dirt brown, grass green, rock gray, etc.).
+
+Save to:
+
+```
+public/maps/<name>/
+  mask.png           # the terrain shape (alpha matters)
+  background.png     # optional parallax background (sky, distant hills)
+  config.json        # spawn points, theme, name, description
+```
+
+### 2. Map config
+
+`public/maps/volcano/config.json`:
+
+```json
+{
+  "id": "volcano",
+  "name": "Volcano Island",
+  "description": "Tight arena with a central crater.",
+  "mask": "mask.png",
+  "background": "background.png",
+  "theme": "volcanic",
+  "spawnPoints": [
+    { "x": 200, "y": 400 },
+    { "x": 800, "y": 400 },
+    { "x": 1400, "y": 350 },
+    { "x": 600, "y": 600 }
+  ],
+  "waterLevel": 980,
+  "maxWorms": 4
+}
+```
+
+Spawn points are center coordinates for worm placement at round start. Each worm spawns at one point, randomized among available spots.
+
+### 3. Register the map
+
+`src/maps/index.ts`:
+
+```ts
+export const MAPS = {
+  volcano: () => import("../../public/maps/volcano/config.json"),
+  forest: () => import("../../public/maps/forest/config.json"),
+  // ...
+};
+```
+
+Lazy-loaded so the selector doesn't pull every map's assets at boot.
+
+### 4. Test
+
+```sh
+npm run dev
+```
+
+Start local game -> lobby -> Map picker -> your map appears. Select, start game, verify spawn points are reachable (no worms trapped in cavities) and terrain destruction looks right.
+
+## Path B: procedural generator
+
+For variety without authoring dozens of maps. Hedgewars uses perlin noise + maze; we can do similar.
+
+`src/maps/generators/perlin.ts`:
+
+```ts
+import { createNoise2D } from "simplex-noise";
+
+export function generatePerlinMap(seed: string, options: GenOptions): MapData {
+  const noise = createNoise2D(seed);
+  const mask = new OffscreenCanvas(options.width, options.height);
+  const ctx = mask.getContext("2d");
+  // Draw terrain by sampling noise at each column, filling below threshold
+  // ...
+  return {
+    mask,
+    spawnPoints: findReachableSpawns(mask, options.players),
+    theme: options.theme,
+  };
+}
+```
+
+Players share the seed; server authoritatively uses the seed to generate the same map on every client. No image transfer needed — just send the seed in the Colyseus Room state.
+
+### Registering a generator
+
+```ts
+export const MAP_GENERATORS = {
+  perlin: generatePerlinMap,
+  maze: generateMazeMap,
+  caverns: generateCavernsMap,
+};
+```
+
+Lobby map-picker offers "Random (perlin)" as an entry; clicking rolls a seed.
+
+## Theme system
+
+Themes swap terrain visual fill + background + audio ambience without changing mask geometry. Configured per-map (`theme: "volcanic"`) or per-generator output.
+
+`src/themes/volcanic.ts`:
+
+```ts
+export const volcanic: Theme = {
+  id: "volcanic",
+  terrainFill: "url(#volcanic-pattern)",
+  backgroundTint: "#3a1a10",
+  ambientLoop: "assets/audio/ambient/volcano.ogg",
+  particleEffect: "embers",
+};
+```
+
+Makes "generate 3 maps in 3 themes = 9 experiences."
+
+## Checklist
+
+- [ ] Mask PNG authored (or generator written)
+- [ ] Spawn points placed (validate reachability)
+- [ ] Config JSON written
+- [ ] Registered in `src/maps/index.ts`
+- [ ] Tested in dev: spawn points work, terrain destruction matches map edges cleanly
+- [ ] Theme exists (or "default" assigned)
+- [ ] If using CC-BY assets, NOTICE updated
+
+Typical hand-authored map: 2-4 hours of pixel art + 15 min of config. Procedural generator: 1-2 days to write one, infinite maps from it after.

--- a/docs/guides/adding-a-weapon.md
+++ b/docs/guides/adding-a-weapon.md
@@ -1,0 +1,130 @@
+# Adding a weapon
+
+Takes ~30-60 minutes once the weapon system lands in Epic 6. Assumes stack per [ADR-001](../decisions/001-framework-pivot.md): Phaser 3, planck.js, Aseprite, dat.gui.
+
+## 1. Sprite
+
+Author the weapon's visual in **Aseprite**. Required frames depend on the weapon:
+
+- **Projectile weapons** (grenade, bazooka, holy grenade, cluster bomb): one static frame OR rotation frames if it spins in flight.
+- **Placeable / walking weapons** (land mine, old woman, sheep, super sheep): walk/idle animations if it moves on its own.
+- **Explosion / hit effect**: most weapons share the same explosion sprite sheet (`fx-explosion.png`); individual weapons only ship unique art for unique visuals.
+
+Export from Aseprite: **File -> Export Sprite Sheet** with **Output: Array**, JSON format, one atlas per weapon.
+
+```
+public/assets/weapons/
+  grenade.png       # sprite sheet
+  grenade.json      # Aseprite frame data
+```
+
+## 2. Register the loader
+
+In `src/loaders/weapons.ts` (created in Epic 6), add a line:
+
+```ts
+scene.load.atlas("grenade", "assets/weapons/grenade.png", "assets/weapons/grenade.json");
+```
+
+All weapon atlases get preloaded at game start; no runtime asset loading.
+
+## 3. Write the weapon config
+
+Create `src/weapons/grenade.ts`:
+
+```ts
+import type { WeaponConfig } from "./types";
+
+export const grenade: WeaponConfig = {
+  id: "grenade",
+  name: "Hand Grenade",
+  icon: "grenade-icon",               // atlas key for weapon-select icon
+  sprite: "grenade",                   // atlas key for in-world sprite
+  body: {
+    shape: "circle",
+    radius: 0.2,                       // meters
+    density: 1.0,
+    friction: 0.5,
+    restitution: 0.3,                  // bouncy
+  },
+  launch: {
+    type: "aimed-arc",                 // charge + release, affected by wind
+    maxVelocity: 25,                   // m/s at full charge
+  },
+  fuseMs: 3000,                        // detonates 3s after launch
+  explosion: {
+    radius: 60,                        // px
+    damage: 50,                        // hp
+    knockback: 400,                    // px/s applied to nearby bodies
+  },
+  endsTurn: true,
+  ammoDefault: 4,                      // starting ammo per worm per round
+};
+```
+
+The `WeaponConfig` type (defined in `src/weapons/types.ts`) covers all fields every weapon needs. Unique behaviors (homing missile tracking, rc plane steering, portal gun) add an `onTick(body, context, dt)` function.
+
+### Unique behavior example
+
+```ts
+export const homingMissile: WeaponConfig = {
+  id: "homing-missile",
+  // ... base config ...
+  launch: { type: "direct", maxVelocity: 30 },
+  fuseMs: 4000,
+  onTick(body, ctx, dt) {
+    const target = ctx.paintedTarget;
+    if (!target) return;
+    const toTarget = target.minus(body.getPosition()).normalize();
+    body.applyForceToCenter(toTarget.mul(0.5));
+  },
+};
+```
+
+Keep unique logic ~10-30 lines. If a weapon needs more, question whether the abstraction is wrong.
+
+## 4. Register in the weapon index
+
+`src/weapons/index.ts`:
+
+```ts
+import { grenade } from "./grenade";
+import { bazooka } from "./bazooka";
+// ...
+
+export const WEAPONS = {
+  grenade,
+  bazooka,
+  // ...
+} as const;
+
+export type WeaponId = keyof typeof WEAPONS;
+```
+
+The weapon selector UI reads `WEAPONS`, no further wiring.
+
+## 5. Test + tune in dev
+
+```sh
+npm run dev
+```
+
+Open localhost:5173, start a local game, press `` ` `` (backtick) to toggle dat.gui. The weapon's tunables (velocity, explosion radius, fuse time) appear under **Weapons -> <name>**. Drag sliders, fire the weapon, feel the change.
+
+When happy, copy the values back into the config file and commit.
+
+## 6. Multiplayer
+
+If the weapon adds new schema state (e.g., placed land mines, thrown ninja ropes attached to terrain), add it to `server/src/state/GameState.ts` and the client-side schema mirror. For normal projectiles, the existing `Projectile` schema covers everything.
+
+## Checklist
+
+- [ ] Aseprite file + atlas exported to `public/assets/weapons/<name>/`
+- [ ] Added to asset loader in `src/loaders/weapons.ts`
+- [ ] Config file at `src/weapons/<name>.ts`
+- [ ] Added to `WEAPONS` export in `src/weapons/index.ts`
+- [ ] Tested in dev with dat.gui; final constants committed
+- [ ] Icon added to weapon selector atlas
+- [ ] NOTICE.md updated if source is CC-BY (attribution required)
+
+Typical PR: 1 weapon = ~100 lines across 3-4 files + 1 sprite. Agent-executable via /execute when Epic 6 is done.

--- a/docs/guides/tuning-physics.md
+++ b/docs/guides/tuning-physics.md
@@ -1,0 +1,141 @@
+# Tuning physics and game feel
+
+All game-tunable constants live in `src/tuning.ts`. A `dat.gui` debug overlay (toggled with `` ` `` backtick in dev builds) exposes them as sliders. Tune live, commit final values.
+
+## Philosophy
+
+- **No hardcoded magic numbers in game logic.** Every constant that might need tweaking goes in `tuning.ts` with a named export.
+- **Dev-only overlay.** The tuning UI is stripped from production builds (Vite dead-code elimination via `import.meta.env.DEV`).
+- **Server + client share tuning.** Authoritative physics runs on the server; client mirrors it. Tuning changes must propagate to both — shared module imported by `server/` and `src/`.
+
+## Structure of `tuning.ts`
+
+```ts
+// src/tuning.ts
+export const tuning = {
+  world: {
+    gravity: { x: 0, y: 10 },
+    pxPerMeter: 30,
+  },
+  worm: {
+    walkSpeed: 2.5,        // m/s
+    jumpImpulse: 6,        // m/s vertical
+    backflipImpulse: 8,
+    maxFallDamage: 40,
+    fallDamageThresholdMs: 1200,
+  },
+  weapons: {
+    grenade: {
+      fuseMs: 3000,
+      explosionRadius: 60,
+      explosionDamage: 50,
+      knockback: 400,
+    },
+    bazooka: {
+      velocity: 25,
+      windSusceptibility: 1.0,
+      explosionRadius: 55,
+      explosionDamage: 60,
+    },
+    // ...
+  },
+  turn: {
+    durationMs: 45000,
+    retreatMs: 3000,
+  },
+  wind: {
+    changeRange: 5,   // +/- per turn
+    maxStrength: 5,
+  },
+} as const;
+```
+
+Everything is `as const` so TypeScript treats values as exact literals. Game code reads `tuning.weapons.grenade.fuseMs`, not magic strings.
+
+## Using tuning in game code
+
+```ts
+import { tuning } from "./tuning";
+
+function createGrenade(pos: Vec2) {
+  return {
+    body: world.createBody({
+      type: "dynamic",
+      position: pos,
+    }),
+    fuseMs: tuning.weapons.grenade.fuseMs,
+    // ...
+  };
+}
+```
+
+## dat.gui overlay
+
+`src/debug/tuningPanel.ts`:
+
+```ts
+import { GUI } from "dat.gui";
+import { tuning } from "../tuning";
+
+export function mountTuningPanel(): GUI | null {
+  if (!import.meta.env.DEV) return null;
+
+  const gui = new GUI({ width: 300, hideable: true });
+  gui.closed = true;
+
+  const world = gui.addFolder("World");
+  world.add(tuning.world.gravity, "y", 0, 30, 0.1).name("Gravity Y");
+
+  const weapons = gui.addFolder("Weapons");
+  for (const [id, w] of Object.entries(tuning.weapons)) {
+    const sub = weapons.addFolder(id);
+    // auto-generate sliders per property
+    for (const [k, v] of Object.entries(w)) {
+      if (typeof v !== "number") continue;
+      sub.add(w as Record<string, number>, k);
+    }
+  }
+
+  // Hotkey
+  window.addEventListener("keydown", (e) => {
+    if (e.key === "`") gui.closed = !gui.closed;
+  });
+
+  return gui;
+}
+```
+
+Called once in `main.ts`. Panel floats top-right; sliders write directly into `tuning` (mutable at runtime). Changes apply the next time game code reads them.
+
+## Typical tuning workflow
+
+1. `npm run dev`, open localhost:5173
+2. Start a local game
+3. Press `` ` `` (backtick): panel appears
+4. Drill into `Weapons > grenade > explosionRadius`, drag slider
+5. Throw grenades; watch effect
+6. When satisfied, copy value back into `src/tuning.ts` literally (the panel is non-persistent)
+7. Commit `tuning.ts` change
+
+## Limitations
+
+- **Structural changes** (adding new keys, changing shapes) need code edit + restart. The panel only tweaks numbers already in `tuning.ts`.
+- **Server tuning**: when tuning affects server-side simulation (most things), you need to restart the Colyseus server after committing. The live panel only tweaks the local client, so single-player / lobby preview is the right place to tune.
+- **No save/load**: panel state is ephemeral. Commit to `tuning.ts` or lose your changes on reload.
+
+## Why dat.gui specifically
+
+- Small (~40KB gzipped)
+- Zero-config for numeric tuning
+- Works with plain objects (no React/Vue)
+- Industry standard in web game dev since ~2013 (Three.js examples use it)
+
+Alternatives considered: Tweakpane (more modern, slightly larger), lil-gui (a dat.gui fork, basically identical). dat.gui is the safest default.
+
+## Checklist for a new tunable
+
+- [ ] Added to `src/tuning.ts` with descriptive name
+- [ ] Game code reads from `tuning.*` instead of a local constant
+- [ ] Panel auto-picks it up (if it's a number under a known folder)
+- [ ] Committed default value is the tuned-and-happy value, not a placeholder
+- [ ] If server uses this constant, `server/` also imports from the same module

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,61 @@
+# worms server (Colyseus)
+
+Authoritative multiplayer server for the worms web game. Manages rooms (4-letter join codes), turn state, physics simulation, state sync.
+
+## Status
+
+**Scaffold only.** This directory was set up in PR (the pivot PR) per [ADR-001](../docs/decisions/001-framework-pivot.md). Full implementation lands in:
+
+- **Epic 8** - lobby + 4-letter room codes + join/leave flow
+- **Epic 9** - authoritative game loop + Colyseus schema for shared state
+- **Epic 10** - reconnection + disconnect handling
+
+Current state: one `GameRoom` class that logs join/leave events. Does nothing game-specific.
+
+## Run locally
+
+```sh
+cd server
+npm install
+npm run dev
+```
+
+Server listens on `:2567` by default (override with `PORT`).
+
+From the client (when Epic 8 lands), connect to `ws://localhost:2567`.
+
+## Scripts
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | tsx watch mode; auto-restarts on file changes |
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm start` | Run the compiled server |
+| `npm run typecheck` | `tsc --noEmit` |
+
+## Structure
+
+```
+server/
+  src/
+    index.ts           entry: HTTP server + Colyseus + transport
+    rooms/
+      GameRoom.ts      Room class (one instance per game)
+    state/             Colyseus schema (added Epic 9)
+    simulation/        physics + turn logic (added Epic 9)
+```
+
+## Deploy (future, Epic 13)
+
+Options, decided per cost/latency needs at Epic 13 time:
+
+1. **Co-locate on brain's EC2** (100.105.131.123). nginx proxies `/worms/ws` to the Colyseus port. Same TLS cert as brain. No new infra.
+2. **Fly.io app**. Regional game servers, anycast routing, better latency for non-US players. Costs ~$5-10/mo for a hobby tier.
+
+Colyseus itself is stateless per Room; horizontal scaling is possible via the presence adapter (Redis). For MVP, single-instance on brain's EC2 is fine.
+
+## References
+
+- [Colyseus docs](https://docs.colyseus.io/)
+- [Colyseus GitHub](https://github.com/colyseus/colyseus)
+- [ADR-001](../docs/decisions/001-framework-pivot.md) - framework pivot rationale

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "worms-server",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Colyseus multiplayer server for the worms web game",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@colyseus/core": "^0.15.0",
+    "@colyseus/ws-transport": "^0.15.0",
+    "colyseus": "^0.15.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,18 @@
+import { Server } from "@colyseus/core";
+import { WebSocketTransport } from "@colyseus/ws-transport";
+import { createServer } from "node:http";
+import { GameRoom } from "./rooms/GameRoom.js";
+
+const port = Number(process.env.PORT ?? 2567);
+
+const httpServer = createServer();
+
+const gameServer = new Server({
+  transport: new WebSocketTransport({ server: httpServer }),
+});
+
+gameServer.define("game", GameRoom);
+
+httpServer.listen(port, () => {
+  console.log(`worms Colyseus server listening on :${port}`);
+});

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -1,0 +1,28 @@
+import { Room, type Client } from "@colyseus/core";
+
+/**
+ * One GameRoom instance per active game.
+ *
+ * Scaffold only. Full implementation lands in Epic 8 (lobby + room codes),
+ * Epic 9 (authoritative state + schema), and Epic 10 (reconnection).
+ * See docs/decisions/001-framework-pivot.md for context.
+ */
+export class GameRoom extends Room {
+  maxClients = 8;
+
+  onCreate(): void {
+    console.log("GameRoom created", this.roomId);
+  }
+
+  onJoin(client: Client): void {
+    console.log(client.sessionId, "joined", this.roomId);
+  }
+
+  onLeave(client: Client): void {
+    console.log(client.sessionId, "left", this.roomId);
+  }
+
+  onDispose(): void {
+    console.log("GameRoom disposed", this.roomId);
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Framework pivot documented and scaffolded. Port the 2013 reference's algorithms; replace its architecture with a modern indie-game stack.

**Stack change**:
- **Client**: Phaser 3 (batteries-included 2D framework; sprites, input, scenes, audio, tweens) + planck.js (Box2D physics) + Aseprite (pixel-art pipeline) + dat.gui (live tuning)
- **Server**: Colyseus (room-based multiplayer framework; collapses Epic 8/9/10 into one integration epic)
- **Deploy** (future): Cloudflare Pages for client, Fly.io or brain's EC2 for server

**Why**: the 2013 reference is ~60% custom game-engine plumbing. Porting line-by-line rebuilds a 2013 engine. Modern tools replace that plumbing so we focus on game-specific code. Expected MVP effort drops from 12-15 weeks to 5-7 weeks. Priorities the user named (casual drop-in-and-play, snappy, reproducible content) all map better to the new stack.

**Nothing game-related built yet** - this PR is pure alignment: ADR, guides, scaffolding. Epic 3 (terrain) is the first PR that exercises the new stack.

## Files

### New: ADR
- \`docs/decisions/001-framework-pivot.md\` - full rationale, alternatives considered, consequences per epic

### New: drop-in workflow guides
- \`docs/guides/adding-a-weapon.md\` - Aseprite + data file; ~30-60 min per new weapon
- \`docs/guides/adding-a-map.md\` - PNG mask OR procedural generator; ~2-4h hand-authored or 1-2d per generator
- \`docs/guides/adding-a-character.md\` - Aseprite file with required animation tags
- \`docs/guides/tuning-physics.md\` - dat.gui overlay + \`src/tuning.ts\` (no hardcoded magic numbers)

### New: server scaffold
- \`server/package.json\` - Colyseus + tsx + TypeScript
- \`server/src/index.ts\` + \`server/src/rooms/GameRoom.ts\` - placeholder room that logs join/leave
- \`server/README.md\` - run instructions + deploy options

### Updated
- \`CLAUDE.md\` - new Stack section, new Drop-in philosophy, expanded Key decisions, updated References by epic
- \`docs/ROADMAP.md\` - reflects pivot, Epic 8-10 collapse notation, session log

## Test plan

- [x] docs render correctly on GitHub
- [x] Markdown links resolve
- [ ] \`cd server && npm install && npm run dev\` starts Colyseus on :2567 (deferred; will verify when Epic 8 begins)
- [ ] No regression to client build (no client code changed; existing Vite build still works)

## What changes in the open issues

Per the new Epic 8-10 collapse, I'll comment on #8, #9, #10 referencing this ADR so the history is clear. Issue bodies will get a \"pivot note\" appended.

## Follow-ups (not this PR)

- Epic 3 plan rewrite around Phaser Scene (next PR)
- Add Phaser + planck + dat.gui to root \`package.json\` (in Epic 3 PR)
- Issue re-triage comments (separate gh action, not a PR)

Closes no issues directly; realigns the roadmap for everything from Epic 3 forward.