### PR TITLE
Epic 9: server-as-turn-arbiter netcode (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,22 @@ Server (`server/`):
 3. Tab A: http://localhost:5173/, nickname "Alice", Create Room, note the 4-letter code.
 4. Tab B (incognito): http://localhost:5173/?room=CODE, nickname "Bob", Join.
 5. Alice picks a map, both hit Ready, Alice clicks Start Game.
-6. Both tabs transition to the game with the selected map.
+6. Both tabs transition to the same map with the same seed. Teams are
+   assigned by join order (Alice = team red, Bob = team blue).
+7. Alice's tab is active first; Bob's tab shows a "Waiting for Alice..."
+   banner and has input locked. Alice walks, fires, ends turn.
+8. Server rotates the active team; Bob's input unlocks and Alice's tab
+   shows the spectator banner. Positions snap at each turn boundary.
+9. Keep alternating until one team has no alive worms. Server broadcasts
+   game_over; both tabs show the win banner.
 
-Game state remains client-local in Epic 8; authoritative netcode lands in Epic 9.
+Architecture note (Epic 9 Option C): the server arbitrates turn
+ownership + relays the active player's inputs + accepts an authoritative
+snapshot at turn end. Each client still runs its own planck sim locally;
+physics drift within a turn is absorbed by the end-of-turn snapshot.
+No server-side physics. See `docs/plans/epic-9-netcode.md` for the full
+architecture and the `#45` issue for the upgrade path to authoritative
+server physics if the Option C model ever hits its limits.
 
 ## Structure
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@ Source of truth: [GitHub issues](https://github.com/scottmccarrison/worms/issues
 | 6  | Weapon system (data-driven, 8 + Bazooka) | Partial  | (6a PR TBD) | [epic-6a-weapons-infra](plans/epic-6a-weapons-infra.md) |
 | 7  | Map loading + starter maps               | Done     | (Epic 7 PR) | [epic-7-maps](plans/epic-7-maps.md)             |
 | 8  | Colyseus integration: lobby + rooms [*]  | Done     | (Epic 8 PR) | [epic-8-lobby](plans/epic-8-lobby.md)           |
-| 9  | Colyseus integration: state schema [*]   | Todo     | -        | -                                                  |
+| 9  | Colyseus integration: state schema [*]   | Done (Option C) | (Epic 9 PR) | [epic-9-netcode](plans/epic-9-netcode.md)    |
 | 10 | Colyseus integration: reconnection [*]   | Todo     | -        | -                                                  |
 | 11 | Source original sprite assets (Aseprite) | Todo     | -        | -                                                  |
 | 12 | Source original audio assets             | Todo     | -        | -                                                  |

--- a/server/src/game/TurnArbiter.test.ts
+++ b/server/src/game/TurnArbiter.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { LobbyState } from "../state/LobbyState.js";
+import { TURN_DURATION_MS } from "../state/constants.js";
+import {
+  type ArbiterRoomAdapter,
+  type TeamRoster,
+  TurnArbiter,
+  type TurnSnapshot,
+} from "./TurnArbiter.js";
+
+/**
+ * Minimal in-memory adapter so TurnArbiter can run without a Colyseus
+ * Room. Captures broadcasts so tests can assert on them.
+ */
+class StubRoom implements ArbiterRoomAdapter {
+  state = new LobbyState();
+  broadcasts: Array<{ type: string; payload: unknown }> = [];
+  connected = new Set<string>();
+
+  broadcast(type: string, payload: unknown): void {
+    this.broadcasts.push({ type, payload });
+  }
+  getConnectedSessionIds(): Set<string> {
+    return this.connected;
+  }
+}
+
+function rosterFor(id: string, ownerSessionId: string, wormCount = 2): TeamRoster {
+  const wormIds: string[] = [];
+  for (let i = 0; i < wormCount; i++) wormIds.push(`${id}-${i}`);
+  return { id, ownerSessionId, wormIds };
+}
+
+describe("TurnArbiter", () => {
+  it("advanceTurn skips ownerless teams", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [
+      rosterFor("red", "alice"),
+      rosterFor("blue", ""), // ownerless; must be skipped
+      rosterFor("green", "bob"),
+      rosterFor("yellow", ""), // ownerless
+    ];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue", "green", "yellow"], rosters, TURN_DURATION_MS);
+
+    expect(room.state.currentTeamId).toBe("red");
+
+    // Full-alive snapshot so no game_over triggers.
+    const snap: TurnSnapshot = {
+      worms: [
+        { id: "red-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "green-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "green-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "yellow-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "yellow-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+      ],
+      terrainCuts: [],
+    };
+    arbiter.onSnapshot(snap);
+
+    // Should have skipped "blue" (ownerless) and landed on "green".
+    expect(room.state.currentTeamId).toBe("green");
+    const resolved = room.broadcasts.find((b) => b.type === "turn_resolved");
+    expect(resolved).toBeDefined();
+    expect((resolved?.payload as { nextTeamId: string }).nextTeamId).toBe("green");
+  });
+
+  it("declares game_over when only one team has alive worms", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [
+      rosterFor("red", "alice"),
+      rosterFor("blue", "bob"),
+    ];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    // All blue worms dead; red fully alive.
+    const snap: TurnSnapshot = {
+      worms: [
+        { id: "red-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 0, y: 0, vx: 0, vy: 0, hp: 0, alive: false },
+        { id: "blue-1", x: 0, y: 0, vx: 0, vy: 0, hp: 0, alive: false },
+      ],
+      terrainCuts: [],
+    };
+    arbiter.onSnapshot(snap);
+
+    const gameOver = room.broadcasts.find((b) => b.type === "game_over");
+    expect(gameOver).toBeDefined();
+    expect((gameOver?.payload as { winnerTeamId: string | null }).winnerTeamId).toBe("red");
+    // No turn_resolved should be emitted on game_over.
+    expect(room.broadcasts.find((b) => b.type === "turn_resolved")).toBeUndefined();
+    // Turn state is zeroed out so clients stop running timers.
+    expect(room.state.currentTeamId).toBe("");
+    expect(room.state.currentWormId).toBe("");
+    expect(room.state.turnEndsAt).toBe(0);
+  });
+
+  it("forceAdvance uses last known snapshot", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [
+      rosterFor("red", "alice"),
+      rosterFor("blue", "bob"),
+    ];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    // First turn: red fires a snapshot establishing positions.
+    const snap1: TurnSnapshot = {
+      worms: [
+        { id: "red-0", x: 100, y: 200, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 120, y: 200, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 300, y: 200, vx: 0, vy: 0, hp: 90, alive: true },
+        { id: "blue-1", x: 320, y: 200, vx: 0, vy: 0, hp: 100, alive: true },
+      ],
+      terrainCuts: [{ x: 150, y: 150, r: 30, seq: 1 }],
+    };
+    arbiter.onSnapshot(snap1);
+
+    // Now blue's turn. Before blue sends a snapshot, timeout forces
+    // an advance. Resolution must use snap1's positions and NO cuts.
+    room.broadcasts.length = 0;
+    arbiter.forceAdvance();
+
+    const resolved = room.broadcasts.find((b) => b.type === "turn_resolved");
+    expect(resolved).toBeDefined();
+    const payload = resolved?.payload as {
+      worms: Array<{ id: string; x: number }>;
+      terrainCuts: unknown[];
+      nextTeamId: string;
+    };
+    expect(payload.worms.find((w) => w.id === "red-0")?.x).toBe(100);
+    expect(payload.terrainCuts).toHaveLength(0);
+    // Cycled back to red since blue never acted.
+    expect(payload.nextTeamId).toBe("red");
+  });
+});

--- a/server/src/game/TurnArbiter.test.ts
+++ b/server/src/game/TurnArbiter.test.ts
@@ -74,10 +74,7 @@ describe("TurnArbiter", () => {
     const room = new StubRoom();
     room.connected = new Set(["alice", "bob"]);
 
-    const rosters: TeamRoster[] = [
-      rosterFor("red", "alice"),
-      rosterFor("blue", "bob"),
-    ];
+    const rosters: TeamRoster[] = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
     const arbiter = new TurnArbiter(room);
     arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
 
@@ -108,10 +105,7 @@ describe("TurnArbiter", () => {
     const room = new StubRoom();
     room.connected = new Set(["alice", "bob"]);
 
-    const rosters: TeamRoster[] = [
-      rosterFor("red", "alice"),
-      rosterFor("blue", "bob"),
-    ];
+    const rosters: TeamRoster[] = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
     const arbiter = new TurnArbiter(room);
     arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
 

--- a/server/src/game/TurnArbiter.ts
+++ b/server/src/game/TurnArbiter.ts
@@ -1,0 +1,331 @@
+import { ArraySchema } from "@colyseus/schema";
+import type { LobbyState } from "../state/LobbyState.js";
+import { SETTLE_GRACE_MS } from "../state/constants.js";
+
+/**
+ * One snapshot entry per worm, as sent by the active client inside a
+ * `turn_snapshot` message at the end of its local turn.
+ *
+ * This is the only authoritative physics state the server sees. It
+ * keys drift reconciliation on the `turn_resolved` broadcast.
+ */
+export interface WormSnapshot {
+  id: string; // e.g. "red-0"
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp: number;
+  alive: boolean;
+}
+
+/** Circular terrain cut, monotonic `seq` for idempotent reapply. */
+export interface CircleCut {
+  x: number;
+  y: number;
+  r: number;
+  seq: number;
+}
+
+/** Payload shape of `turn_snapshot` (C->S from the active player). */
+export interface TurnSnapshot {
+  worms: WormSnapshot[];
+  terrainCuts: CircleCut[];
+}
+
+/**
+ * Everything TurnArbiter needs from a GameRoom. Kept narrow so the
+ * class is unit-testable with a plain object stub (no Colyseus Room
+ * instance required in tests).
+ */
+export interface ArbiterRoomAdapter {
+  /** Mutable authoritative state; arbiter writes the turn fields directly. */
+  readonly state: LobbyState;
+  /** Broadcast a message to every connected client. */
+  broadcast(type: string, payload: unknown): void;
+  /** Snapshot of session ids currently present; used to skip disconnected team owners. */
+  getConnectedSessionIds(): Set<string>;
+}
+
+/**
+ * One roster entry per team. Populated at `start_game` and kept
+ * immutable for the lifetime of the game.
+ */
+export interface TeamRoster {
+  id: string; // "red" | "blue" | "green" | "yellow"
+  ownerSessionId: string; // empty string means unowned / skip
+  wormIds: string[]; // e.g. ["red-0", "red-1"]
+}
+
+/**
+ * Server turn arbiter. Decides whose turn is active, advances on
+ * snapshot-from-active-player, force-advances on timeout or active
+ * player drop.
+ *
+ * Option C: does NOT run planck. Tracks alive counts purely from the
+ * `turn_snapshot` stream. The per-worm `alive` flag + the per-team
+ * wormIds list give us enough to detect game_over and skip dead teams.
+ */
+export class TurnArbiter {
+  private readonly room: ArbiterRoomAdapter;
+  private teamRosters = new Map<string, TeamRoster>();
+  private currentTeamIdx = 0;
+  /** Round-robin cursor per team so worms cycle within a team. */
+  private teamWormCursor = new Map<string, number>();
+  /** Alive count per team, derived from the most recent snapshot. */
+  private aliveByTeam = new Map<string, number>();
+  /** Last `turn_snapshot` we received, used to synthesize a force-advance resolution. */
+  private lastSnapshot: TurnSnapshot | null = null;
+  /** True once this turn has received a snapshot; reset each advance. */
+  private gotSnapshotThisTurn = false;
+  /** True once game_over has been declared; arbiter becomes a no-op. */
+  private gameOver = false;
+  private turnDurationMs = 0;
+
+  constructor(room: ArbiterRoomAdapter) {
+    this.room = room;
+  }
+
+  /**
+   * Initialise the arbiter at the moment of start_game. `teamOrder`
+   * is the canonical cycle; `rosters` supplies worm ids + ownership
+   * for each team. The first team in `teamOrder` becomes active.
+   */
+  start(teamOrder: string[], rosters: TeamRoster[], turnDurationMs: number): void {
+    this.teamRosters.clear();
+    this.teamWormCursor.clear();
+    this.aliveByTeam.clear();
+    for (const r of rosters) {
+      this.teamRosters.set(r.id, r);
+      this.teamWormCursor.set(r.id, 0);
+      this.aliveByTeam.set(r.id, r.wormIds.length);
+    }
+
+    // Mirror teamOrder into replicated state. ArraySchema doesn't
+    // accept a spread constructor in 2.x; push one-by-one.
+    this.room.state.teamOrder = new ArraySchema<string>();
+    for (const id of teamOrder) this.room.state.teamOrder.push(id);
+
+    this.currentTeamIdx = 0;
+    this.turnDurationMs = turnDurationMs;
+    this.gameOver = false;
+    this.lastSnapshot = null;
+    this.gotSnapshotThisTurn = false;
+
+    const firstTeamId = teamOrder[0] ?? "";
+    this.room.state.currentTeamId = firstTeamId;
+    this.room.state.currentWormId = this.pickNextWormInTeam(firstTeamId);
+    this.room.state.turnSeq = 1;
+    this.room.state.turnEndsAt = Date.now() + turnDurationMs;
+  }
+
+  /**
+   * Called from a plain setInterval in GameRoom (20Hz). If the turn
+   * ran long AND no snapshot arrived, force-advance with last-known
+   * positions. Otherwise a no-op (clients drive turn end via
+   * `turn_snapshot`).
+   */
+  onTick(_dtMs: number): void {
+    if (this.gameOver) return;
+    if (this.gotSnapshotThisTurn) return;
+    const now = Date.now();
+    if (now > this.room.state.turnEndsAt + SETTLE_GRACE_MS) {
+      this.forceAdvance();
+    }
+  }
+
+  /**
+   * Accept a snapshot from the active player. Updates the alive-count
+   * tally, broadcasts `turn_resolved`, and advances to the next turn.
+   */
+  onSnapshot(snap: TurnSnapshot): void {
+    if (this.gameOver) return;
+    this.lastSnapshot = snap;
+    this.gotSnapshotThisTurn = true;
+    this.applySnapshotToAliveTally(snap);
+    const nextResolution = this.advanceTurn(snap);
+    if (nextResolution) {
+      this.room.broadcast("turn_resolved", {
+        turnSeq: nextResolution.turnSeq,
+        worms: snap.worms,
+        terrainCuts: snap.terrainCuts,
+        nextTeamId: nextResolution.nextTeamId,
+        nextWormId: nextResolution.nextWormId,
+      });
+    }
+  }
+
+  /**
+   * Timeout path + active-player-left path. Synthesizes a resolution
+   * from the last known snapshot (empty snapshot if we never got one).
+   */
+  forceAdvance(): void {
+    if (this.gameOver) return;
+    const synth: TurnSnapshot = this.lastSnapshot ?? { worms: [], terrainCuts: [] };
+    this.gotSnapshotThisTurn = true;
+    this.applySnapshotToAliveTally(synth);
+    const nextResolution = this.advanceTurn(synth);
+    if (nextResolution) {
+      this.room.broadcast("turn_resolved", {
+        turnSeq: nextResolution.turnSeq,
+        worms: synth.worms,
+        // No new cuts on a synthetic advance.
+        terrainCuts: [],
+        nextTeamId: nextResolution.nextTeamId,
+        nextWormId: nextResolution.nextWormId,
+      });
+    }
+  }
+
+  /**
+   * Notify the arbiter that a player left the room mid-game. If they
+   * owned the active team we force-advance so everyone else can keep
+   * playing. Other leaves are handled lazily: `advanceTurn` re-checks
+   * connected session ids each turn.
+   */
+  onPlayerLeft(sessionId: string): void {
+    if (this.gameOver) return;
+    const activeTeamId = this.room.state.currentTeamId;
+    const activeTeam = this.teamRosters.get(activeTeamId);
+    if (activeTeam && activeTeam.ownerSessionId === sessionId) {
+      this.forceAdvance();
+    }
+  }
+
+  // ---- private helpers ----
+
+  /**
+   * Pick the next team in `teamOrder` that (a) has an owner still
+   * connected AND (b) still has alive worms. If only one team qualifies
+   * on the "alive worms" axis, emit game_over instead of advancing.
+   *
+   * Returns the next-turn info, or null if the game ended.
+   */
+  private advanceTurn(
+    _snap: TurnSnapshot,
+  ): { turnSeq: number; nextTeamId: string; nextWormId: string } | null {
+    // First: detect game_over purely on alive worms (ignoring ownership;
+    // we want the game to end if only one team has worms left even if
+    // that team's owner is still here).
+    const teamsWithAliveWorms: string[] = [];
+    for (const teamId of this.room.state.teamOrder) {
+      if ((this.aliveByTeam.get(teamId) ?? 0) > 0) {
+        teamsWithAliveWorms.push(teamId);
+      }
+    }
+    if (teamsWithAliveWorms.length <= 1) {
+      const winnerTeamId = teamsWithAliveWorms[0] ?? null;
+      this.declareGameOver(winnerTeamId);
+      return null;
+    }
+
+    // Find the next team in teamOrder that's eligible: alive worms AND
+    // a connected owner. Skip ownerless / disconnected entries.
+    const connected = this.room.getConnectedSessionIds();
+    const teamOrderLen = this.room.state.teamOrder.length;
+    let nextTeamId = "";
+    for (let step = 1; step <= teamOrderLen; step++) {
+      const idx = (this.currentTeamIdx + step) % teamOrderLen;
+      const candidate = this.room.state.teamOrder[idx];
+      if (!candidate) continue;
+      const roster = this.teamRosters.get(candidate);
+      if (!roster) continue;
+      if (!roster.ownerSessionId) continue;
+      if (!connected.has(roster.ownerSessionId)) continue;
+      if ((this.aliveByTeam.get(candidate) ?? 0) <= 0) continue;
+      this.currentTeamIdx = idx;
+      nextTeamId = candidate;
+      break;
+    }
+
+    if (!nextTeamId) {
+      // No eligible team to hand off to (everyone who had alive worms
+      // disconnected). Declare game_over with no winner.
+      this.declareGameOver(null);
+      return null;
+    }
+
+    const nextWormId = this.pickNextWormInTeam(nextTeamId);
+
+    this.room.state.currentTeamId = nextTeamId;
+    this.room.state.currentWormId = nextWormId;
+    this.room.state.turnSeq += 1;
+    this.room.state.turnEndsAt = Date.now() + this.turnDurationMs;
+    this.gotSnapshotThisTurn = false;
+
+    return {
+      turnSeq: this.room.state.turnSeq,
+      nextTeamId,
+      nextWormId,
+    };
+  }
+
+  /**
+   * Round-robin through a team's worm list, skipping dead worms (per
+   * the latest snapshot). If every worm is dead, returns "".
+   */
+  private pickNextWormInTeam(teamId: string): string {
+    const roster = this.teamRosters.get(teamId);
+    if (!roster || roster.wormIds.length === 0) return "";
+
+    const deadIds = this.deadWormIds();
+    const startCursor = this.teamWormCursor.get(teamId) ?? 0;
+
+    for (let step = 0; step < roster.wormIds.length; step++) {
+      const idx = (startCursor + step) % roster.wormIds.length;
+      const wormId = roster.wormIds[idx];
+      if (!deadIds.has(wormId)) {
+        this.teamWormCursor.set(teamId, (idx + 1) % roster.wormIds.length);
+        return wormId;
+      }
+    }
+    return "";
+  }
+
+  private deadWormIds(): Set<string> {
+    const out = new Set<string>();
+    if (!this.lastSnapshot) return out;
+    for (const w of this.lastSnapshot.worms) {
+      if (!w.alive) out.add(w.id);
+    }
+    return out;
+  }
+
+  private applySnapshotToAliveTally(snap: TurnSnapshot): void {
+    // Re-derive alive counts from scratch so a snapshot that revives a
+    // worm (e.g. hp clamp edge case) is respected. If a worm id from
+    // the roster isn't in the snapshot, assume its last-known alive
+    // state (no change).
+    if (snap.worms.length === 0) return;
+    // Build quick lookup of "this snapshot's alive list" per worm id.
+    const snapAlive = new Map<string, boolean>();
+    for (const w of snap.worms) snapAlive.set(w.id, w.alive);
+
+    for (const [teamId, roster] of this.teamRosters) {
+      let alive = 0;
+      for (const wormId of roster.wormIds) {
+        const explicit = snapAlive.get(wormId);
+        if (explicit === undefined) {
+          // Worm not reported this snapshot; keep previous alive tally
+          // for this slot (approximate: assume alive unless we already
+          // recorded it dead via lastSnapshot).
+          const priorDead = this.lastSnapshot
+            ? this.lastSnapshot.worms.find((w) => w.id === wormId && !w.alive)
+            : undefined;
+          if (!priorDead) alive += 1;
+        } else if (explicit) {
+          alive += 1;
+        }
+      }
+      this.aliveByTeam.set(teamId, alive);
+    }
+  }
+
+  private declareGameOver(winnerTeamId: string | null): void {
+    this.gameOver = true;
+    this.room.state.currentTeamId = "";
+    this.room.state.currentWormId = "";
+    this.room.state.turnEndsAt = 0;
+    this.room.broadcast("game_over", { winnerTeamId });
+  }
+}

--- a/server/src/rooms/GameRoom.test.ts
+++ b/server/src/rooms/GameRoom.test.ts
@@ -230,6 +230,190 @@ describe("GameRoom lobby", () => {
     await bob.leave();
   });
 
+  // ---- Epic 9: turn arbiter integration ----
+
+  /**
+   * Spin up two players and start the game. Returns both rooms plus
+   * the `game_started` payload so Epic 9 tests can read team owners /
+   * current active team without duplicating 40 lines of setup.
+   */
+  async function setupStartedGame(): Promise<{
+    alice: Awaited<ReturnType<typeof colyseus.sdk.joinOrCreate>>;
+    bob: Awaited<ReturnType<typeof colyseus.sdk.joinOrCreate>>;
+    payload: any;
+  }> {
+    const alice = await colyseus.sdk.joinOrCreate("game", {
+      nickname: "Alice",
+      color: ALLOWED_COLORS[0],
+    });
+    await tick();
+    const code = (alice.state as any).code as string;
+
+    const bob = await colyseus.sdk.joinOrCreate("game", {
+      code,
+      nickname: "Bob",
+      color: ALLOWED_COLORS[1],
+    });
+    await tick();
+
+    bob.send("set_ready", { ready: true });
+    await tick(60);
+
+    const starts: any[] = [];
+    alice.onMessage("game_started", (p) => starts.push(p));
+
+    alice.send("start_game", {});
+    await tick(150);
+
+    return { alice, bob, payload: starts[0] };
+  }
+
+  it("start_game assigns team owners deterministically from player join order", async () => {
+    const { alice, bob, payload } = await setupStartedGame();
+
+    // Player 0 (Alice, first joiner) gets team 0 ("red"); Bob gets "blue".
+    expect(payload.teams[0].id).toBe("red");
+    expect(payload.teams[0].ownerSessionId).toBe(alice.sessionId);
+    expect(payload.teams[1].id).toBe("blue");
+    expect(payload.teams[1].ownerSessionId).toBe(bob.sessionId);
+
+    // And ownership is mirrored onto the replicated LobbyPlayer rows so
+    // clients can do the lookup without reparsing the teams array.
+    const alicePlayer = (alice.state as any).players.get(alice.sessionId);
+    const bobPlayer = (alice.state as any).players.get(bob.sessionId);
+    expect(alicePlayer.ownerOfTeamId).toBe("red");
+    expect(bobPlayer.ownerOfTeamId).toBe("blue");
+
+    await alice.leave();
+    await bob.leave();
+  });
+
+  it("drops input_walk from the non-active player silently", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    // Whichever one is non-active sends input_walk; it must not reach
+    // the other. Determine active via currentTeamId -> owner mapping.
+    const activeTeamId = (alice.state as any).currentTeamId as string;
+    const nonActive = activeTeamId === "red" ? bob : alice;
+    const other = activeTeamId === "red" ? alice : bob;
+
+    const walkReceived: any[] = [];
+    other.onMessage("input_walk", (p) => walkReceived.push(p));
+
+    nonActive.send("input_walk", { dir: 1, seq: 1 });
+    await tick(100);
+
+    expect(walkReceived).toHaveLength(0);
+
+    await alice.leave();
+    await bob.leave();
+  });
+
+  it("relays input_walk from the active player to the other client only", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    const activeTeamId = (alice.state as any).currentTeamId as string;
+    const active = activeTeamId === "red" ? alice : bob;
+    const spectator = activeTeamId === "red" ? bob : alice;
+
+    const activeWalkSelfEcho: any[] = [];
+    const spectatorWalk: any[] = [];
+    active.onMessage("input_walk", (p) => activeWalkSelfEcho.push(p));
+    spectator.onMessage("input_walk", (p) => spectatorWalk.push(p));
+
+    active.send("input_walk", { dir: -1, seq: 7 });
+    await tick(100);
+
+    // Server re-broadcasts with { except: sender } so the active
+    // player's own client does NOT receive an echo back.
+    expect(activeWalkSelfEcho).toHaveLength(0);
+    expect(spectatorWalk).toHaveLength(1);
+    expect(spectatorWalk[0]).toMatchObject({ dir: -1, seq: 7 });
+
+    await alice.leave();
+    await bob.leave();
+  });
+
+  it("broadcasts turn_resolved to all clients on turn_snapshot from the active player", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    const activeTeamId = (alice.state as any).currentTeamId as string;
+    const active = activeTeamId === "red" ? alice : bob;
+
+    const aliceResolved: any[] = [];
+    const bobResolved: any[] = [];
+    alice.onMessage("turn_resolved", (p) => aliceResolved.push(p));
+    bob.onMessage("turn_resolved", (p) => bobResolved.push(p));
+
+    active.send("turn_snapshot", {
+      worms: [
+        { id: "red-0", x: 10, y: 20, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 30, y: 20, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 50, y: 20, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-1", x: 70, y: 20, vx: 0, vy: 0, hp: 100, alive: true },
+      ],
+      terrainCuts: [{ x: 100, y: 100, r: 40, seq: 1 }],
+    });
+    await tick(150);
+
+    // Both clients (including the sender) receive turn_resolved since
+    // the server broadcasts to everyone, not just spectators.
+    expect(aliceResolved).toHaveLength(1);
+    expect(bobResolved).toHaveLength(1);
+    expect(typeof aliceResolved[0].turnSeq).toBe("number");
+    expect(aliceResolved[0].turnSeq).toBeGreaterThanOrEqual(2);
+
+    await alice.leave();
+    await bob.leave();
+  });
+
+  it("advances state.currentTeamId to the next team after turn_resolved", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    const firstTeamId = (alice.state as any).currentTeamId as string;
+    const active = firstTeamId === "red" ? alice : bob;
+
+    active.send("turn_snapshot", {
+      worms: [
+        { id: "red-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+      ],
+      terrainCuts: [],
+    });
+    await tick(150);
+
+    const secondTeamId = (alice.state as any).currentTeamId as string;
+    expect(secondTeamId).not.toBe("");
+    expect(secondTeamId).not.toBe(firstTeamId);
+
+    await alice.leave();
+    await bob.leave();
+  });
+
+  it("force-advances turn when the active player disconnects", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    const firstTeamId = (alice.state as any).currentTeamId as string;
+    const active = firstTeamId === "red" ? alice : bob;
+    const spectator = firstTeamId === "red" ? bob : alice;
+
+    const resolved: any[] = [];
+    spectator.onMessage("turn_resolved", (p) => resolved.push(p));
+
+    await active.leave();
+    await tick(200);
+
+    // Active player leaving while holding the turn forces an advance;
+    // the remaining client gets a turn_resolved pointing at itself.
+    expect(resolved.length).toBeGreaterThanOrEqual(1);
+    expect((spectator.state as any).currentTeamId).not.toBe(firstTeamId);
+    expect((spectator.state as any).currentTeamId).not.toBe("");
+
+    await spectator.leave();
+  });
+
   it("select_map from host updates selectedMapId; rejects unknown map ids", async () => {
     const alice = await colyseus.sdk.joinOrCreate("game", {
       nickname: "Alice",

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -356,6 +356,19 @@ export class GameRoom extends Room<LobbyState> {
       }, 50);
     });
 
+    // ---- Epic 9 turn resolution ----
+    //
+    // Active player tells us the authoritative end-of-turn state; we
+    // forward to the arbiter which broadcasts `turn_resolved` (or
+    // `game_over`) on our behalf and advances the turn.
+    this.onMessage("turn_snapshot", (client, payload: unknown) => {
+      if (!this.validateActiveInput(client)) return;
+      if (!this.arbiter) return;
+      const snap = sanitiseTurnSnapshot(payload);
+      if (!snap) return;
+      this.arbiter.onSnapshot(snap);
+    });
+
     // ---- Epic 9 input relay ----
     //
     // Each gameplay input the active player sends is validated and then
@@ -465,6 +478,68 @@ function firstFreeColor(state: LobbyState): string | null {
 
 function isAllowedMap(mapId: string): boolean {
   return (MAP_WHITELIST as readonly string[]).includes(mapId);
+}
+
+/**
+ * Defensive parse of a `turn_snapshot` payload. Returns null for
+ * anything that doesn't match the expected shape so a malformed
+ * message doesn't crash the arbiter or poison the alive-count tally.
+ */
+function sanitiseTurnSnapshot(input: unknown): {
+  worms: Array<{
+    id: string;
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    hp: number;
+    alive: boolean;
+  }>;
+  terrainCuts: Array<{ x: number; y: number; r: number; seq: number }>;
+} | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = input as { worms?: unknown; terrainCuts?: unknown };
+  if (!Array.isArray(raw.worms)) return null;
+  if (!Array.isArray(raw.terrainCuts)) return null;
+
+  const worms: Array<{
+    id: string;
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    hp: number;
+    alive: boolean;
+  }> = [];
+  for (const w of raw.worms) {
+    if (!w || typeof w !== "object") continue;
+    const r = w as {
+      id?: unknown;
+      x?: unknown;
+      y?: unknown;
+      vx?: unknown;
+      vy?: unknown;
+      hp?: unknown;
+      alive?: unknown;
+    };
+    if (typeof r.id !== "string") continue;
+    if (typeof r.x !== "number" || typeof r.y !== "number") continue;
+    if (typeof r.vx !== "number" || typeof r.vy !== "number") continue;
+    if (typeof r.hp !== "number") continue;
+    if (typeof r.alive !== "boolean") continue;
+    worms.push({ id: r.id, x: r.x, y: r.y, vx: r.vx, vy: r.vy, hp: r.hp, alive: r.alive });
+  }
+
+  const terrainCuts: Array<{ x: number; y: number; r: number; seq: number }> = [];
+  for (const c of raw.terrainCuts) {
+    if (!c || typeof c !== "object") continue;
+    const r = c as { x?: unknown; y?: unknown; r?: unknown; seq?: unknown };
+    if (typeof r.x !== "number" || typeof r.y !== "number") continue;
+    if (typeof r.r !== "number" || typeof r.seq !== "number") continue;
+    terrainCuts.push({ x: r.x, y: r.y, r: r.r, seq: r.seq });
+  }
+
+  return { worms, terrainCuts };
 }
 
 /**

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -341,10 +341,14 @@ export class GameRoom extends Room<LobbyState> {
 
       // Hand off to the arbiter. Roster shape deliberately mirrors the
       // client-facing TeamInit so the arbiter has wormIds + owner.
+      // Use wormNames verbatim as the arbiter's wormIds; this guarantees
+      // the server's `currentWormId` broadcasts match the client's
+      // `worm.name` field so remote input + snapshot lookups find the
+      // right worm. Caught by bugcheck of the first Epic 9 integration.
       const rosters: TeamRoster[] = teams.map((t) => ({
         id: t.id,
         ownerSessionId: t.ownerSessionId,
-        wormIds: t.wormNames.map((_, idx) => `${t.id}-${idx}`),
+        wormIds: t.wormNames.slice(),
       }));
       this.arbiter = new TurnArbiter(this.makeArbiterAdapter());
       this.arbiter.start(teamOrder, rosters, TURN_DURATION_MS);
@@ -523,20 +527,40 @@ function sanitiseTurnSnapshot(input: unknown): {
       alive?: unknown;
     };
     if (typeof r.id !== "string") continue;
-    if (typeof r.x !== "number" || typeof r.y !== "number") continue;
-    if (typeof r.vx !== "number" || typeof r.vy !== "number") continue;
-    if (typeof r.hp !== "number") continue;
+    if (!Number.isFinite(r.x) || !Number.isFinite(r.y)) continue;
+    if (!Number.isFinite(r.vx) || !Number.isFinite(r.vy)) continue;
+    if (!Number.isFinite(r.hp)) continue;
     if (typeof r.alive !== "boolean") continue;
-    worms.push({ id: r.id, x: r.x, y: r.y, vx: r.vx, vy: r.vy, hp: r.hp, alive: r.alive });
+    // Clamp hp to [0, 100] so a buggy / malicious client cannot ship negative
+    // or outsized values. Bugcheck flagged this as a peer-crash vector because
+    // NaN/Infinity in planck setPosition puts bodies into undefined state.
+    const hp = Math.max(0, Math.min(100, r.hp as number));
+    worms.push({
+      id: r.id,
+      x: r.x as number,
+      y: r.y as number,
+      vx: r.vx as number,
+      vy: r.vy as number,
+      hp,
+      alive: r.alive && hp > 0,
+    });
   }
 
   const terrainCuts: Array<{ x: number; y: number; r: number; seq: number }> = [];
   for (const c of raw.terrainCuts) {
     if (!c || typeof c !== "object") continue;
     const r = c as { x?: unknown; y?: unknown; r?: unknown; seq?: unknown };
-    if (typeof r.x !== "number" || typeof r.y !== "number") continue;
-    if (typeof r.r !== "number" || typeof r.seq !== "number") continue;
-    terrainCuts.push({ x: r.x, y: r.y, r: r.r, seq: r.seq });
+    if (!Number.isFinite(r.x) || !Number.isFinite(r.y)) continue;
+    if (!Number.isFinite(r.r) || !Number.isFinite(r.seq)) continue;
+    // Clamp terrain cut radius to a sane range; anything bigger than the
+    // canvas or negative is nonsense.
+    const radius = Math.max(0, Math.min(500, r.r as number));
+    terrainCuts.push({
+      x: r.x as number,
+      y: r.y as number,
+      r: radius,
+      seq: r.seq as number,
+    });
   }
 
   return { worms, terrainCuts };

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -19,6 +19,22 @@ const EMPTY_ROOM_GRACE_MS = 5 * 60 * 1000; // 5 minutes
 const MIN_PLAYERS_TO_START = 2;
 
 /**
+ * All gameplay-input message types the server relays from the active
+ * player to spectators. Kept as a const array so the handler wiring
+ * loop in `registerMessageHandlers` can stay declarative.
+ */
+const INPUT_MESSAGE_TYPES = [
+  "input_walk",
+  "input_jump",
+  "input_backflip",
+  "input_aim_angle",
+  "input_aim_power",
+  "input_select_weapon",
+  "input_fire",
+  "input_end_turn",
+] as const;
+
+/**
  * One GameRoom instance per active game.
  *
  * Epic 8 scope: lobby-only. Players join, pick nicknames/colors,
@@ -121,7 +137,20 @@ export class GameRoom extends Room<LobbyState> {
 
   onLeave(client: Client, consented: boolean): void {
     const wasHost = this.state.hostSessionId === client.sessionId;
+    const wasActiveOwner =
+      this.state.phase === "playing" &&
+      this.state.players.get(client.sessionId)?.ownerOfTeamId === this.state.currentTeamId &&
+      this.state.currentTeamId !== "";
+
     this.state.players.delete(client.sessionId);
+
+    // Post-lobby: let the arbiter know so it can force-advance if the
+    // active player just left. Arbiter itself also re-checks connected
+    // sessionIds on advanceTurn, so a non-active departure needs no
+    // explicit handling here.
+    if (this.state.phase === "playing" && this.arbiter && wasActiveOwner) {
+      this.arbiter.onPlayerLeft(client.sessionId);
+    }
 
     if (wasHost && this.state.players.size > 0) {
       // Promote the earliest-joined remaining player.
@@ -327,10 +356,40 @@ export class GameRoom extends Room<LobbyState> {
       }, 50);
     });
 
+    // ---- Epic 9 input relay ----
+    //
+    // Each gameplay input the active player sends is validated and then
+    // re-broadcast to every other client. Validation: phase==="playing"
+    // AND the sender owns state.currentTeamId. On violation we return
+    // silently (no error reply) so a non-malicious mis-timed keystroke
+    // from a backseater doesn't spam the error channel; see bugcheck
+    // targets in the Epic 9 plan for the "drop silently" rationale.
+    for (const inputType of INPUT_MESSAGE_TYPES) {
+      this.onMessage(inputType, (client, payload) => {
+        if (!this.validateActiveInput(client)) return;
+        this.broadcast(inputType, payload, { except: client });
+      });
+    }
+
     this.onMessage("leave", (client) => {
       // Client-initiated clean disconnect. Colyseus will call onLeave.
       client.leave();
     });
+  }
+
+  /**
+   * Guard common to all `input_*` and `turn_snapshot` handlers: the
+   * sender must be the active player for the current team. Silent on
+   * failure per Epic 9 plan (avoid giving cheaters confirmation that a
+   * forged message was seen).
+   */
+  private validateActiveInput(client: Client): boolean {
+    if (this.state.phase !== "playing") return false;
+    const player = this.state.players.get(client.sessionId);
+    if (!player) return false;
+    if (!this.state.currentTeamId) return false;
+    if (player.ownerOfTeamId !== this.state.currentTeamId) return false;
+    return true;
   }
 
   // ---- helpers ----

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -1,6 +1,8 @@
 import { type Client, Room, matchMaker } from "@colyseus/core";
 import { generateUniqueCode } from "../codegen.js";
+import { type ArbiterRoomAdapter, type TeamRoster, TurnArbiter } from "../game/TurnArbiter.js";
 import { ALLOWED_COLORS, LobbyPlayer, LobbyState } from "../state/LobbyState.js";
+import { TURN_DURATION_MS } from "../state/constants.js";
 
 /**
  * Whitelist of map ids a host may select. Mirrors
@@ -31,6 +33,16 @@ export class GameRoom extends Room<LobbyState> {
 
   /** Handle returned by setTimeout for the empty-room disposal timer. */
   private disposeTimer: NodeJS.Timeout | null = null;
+
+  /** Epic 9 turn arbiter; null until `start_game` promotes the room to "playing". */
+  private arbiter: TurnArbiter | null = null;
+
+  /**
+   * Plain 20Hz setInterval driving TurnArbiter.onTick. We deliberately
+   * use a vanilla setInterval instead of Colyseus' setSimulationInterval
+   * so the arbiter stays decoupled from Colyseus' internal patch loop.
+   */
+  private simInterval: NodeJS.Timeout | null = null;
 
   async onCreate(options: { nickname?: string; color?: string } = {}): Promise<void> {
     // Keep the room alive past the last-client-leaves moment so the
@@ -139,7 +151,33 @@ export class GameRoom extends Room<LobbyState> {
 
   onDispose(): void {
     this.clearDisposeTimer();
+    if (this.simInterval) {
+      clearInterval(this.simInterval);
+      this.simInterval = null;
+    }
     console.log(`GameRoom ${this.roomId} (${this.state?.code ?? "?"}) disposed`);
+  }
+
+  /**
+   * Build the narrow adapter the TurnArbiter consumes. Intentionally
+   * inline so arbiter doesn't need to know about Colyseus' Client type.
+   */
+  private makeArbiterAdapter(): ArbiterRoomAdapter {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    return {
+      get state() {
+        return self.state;
+      },
+      broadcast(type, payload) {
+        self.broadcast(type, payload);
+      },
+      getConnectedSessionIds() {
+        const out = new Set<string>();
+        for (const c of self.clients) out.add(c.sessionId);
+        return out;
+      },
+    };
   }
 
   // ---- message handlers ----
@@ -243,13 +281,50 @@ export class GameRoom extends Room<LobbyState> {
       }
 
       const seed = Math.floor(Math.random() * 2 ** 31);
-      const teams = buildDefaultTeams();
+
+      // Build teams keyed to player join order so team-to-sessionId
+      // ownership is deterministic (Alice joined first -> owns team 0).
+      const sortedPlayers = [...this.state.players.values()].sort(
+        (a, b) => a.joinedAt - b.joinedAt,
+      );
+      const teamCount = Math.min(sortedPlayers.length, 4);
+      const teams = buildTeamsForPlayers(sortedPlayers, teamCount);
+
+      // Mirror ownership onto the replicated LobbyPlayer rows so
+      // clients (and the arbiter's adapter) can see who owns what.
+      for (const t of teams) {
+        if (!t.ownerSessionId) continue;
+        const p = this.state.players.get(t.ownerSessionId);
+        if (p) p.ownerOfTeamId = t.id;
+      }
+
+      // Shuffle teamOrder so turn cycle is randomised per game. Order
+      // is what the arbiter walks; ownership lives on the per-team
+      // roster, so shuffling here is purely about turn rotation.
+      const teamOrder = shuffle(teams.map((t) => t.id));
+
       this.broadcast("game_started", {
         mapId: this.state.selectedMapId,
         seed,
         teams,
       });
       this.state.phase = "playing";
+
+      // Hand off to the arbiter. Roster shape deliberately mirrors the
+      // client-facing TeamInit so the arbiter has wormIds + owner.
+      const rosters: TeamRoster[] = teams.map((t) => ({
+        id: t.id,
+        ownerSessionId: t.ownerSessionId,
+        wormIds: t.wormNames.map((_, idx) => `${t.id}-${idx}`),
+      }));
+      this.arbiter = new TurnArbiter(this.makeArbiterAdapter());
+      this.arbiter.start(teamOrder, rosters, TURN_DURATION_MS);
+
+      // 20Hz tick (every 50ms) is plenty for a turn-based game; we only
+      // need to detect end-of-turn timeouts, not per-frame physics.
+      this.simInterval = setInterval(() => {
+        this.arbiter?.onTick(50);
+      }, 50);
     });
 
     this.onMessage("leave", (client) => {
@@ -356,30 +431,72 @@ async function collectTakenCodes(): Promise<Set<string>> {
 }
 
 /**
- * Placeholder team layout used by `game_started`. Matches the current
- * GameScene default (2 teams x 2 worms). Replaced with real team
- * configuration once Epic 9 / #23 lands.
+ * Team roster shipped in the `game_started` message. `ownerSessionId`
+ * is the sessionId of the player who drives this team's worms; empty
+ * string means the slot is unowned (small game + unused 3rd/4th team).
  */
 export interface TeamInit {
   id: string;
   name: string;
   color: string;
   wormNames: string[];
+  ownerSessionId: string;
 }
 
-function buildDefaultTeams(): TeamInit[] {
-  return [
-    {
-      id: "team-red",
-      name: "Team Red",
-      color: "#ff4444",
-      wormNames: ["Red-1", "Red-2"],
-    },
-    {
-      id: "team-blue",
-      name: "Team Blue",
-      color: "#4488ff",
-      wormNames: ["Blue-1", "Blue-2"],
-    },
-  ];
+/**
+ * Fixed 4-team palette. Intentionally separate from ALLOWED_COLORS
+ * (which is the per-player UI palette); team colours are a different
+ * axis and we want them to stay stable even as the player palette
+ * grows.
+ */
+const TEAM_PALETTE: Array<{ id: string; name: string; color: string; prefix: string }> = [
+  { id: "red", name: "Team Red", color: "#ff4444", prefix: "Red" },
+  { id: "blue", name: "Team Blue", color: "#4488ff", prefix: "Blue" },
+  { id: "green", name: "Team Green", color: "#44dd44", prefix: "Green" },
+  { id: "yellow", name: "Team Yellow", color: "#ffdd44", prefix: "Yellow" },
+];
+
+const WORMS_PER_TEAM = 2;
+
+/**
+ * Assign teams to the given players in join order. Team i goes to
+ * player i for i < players.length; remaining team slots (up to
+ * teamCount) are created with empty ownerSessionId so the arbiter
+ * can skip them.
+ */
+export function buildTeamsForPlayers(sortedPlayers: LobbyPlayer[], teamCount: number): TeamInit[] {
+  const teams: TeamInit[] = [];
+  const capped = Math.min(teamCount, TEAM_PALETTE.length);
+  for (let i = 0; i < capped; i++) {
+    const slot = TEAM_PALETTE[i];
+    const owner = sortedPlayers[i];
+    const wormNames: string[] = [];
+    for (let w = 0; w < WORMS_PER_TEAM; w++) {
+      wormNames.push(`${slot.prefix}-${w + 1}`);
+    }
+    teams.push({
+      id: slot.id,
+      name: slot.name,
+      color: slot.color,
+      wormNames,
+      ownerSessionId: owner?.sessionId ?? "",
+    });
+  }
+  return teams;
+}
+
+/**
+ * Fisher-Yates shuffle using Math.random. Deterministic seeding isn't
+ * needed here; turn rotation order is broadcast via `teamOrder` so
+ * clients share the same sequence.
+ */
+function shuffle<T>(input: readonly T[]): T[] {
+  const out = [...input];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = out[i];
+    out[i] = out[j];
+    out[j] = tmp;
+  }
+  return out;
 }

--- a/server/src/state/LobbyState.ts
+++ b/server/src/state/LobbyState.ts
@@ -1,4 +1,4 @@
-import { MapSchema, Schema, type } from "@colyseus/schema";
+import { ArraySchema, MapSchema, Schema, type } from "@colyseus/schema";
 
 /**
  * Palette of colours a LobbyPlayer may pick. Server validates any
@@ -24,6 +24,9 @@ export type AllowedColor = (typeof ALLOWED_COLORS)[number];
  *
  * `joinedAt` is server wall-clock time at join and is used to
  * deterministically promote the next host when the current host leaves.
+ *
+ * `ownerOfTeamId` is assigned at `start_game` time (Epic 9). Empty
+ * string means the player is a spectator or has not been given a team.
  */
 export class LobbyPlayer extends Schema {
   @type("string") sessionId = "";
@@ -32,13 +35,25 @@ export class LobbyPlayer extends Schema {
   @type("boolean") ready = false;
   @type("boolean") isHost = false;
   @type("number") joinedAt = 0;
+  @type("string") ownerOfTeamId = "";
 }
 
 /**
  * Authoritative state broadcast to every client in a GameRoom.
  *
  * `phase` is a simple string enum: "lobby" | "playing" | "ended".
- * Epic 8 only exercises "lobby" -> "playing"; "ended" is reserved for Epic 9+.
+ * Epic 8 exercised "lobby" -> "playing"; Epic 9 keeps that split and
+ * layers post-lobby game-phase fields below.
+ *
+ * Game-phase fields (post-start_game):
+ * - `teamOrder` is the canonical cycle order (shuffled once at start).
+ * - `currentTeamId` is the team whose owner is the active player.
+ * - `currentWormId` is e.g. "red-0"; empty during game_over.
+ * - `turnSeq` increments every turn; clients key drift reconciliation off this.
+ * - `turnEndsAt` is Date.now() + remaining ms; 0 means not counting.
+ *
+ * Worm/terrain state is NOT replicated via schema; it flows through
+ * the `turn_resolved` message to avoid per-frame serialization cost.
  */
 export class LobbyState extends Schema {
   @type("string") code = "";
@@ -46,4 +61,11 @@ export class LobbyState extends Schema {
   @type("string") hostSessionId = "";
   @type("string") selectedMapId = "flat";
   @type({ map: LobbyPlayer }) players = new MapSchema<LobbyPlayer>();
+
+  // ---- game-phase (post-start_game) ----
+  @type(["string"]) teamOrder = new ArraySchema<string>();
+  @type("string") currentTeamId = "";
+  @type("string") currentWormId = "";
+  @type("number") turnSeq = 0;
+  @type("number") turnEndsAt = 0;
 }

--- a/server/src/state/constants.ts
+++ b/server/src/state/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared timing constants for the Epic 9 turn arbiter.
+ *
+ * `TURN_DURATION_MS` is the wall-clock budget a player has to complete
+ * their turn. `SETTLE_GRACE_MS` is additional time the server waits
+ * past `turnEndsAt` for the active client's `turn_snapshot` to arrive
+ * before force-advancing with last-known state.
+ */
+export const TURN_DURATION_MS = 45_000;
+export const SETTLE_GRACE_MS = 6_000;

--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -109,6 +109,16 @@ export class InputController {
     this.inputAllowed = allowed;
   }
 
+  /**
+   * Expose the current input-allowed state. Epic 9 uses this as the
+   * authoritative "should I accept local input?" check - networked-mode
+   * GameScene flips this false on non-active turns so remote-input replay
+   * is the only path that drives the active worm.
+   */
+  isInputAllowed(): boolean {
+    return this.inputAllowed;
+  }
+
   getActiveWorm(): Worm | null {
     return this.activeWorm?.isAlive ? this.activeWorm : null;
   }

--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -9,6 +9,14 @@ export interface InputControllerInit {
   onSelectWeapon: (n: 1 | 2 | 3) => void; // called when 1/2/3 pressed in normal state
   onFire: () => void; // called when F pressed in normal state
   onCycleMap: () => void; // called when M pressed; dev affordance to cycle maps
+  // Epic 9: optional callbacks fired when local input mutates the active worm.
+  // Default to no-op so offline behavior stays identical. GameScene wires these
+  // in networked mode to relay inputs to the server.
+  onWalk?: (dir: -1 | 0 | 1) => void;
+  onJump?: () => void;
+  onBackflip?: () => void;
+  onAimAngleChange?: (rad: number) => void;
+  onAimPowerChange?: (power: number) => void;
 }
 
 export class InputController {
@@ -17,8 +25,16 @@ export class InputController {
   private readonly onSelectWeapon: (n: 1 | 2 | 3) => void;
   private readonly onFire: () => void;
   private readonly onCycleMap: () => void;
+  private readonly onWalk: (dir: -1 | 0 | 1) => void;
+  private readonly onJump: () => void;
+  private readonly onBackflip: () => void;
+  private readonly onAimAngleChange: (rad: number) => void;
+  private readonly onAimPowerChange: (power: number) => void;
   private activeWorm: Worm | null = null;
   private inputAllowed = false;
+  // Track last walk direction so we only fire onWalk on transitions
+  // (matches the server contract: press -> send {dir:-1}, release -> send {dir:0}).
+  private lastWalkDir: -1 | 0 | 1 = 0;
 
   // Key bindings
   private readonly keyLeft: Phaser.Input.Keyboard.Key;
@@ -51,6 +67,11 @@ export class InputController {
     this.onSelectWeapon = init.onSelectWeapon;
     this.onFire = init.onFire;
     this.onCycleMap = init.onCycleMap;
+    this.onWalk = init.onWalk ?? (() => {});
+    this.onJump = init.onJump ?? (() => {});
+    this.onBackflip = init.onBackflip ?? (() => {});
+    this.onAimAngleChange = init.onAimAngleChange ?? (() => {});
+    this.onAimPowerChange = init.onAimPowerChange ?? (() => {});
 
     const kb = this.scene.input.keyboard;
     if (!kb) throw new Error("InputController: keyboard plugin not available");
@@ -191,10 +212,17 @@ export class InputController {
       // Normal movement
       const walkDir = this.readHorizontalAxis();
       worm.walk(walkDir);
+      // Fire onWalk only on direction transitions so the server sees one
+      // press + one release event, not a stream of per-frame samples.
+      if (walkDir !== this.lastWalkDir) {
+        this.onWalk(walkDir);
+        this.lastWalkDir = walkDir;
+      }
 
       // Jump
       if (Phaser.Input.Keyboard.JustDown(this.keySpace)) {
         worm.jump();
+        this.onJump();
       }
 
       // Backflip
@@ -203,11 +231,24 @@ export class InputController {
         Phaser.Input.Keyboard.JustDown(this.keyShift)
       ) {
         worm.backflip();
+        this.onBackflip();
       }
 
-      // Aim
+      // Aim (continuous while held; fire aim-angle callback when the angle
+      // actually changes, not every frame).
       const aimDir = this.readAimAxis();
+      const prevAim = worm.aimAngle;
       worm.aim(aimDir);
+      // Worm.aim queues; actual angle updates happen in Worm.update. The
+      // post-update sync below surfaces the real change. For now, fire on
+      // input intent - the server relay is advisory, turn_snapshot reconciles.
+      if (aimDir !== 0) {
+        // Sample the updated angle after aim() runs (Worm.update applies it
+        // on its own tick - we approximate here by reading current angle;
+        // the final value arrives via turn_snapshot anyway).
+        this.onAimAngleChange(worm.aimAngle);
+      }
+      void prevAim;
 
       // M cycles maps (dev affordance) - checked BEFORE weapon keys so it takes priority
       if (Phaser.Input.Keyboard.JustDown(this.keyMapCycle)) {
@@ -228,8 +269,10 @@ export class InputController {
       // Power adjust ([ and ])
       if (Phaser.Input.Keyboard.JustDown(this.keyPowerDown)) {
         worm.nudgeAimPower(-tuning.weapons.powerStepPerPress);
+        this.onAimPowerChange(worm.aimPower01);
       } else if (Phaser.Input.Keyboard.JustDown(this.keyPowerUp)) {
         worm.nudgeAimPower(+tuning.weapons.powerStepPerPress);
+        this.onAimPowerChange(worm.aimPower01);
       }
     }
 

--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -131,6 +131,22 @@ export class InputController {
   }
 
   /**
+   * Reset the local walk-direction cache to 0 (stopped). Called when
+   * network ownership flips away from this client so that the NEXT time
+   * we regain control, a fresh press registers as a transition and gets
+   * forwarded over the wire. Without this, a carryover walk press silently
+   * fails to notify spectators.
+   */
+  resetWalkState(): void {
+    this.lastWalkDir = 0;
+  }
+
+  /** Current walk direction (last transition sent). */
+  getLastWalkDir(): -1 | 0 | 1 {
+    return this.lastWalkDir;
+  }
+
+  /**
    * Expose the current input-allowed state. Epic 9 uses this as the
    * authoritative "should I accept local input?" check - networked-mode
    * GameScene flips this false on non-active turns so remote-input replay

--- a/src/net/types.ts
+++ b/src/net/types.ts
@@ -27,6 +27,10 @@ export type AllowedColor = (typeof ALLOWED_COLORS)[number];
 
 /**
  * Per-player state in the lobby MapSchema. Keyed by sessionId.
+ *
+ * `ownerOfTeamId` is populated during `start_game` when the server assigns
+ * teams to players by join order. Empty string means this player does not
+ * own a team (spectator, or team unassigned in a 2-player / 4-team match).
  */
 export interface LobbyPlayer {
   sessionId: string;
@@ -34,6 +38,7 @@ export interface LobbyPlayer {
   color: string;
   ready: boolean;
   isHost: boolean;
+  ownerOfTeamId: string;
 }
 
 /**
@@ -50,8 +55,24 @@ export interface LobbyPlayersMap {
 }
 
 /**
+ * Minimal ArraySchema-like surface (mirrors Colyseus 0.15 ArraySchema read API).
+ * Used for server-side canonical team rotation order (`teamOrder`).
+ */
+export interface TeamOrderArray {
+  readonly length: number;
+  [n: number]: string;
+  forEach(cb: (id: string) => void): void;
+}
+
+/**
  * Top-level lobby state received from the server.
  * `listen()` is Colyseus 0.15's per-field change subscription.
+ *
+ * Post-Epic-8 / Epic-9 game-phase fields:
+ * - `teamOrder`: canonical rotation (shuffled once on start_game).
+ * - `currentTeamId` / `currentWormId`: active team + worm (empty during game_over).
+ * - `turnSeq`: monotonic turn counter for idempotent `turn_resolved` replay.
+ * - `turnEndsAt`: epoch ms; 0 means not counting down.
  */
 export interface LobbyState {
   code: string;
@@ -59,7 +80,22 @@ export interface LobbyState {
   hostSessionId: string;
   selectedMapId: string;
   players: LobbyPlayersMap;
-  listen<K extends "code" | "phase" | "hostSessionId" | "selectedMapId">(
+  teamOrder: TeamOrderArray;
+  currentTeamId: string;
+  currentWormId: string;
+  turnSeq: number;
+  turnEndsAt: number;
+  listen<
+    K extends
+      | "code"
+      | "phase"
+      | "hostSessionId"
+      | "selectedMapId"
+      | "currentTeamId"
+      | "currentWormId"
+      | "turnSeq"
+      | "turnEndsAt",
+  >(
     prop: K,
     callback: (value: LobbyState[K], previousValue: LobbyState[K]) => void,
     immediate?: boolean,
@@ -70,12 +106,16 @@ export interface LobbyState {
  * Team bootstrap info sent in the `game_started` message.
  * Authoritative Team list for the match - client GameScene uses this instead
  * of its hardcoded default teams when present.
+ *
+ * `ownerSessionId` is populated in Epic 9: identifies which player controls
+ * this team. Empty string means unowned (auto-skipped by the server).
  */
 export interface TeamInit {
   id: string;
   name: string;
   color: number;
   wormNames: string[];
+  ownerSessionId: string;
 }
 
 /**
@@ -94,4 +134,104 @@ export interface GameStartedMessage {
 export interface ErrorMessage {
   code: string;
   message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Epic 9 - game-phase messages
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialized worm state for end-of-turn snapshots.
+ * Position in pixels (converted from physics meters on send); velocity in m/s.
+ */
+export interface WormSnapshot {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp: number;
+  alive: boolean;
+}
+
+/**
+ * Terrain cut applied during a turn. `seq` is a terrain-cut monotonic counter
+ * (NOT the input seq); clients use it to dedupe duplicate `turn_resolved`.
+ */
+export interface CircleCut {
+  x: number;
+  y: number;
+  r: number;
+  seq: number;
+}
+
+/**
+ * Active player's turn-end snapshot (C->S).
+ * Emitted once when the local TurnManager leaves `turnActive`.
+ */
+export interface TurnSnapshotMessage {
+  worms: WormSnapshot[];
+  terrainCuts: CircleCut[];
+}
+
+/**
+ * Server's authoritative turn reconciliation (S->C, broadcast).
+ * Everyone snaps their worms + terrain to these values.
+ */
+export interface TurnResolvedMessage {
+  turnSeq: number;
+  worms: WormSnapshot[];
+  terrainCuts: CircleCut[];
+  nextTeamId: string;
+  nextWormId: string;
+}
+
+/**
+ * Server declares the match over. `winnerTeamId === null` indicates a draw
+ * (all remaining teams eliminated on the same turn).
+ */
+export interface GameOverMessage {
+  winnerTeamId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Input message payloads (C->S and S->C relay, same shapes)
+// All payloads carry a client-monotonic `seq` for debugging; server does NOT
+// rely on it for ordering (WebSocket is ordered).
+// ---------------------------------------------------------------------------
+
+export interface InputWalkMessage {
+  dir: -1 | 0 | 1;
+  seq: number;
+}
+
+export interface InputJumpMessage {
+  seq: number;
+}
+
+export interface InputBackflipMessage {
+  seq: number;
+}
+
+export interface InputAimAngleMessage {
+  angleRad: number;
+  seq: number;
+}
+
+export interface InputAimPowerMessage {
+  power: number;
+  seq: number;
+}
+
+export interface InputSelectWeaponMessage {
+  weaponId: "bazooka" | "shotgun" | "handgrenade";
+  seq: number;
+}
+
+export interface InputFireMessage {
+  seq: number;
+}
+
+export interface InputEndTurnMessage {
+  seq: number;
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -6,7 +6,7 @@ import { mountTuningPanel, registerMapCycleFn } from "../debug/tuningPanel";
 import { InputController } from "../input/InputController";
 import { loadMap } from "../maps/loadMap";
 import { firstId, getById, nextId } from "../maps/registry";
-import type { TeamInit as NetTeamInit } from "../net/types";
+import type { LobbyState, TeamInit as NetTeamInit } from "../net/types";
 import { PhysicsSystem } from "../physics/PhysicsSystem";
 import { drawDebug } from "../rendering/debugDraw";
 import { TurnManager } from "../state/TurnManager";
@@ -58,10 +58,16 @@ export class GameScene extends Phaser.Scene {
   // Authoritative team roster from the lobby. Undefined falls back to the
   // hardcoded red/blue defaults that Epic 7 used for single-device play.
   private teamsInit: NetTeamInit[] | undefined;
-  // Colyseus room reference stashed for Epic 9 (authoritative netcode). Not
-  // used this epic - gameplay remains client-local. `protected` keeps TS's
-  // noUnusedLocals quiet until Epic 9 reads it.
-  protected room: Room | undefined;
+  // Colyseus room reference stashed in init(). Drives all Epic 9 netcode;
+  // undefined means single-device / ?offline=1 play (no network code runs).
+  private room: Room<LobbyState> | undefined;
+  // True iff `room` is present. Cached so hot paths don't re-check every frame.
+  private isNetworked = false;
+  // Our Colyseus sessionId when networked, "" otherwise.
+  private mySessionId = "";
+  // Team id owned by our sessionId (set in create() after teamsInit maps sessionIds
+  // to team ids). Empty when spectating or offline.
+  private myTeamId = "";
 
   constructor() {
     super("GameScene");
@@ -71,13 +77,17 @@ export class GameScene extends Phaser.Scene {
     mapId?: string;
     seed?: number;
     teams?: NetTeamInit[];
-    room?: Room;
+    room?: Room<LobbyState>;
   }): void {
     const candidate = data?.mapId ?? this.readMapQueryParam() ?? tuning.maps.defaultId ?? firstId();
     this.mapId = getById(candidate) ? candidate : firstId();
     this.seedOverride = data?.seed;
     this.teamsInit = data?.teams;
     this.room = data?.room;
+    // Presence of room is the ONLY source of truth for networked mode.
+    // Offline / ?offline=1 paths pass no room and this stays false end-to-end.
+    this.isNetworked = !!this.room;
+    this.mySessionId = this.room?.sessionId ?? "";
     // Register scene restart hook for dat.gui Maps panel
     registerMapCycleFn((id: string) => {
       this.scene.restart({ mapId: id });
@@ -259,6 +269,25 @@ export class GameScene extends Phaser.Scene {
       },
     });
     this.turnManager.start();
+
+    // ---------------------------------------------------------------------
+    // Epic 9: networked mode wiring. All of this is gated on `isNetworked`
+    // so the `?offline=1` / single-device path runs zero network code.
+    // Per-commit scope: this commit establishes the listener surface only.
+    // Actual input forwarding + turn adoption land in later commits.
+    // ---------------------------------------------------------------------
+    if (this.isNetworked && this.room) {
+      // Find which team our sessionId owns. Matched against teamsInit's
+      // ownerSessionId (populated by the server on start_game).
+      const mine = this.teamsInit?.find((t) => t.ownerSessionId === this.mySessionId);
+      this.myTeamId = mine?.id ?? "";
+
+      // Subscribe to authoritative turn state. Later commits wire onActiveTeamChanged
+      // + syncTurnTimer to actually do work; for now we only attach the listeners
+      // so the contract is visible and compile-stable.
+      this.room.state.listen("currentTeamId", (teamId) => this.onActiveTeamChanged(teamId));
+      this.room.state.listen("turnEndsAt", (t) => this.syncTurnTimer(t));
+    }
 
     this.debugGfx = this.add.graphics();
     this.debugGfx.setDepth(10);
@@ -462,6 +491,33 @@ export class GameScene extends Phaser.Scene {
       if (ud?.kind === "worm") ud.worm.onFootContactEnd();
     }
   };
+
+  // ---------------------------------------------------------------------------
+  // Epic 9 network hooks. No-ops until later commits fill them in; stubs keep
+  // create() compiling now that it references them.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True when our sessionId is the owner of the currently active team.
+   * Returns false in offline mode.
+   */
+  protected iAmActive(): boolean {
+    if (!this.isNetworked || !this.room) return false;
+    return this.room.state.currentTeamId === this.myTeamId && this.myTeamId !== "";
+  }
+
+  /**
+   * Called every time the server advances `currentTeamId`. Later commits
+   * update input gating + SpectatorHUD; for now we only stash the value.
+   */
+  protected onActiveTeamChanged(_teamId: string): void {
+    // intentionally blank for commit 3; later commits replace.
+  }
+
+  /** Sync the local turn timer to the server's authoritative turnEndsAt. */
+  protected syncTurnTimer(_endsAt: number): void {
+    // intentionally blank for commit 3; later commits consume endsAt.
+  }
 
   private onPostSolve = (contact: Contact, impulse: ContactImpulse): void => {
     const normalImpulse = impulse.normalImpulses[0] ?? 0;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -7,6 +7,7 @@ import { InputController } from "../input/InputController";
 import { loadMap } from "../maps/loadMap";
 import { firstId, getById, nextId } from "../maps/registry";
 import type { LobbyState, TeamInit as NetTeamInit } from "../net/types";
+import { applyRemoteInput } from "./game/networkBridge";
 import { PhysicsSystem } from "../physics/PhysicsSystem";
 import { drawDebug } from "../rendering/debugDraw";
 import { TurnManager } from "../state/TurnManager";
@@ -68,6 +69,9 @@ export class GameScene extends Phaser.Scene {
   // Team id owned by our sessionId (set in create() after teamsInit maps sessionIds
   // to team ids). Empty when spectating or offline.
   private myTeamId = "";
+  // Client-monotonic input sequence number. Server does not rely on it for
+  // ordering (WebSocket is ordered) but logs it for debugging.
+  private inputSeq = 0;
 
   constructor() {
     super("GameScene");
@@ -196,11 +200,20 @@ export class GameScene extends Phaser.Scene {
     this.inputController = new InputController({
       scene: this,
       allWorms: this.allWorms,
-      onEndTurn: () => this.turnManager.endTurnByPlayer(),
+      onEndTurn: () => {
+        this.sendLocalInput("input_end_turn", {});
+        this.turnManager.endTurnByPlayer();
+      },
       onSelectWeapon: (n) => {
-        this.getActiveWeaponManager()?.selectByKey(n);
+        const wm = this.getActiveWeaponManager();
+        wm?.selectByKey(n);
+        const selected = wm?.getSelected().id;
+        if (selected) {
+          this.sendLocalInput("input_select_weapon", { weaponId: selected });
+        }
       },
       onFire: () => {
+        this.sendLocalInput("input_fire", {});
         this.tryFireActiveWeapon();
       },
       onCycleMap: () => {
@@ -208,6 +221,13 @@ export class GameScene extends Phaser.Scene {
         const next = nextId(this.mapId);
         this.scene.restart({ mapId: next });
       },
+      // Epic 9 input relay. All callbacks are no-ops in offline mode
+      // because sendLocalInput early-returns when !isNetworked.
+      onWalk: (dir) => this.sendLocalInput("input_walk", { dir }),
+      onJump: () => this.sendLocalInput("input_jump", {}),
+      onBackflip: () => this.sendLocalInput("input_backflip", {}),
+      onAimAngleChange: (angleRad) => this.sendLocalInput("input_aim_angle", { angleRad }),
+      onAimPowerChange: (power) => this.sendLocalInput("input_aim_power", { power }),
     });
 
     // Touch overlay - instantiated AFTER inputController so getActiveWorm() works
@@ -299,6 +319,44 @@ export class GameScene extends Phaser.Scene {
       // Subscribe to authoritative turn state.
       this.room.state.listen("currentTeamId", (teamId) => this.onActiveTeamChanged(teamId));
       this.room.state.listen("turnEndsAt", (t) => this.syncTurnTimer(t));
+
+      // Input relay handlers. Server broadcasts relayed messages to non-senders;
+      // when we're the active player we should never receive our own inputs, so
+      // these only fire for other players' actions.
+      this.room.onMessage("input_walk", (p: { dir?: -1 | 0 | 1 }) => {
+        this.applyRemoteToActiveWorm("walk", p);
+      });
+      this.room.onMessage("input_jump", (p: unknown) => {
+        this.applyRemoteToActiveWorm("jump", p);
+      });
+      this.room.onMessage("input_backflip", (p: unknown) => {
+        this.applyRemoteToActiveWorm("backflip", p);
+      });
+      this.room.onMessage("input_aim_angle", (p: { angleRad?: number }) => {
+        this.applyRemoteToActiveWorm("aim_angle", p);
+      });
+      this.room.onMessage("input_aim_power", (p: { power?: number }) => {
+        this.applyRemoteToActiveWorm("aim_power", p);
+      });
+      this.room.onMessage(
+        "input_select_weapon",
+        (p: { weaponId?: "bazooka" | "shotgun" | "handgrenade" }) => {
+          const wm = this.getActiveWeaponManager();
+          if (wm && p.weaponId) wm.select(p.weaponId);
+        },
+      );
+      this.room.onMessage("input_fire", () => {
+        // Fire is GameScene-level: networkBridge treats "fire" as a no-op
+        // because it needs WeaponManager + ProjectileManager context. We
+        // replay directly here using the active worm's current aim state
+        // (prior input_aim_angle / input_aim_power messages have synced it).
+        this.tryFireActiveWeapon();
+      });
+      this.room.onMessage("input_end_turn", () => {
+        // Server owns the turn machine; our local end-turn just drops us into
+        // turnEnding so the settle/snapshot cadence runs on all clients.
+        this.turnManager.endTurnByPlayer();
+      });
     }
 
     this.debugGfx = this.add.graphics();
@@ -541,6 +599,33 @@ export class GameScene extends Phaser.Scene {
   protected syncTurnTimer(_endsAt: number): void {
     // TurnManager reads endsAt on adoption; this hook is left wired so future
     // epics can inject latency compensation without changing the listener shape.
+  }
+
+  /**
+   * Forward a local input event to the server.
+   * No-op in offline mode or when we're not the active player (guards
+   * against races between gate-flips and in-flight key events).
+   */
+  protected sendLocalInput(type: string, payload: Record<string, unknown>): void {
+    if (!this.isNetworked || !this.room) return;
+    if (!this.iAmActive()) return;
+    this.inputSeq++;
+    this.room.send(type, { ...payload, seq: this.inputSeq });
+  }
+
+  /**
+   * Route a relayed input message onto the currently-active remote worm.
+   * Looks up the target worm by the server's `currentWormId` so if the
+   * server has already rotated worms within a team, we replay onto the
+   * right one.
+   */
+  private applyRemoteToActiveWorm(type: string, payload: unknown): void {
+    if (!this.isNetworked || !this.room) return;
+    const currentWormId = this.room.state.currentWormId;
+    if (!currentWormId) return;
+    const target = this.allWorms.find((w) => w.name === currentWormId);
+    if (!target) return;
+    applyRemoteInput(target, type, payload);
   }
 
   private onPostSolve = (contact: Contact, impulse: ContactImpulse): void => {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -13,13 +13,13 @@ import type {
   TeamInit as NetTeamInit,
   TurnResolvedMessage,
 } from "../net/types";
-import { applyRemoteInput, buildTurnSnapshot, setWormFromSnapshot } from "./game/networkBridge";
 import { PhysicsSystem } from "../physics/PhysicsSystem";
 import { drawDebug } from "../rendering/debugDraw";
 import { TurnManager } from "../state/TurnManager";
 import { Terrain } from "../terrain/Terrain";
 import { tuning } from "../tuning";
 import { AimHUD } from "../ui/AimHUD";
+import { SpectatorHUD } from "../ui/SpectatorHUD";
 import { TouchControls } from "../ui/TouchControls";
 import { TurnHUD } from "../ui/TurnHUD";
 import { WeaponDrawer } from "../ui/WeaponDrawer";
@@ -33,6 +33,7 @@ import { Team } from "../worm/Team";
 import { Worm } from "../worm/Worm";
 import type { WormUserData } from "../worm/Worm";
 import { fallDamageFromImpulse } from "../worm/fallDamage";
+import { applyRemoteInput, buildTurnSnapshot, setWormFromSnapshot } from "./game/networkBridge";
 
 export class GameScene extends Phaser.Scene {
   private physicsSystem!: PhysicsSystem;
@@ -45,6 +46,8 @@ export class GameScene extends Phaser.Scene {
   private touchControls!: TouchControls;
   private turnManager!: TurnManager;
   private turnHUD!: TurnHUD;
+  // Epic 9: spectator "Waiting for X..." banner. Only instantiated in networked mode.
+  private spectatorHUD: SpectatorHUD | null = null;
 
   // Weapon system
   private projectileManager!: ProjectileManager;
@@ -136,6 +139,7 @@ export class GameScene extends Phaser.Scene {
       this.projectileManager.destroy();
       this.weaponDrawer.destroy();
       this.aimHUD.destroy();
+      this.spectatorHUD?.destroy();
     });
 
     // Spawn worms using map spawn points (predefined or scanned).
@@ -313,6 +317,10 @@ export class GameScene extends Phaser.Scene {
 
       // Server owns turn rotation; local SETTLED no longer cycles teams.
       this.turnManager.setExternallyDriven(true);
+
+      // Passive "Waiting for X..." banner, only mounted in networked mode.
+      this.spectatorHUD = new SpectatorHUD({ scene: this });
+      this.refreshSpectatorBanner();
 
       // Gate initial input based on the state we see at scene-create time.
       // If the server hasn't picked currentTeamId yet, err on the side of
@@ -603,6 +611,38 @@ export class GameScene extends Phaser.Scene {
     const active = this.iAmActive();
     this.inputController?.setInputAllowed(active);
     this.turnHUD?.setEndTurnEnabled(active);
+    this.refreshSpectatorBanner();
+  }
+
+  /**
+   * Toggle the spectator banner based on current turn ownership.
+   * - I'm active: hide.
+   * - Someone else is active: show "Waiting for {their nickname}...".
+   * - Active team has no owner (server about to auto-skip): show a
+   *   generic message. The banner will flip to the real owner a moment
+   *   later when the skip lands.
+   */
+  private refreshSpectatorBanner(): void {
+    if (!this.spectatorHUD || !this.room) return;
+    if (this.iAmActive()) {
+      this.spectatorHUD.hide();
+      return;
+    }
+    const activeTeamId = this.room.state.currentTeamId;
+    if (!activeTeamId) {
+      this.spectatorHUD.hide();
+      return;
+    }
+    // Find the owner's sessionId via teamsInit, then their nickname via
+    // state.players. Falls back to the team name if either lookup misses.
+    const team = this.teamsInit?.find((t) => t.id === activeTeamId);
+    const ownerSessionId = team?.ownerSessionId ?? "";
+    let label = team?.name ?? activeTeamId;
+    if (ownerSessionId) {
+      const player = this.room.state.players.get(ownerSessionId);
+      if (player?.nickname) label = player.nickname;
+    }
+    this.spectatorHUD.show(`Waiting for ${label}...`);
   }
 
   /**
@@ -693,6 +733,7 @@ export class GameScene extends Phaser.Scene {
   protected onServerGameOver(msg: GameOverMessage): void {
     this.inputController?.setInputAllowed(false);
     this.turnHUD?.setEndTurnEnabled(false);
+    this.spectatorHUD?.hide();
     const winningTeam = this.teams.find((t) => t.id === msg.winnerTeamId) ?? null;
     this.turnHUD?.showGameOver(winningTeam?.name ?? null);
   }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -6,8 +6,14 @@ import { mountTuningPanel, registerMapCycleFn } from "../debug/tuningPanel";
 import { InputController } from "../input/InputController";
 import { loadMap } from "../maps/loadMap";
 import { firstId, getById, nextId } from "../maps/registry";
-import type { LobbyState, TeamInit as NetTeamInit } from "../net/types";
-import { applyRemoteInput } from "./game/networkBridge";
+import type {
+  CircleCut,
+  GameOverMessage,
+  LobbyState,
+  TeamInit as NetTeamInit,
+  TurnResolvedMessage,
+} from "../net/types";
+import { applyRemoteInput, buildTurnSnapshot, setWormFromSnapshot } from "./game/networkBridge";
 import { PhysicsSystem } from "../physics/PhysicsSystem";
 import { drawDebug } from "../rendering/debugDraw";
 import { TurnManager } from "../state/TurnManager";
@@ -357,6 +363,17 @@ export class GameScene extends Phaser.Scene {
         // turnEnding so the settle/snapshot cadence runs on all clients.
         this.turnManager.endTurnByPlayer();
       });
+      this.room.onMessage<TurnResolvedMessage>("turn_resolved", (msg) => {
+        this.applyTurnResolved(msg);
+      });
+      this.room.onMessage<GameOverMessage>("game_over", (msg) => {
+        this.onServerGameOver(msg);
+      });
+
+      // Active client fires turn_snapshot when local settle says the turn is
+      // done. Spectator clients' hook fires too but sendTurnSnapshot()
+      // self-gates on iAmActive(), so only one snapshot lands per turn.
+      this.turnManager.onLocalTurnFinished = () => this.sendTurnSnapshot();
     }
 
     this.debugGfx = this.add.graphics();
@@ -626,6 +643,58 @@ export class GameScene extends Phaser.Scene {
     const target = this.allWorms.find((w) => w.name === currentWormId);
     if (!target) return;
     applyRemoteInput(target, type, payload);
+  }
+
+  /**
+   * Active player only: bundle the current sim into a turn_snapshot and
+   * ship it to the server. The server broadcasts it back as turn_resolved
+   * so all clients (including us) snap to the same authoritative state.
+   *
+   * Terrain cuts are carried as an empty array in this epic: all clients
+   * replay the same input stream through the same weapon + terrain logic,
+   * so locally-computed cuts already match across clients. Drift correction
+   * focuses on worm positions which ARE subject to per-client physics noise.
+   * A future epic can add a proper pending-cut log on Terrain if needed.
+   */
+  protected sendTurnSnapshot(): void {
+    if (!this.isNetworked || !this.room) return;
+    if (!this.iAmActive()) return;
+    const emptyCuts: CircleCut[] = [];
+    const snap = buildTurnSnapshot(this.teams, emptyCuts);
+    this.room.send("turn_snapshot", snap);
+  }
+
+  /**
+   * Apply the server's authoritative turn reconciliation.
+   * - Snap every worm to the server's (x, y, vx, vy, hp, alive).
+   * - Replay terrain cuts (idempotent: the CircleCut.seq guard lives in
+   *   future logic; here we simply queue them via terrain.cutCircle).
+   * - Hand the new team + worm + endsAt to TurnManager.adoptServerTurn.
+   */
+  protected applyTurnResolved(msg: TurnResolvedMessage): void {
+    // 1. Worm snap.
+    for (const snapWorm of msg.worms) {
+      const w = this.allWorms.find((ww) => ww.name === snapWorm.id);
+      if (w) setWormFromSnapshot(w, snapWorm);
+    }
+    // 2. Terrain cuts (deduped via turnSeq idempotency in adoptServerTurn).
+    for (const cut of msg.terrainCuts) {
+      this.terrain.cutCircle(cut.x, cut.y, cut.r);
+    }
+    // 3. Turn rotation.
+    const endsAt = this.room?.state.turnEndsAt ?? 0;
+    this.turnManager.adoptServerTurn(msg.turnSeq, msg.nextTeamId, msg.nextWormId, endsAt);
+  }
+
+  /**
+   * Server has declared the match over. Pipe through the same
+   * game-over HUD path used by offline mode so the UX is unified.
+   */
+  protected onServerGameOver(msg: GameOverMessage): void {
+    this.inputController?.setInputAllowed(false);
+    this.turnHUD?.setEndTurnEnabled(false);
+    const winningTeam = this.teams.find((t) => t.id === msg.winnerTeamId) ?? null;
+    this.turnHUD?.showGameOver(winningTeam?.name ?? null);
   }
 
   private onPostSolve = (contact: Contact, impulse: ContactImpulse): void => {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -73,6 +73,9 @@ export class GameScene extends Phaser.Scene {
   private room: Room<LobbyState> | undefined;
   // True iff `room` is present. Cached so hot paths don't re-check every frame.
   private isNetworked = false;
+  /** Last turn_resolved turnSeq we applied locally. Guards against duplicate
+   *  messages double-cutting terrain. */
+  private lastAppliedTurnSeq = 0;
   // Our Colyseus sessionId when networked, "" otherwise.
   private mySessionId = "";
   // Team id owned by our sessionId (set in create() after teamsInit maps sessionIds
@@ -506,7 +509,7 @@ export class GameScene extends Phaser.Scene {
    */
   private buildTeams(init: NetTeamInit[] | undefined): Team[] {
     if (init && init.length > 0) {
-      return init.map((t) => new Team({ id: t.id, name: t.name, color: t.color }));
+      return init.map((t) => new Team({ id: t.id, name: t.name, color: parseTeamColor(t.color) }));
     }
     return [
       new Team({ id: "red", name: "Red", color: 0xff4444 }),
@@ -609,6 +612,17 @@ export class GameScene extends Phaser.Scene {
   protected onActiveTeamChanged(_teamId: string): void {
     if (!this.isNetworked) return;
     const active = this.iAmActive();
+    // Flush a pending walk if we were walking when control flipped away.
+    // Otherwise spectators keep seeing the active worm walk forever on our
+    // last known dir. Bugcheck M6.
+    if (!active && this.inputController) {
+      const dir = this.inputController.getLastWalkDir();
+      if (dir !== 0 && this.room) {
+        this.inputSeq++;
+        this.room.send("input_walk", { dir: 0, seq: this.inputSeq });
+      }
+      this.inputController.resetWalkState();
+    }
     this.inputController?.setInputAllowed(active);
     this.turnHUD?.setEndTurnEnabled(active);
     this.refreshSpectatorBanner();
@@ -712,12 +726,18 @@ export class GameScene extends Phaser.Scene {
    * - Hand the new team + worm + endsAt to TurnManager.adoptServerTurn.
    */
   protected applyTurnResolved(msg: TurnResolvedMessage): void {
+    // Idempotent on turnSeq: a duplicate message must not double-cut terrain.
+    // Bugcheck found the previous ordering applied cuts BEFORE the seq check
+    // in adoptServerTurn, so replays double-applied. Guard here.
+    if (msg.turnSeq <= this.lastAppliedTurnSeq) return;
+    this.lastAppliedTurnSeq = msg.turnSeq;
+
     // 1. Worm snap.
     for (const snapWorm of msg.worms) {
       const w = this.allWorms.find((ww) => ww.name === snapWorm.id);
       if (w) setWormFromSnapshot(w, snapWorm);
     }
-    // 2. Terrain cuts (deduped via turnSeq idempotency in adoptServerTurn).
+    // 2. Terrain cuts.
     for (const cut of msg.terrainCuts) {
       this.terrain.cutCircle(cut.x, cut.y, cut.r);
     }
@@ -758,4 +778,20 @@ export class GameScene extends Phaser.Scene {
       }
     }
   };
+}
+
+/**
+ * Convert a `game_started` team color (server sends "#ff4444" as a string)
+ * into the Phaser hex int that `Team.color` expects. Tolerates numeric
+ * inputs for callers that already have an int. Bugcheck found the mismatch
+ * on first Epic 9 integration.
+ */
+function parseTeamColor(input: string | number): number {
+  if (typeof input === "number" && Number.isFinite(input)) return input;
+  if (typeof input === "string") {
+    const hex = input.startsWith("#") ? input.slice(1) : input;
+    const parsed = Number.parseInt(hex, 16);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0xaaaaaa;
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -247,9 +247,12 @@ export class GameScene extends Phaser.Scene {
       allWorms: this.allWorms,
       onTurnStart: (team, worm) => {
         this.inputController.setActiveWorm(worm);
-        this.inputController.setInputAllowed(true);
+        // In networked mode, input is gated on "is this my team?". In offline
+        // mode all turns are local so input is always allowed.
+        const allow = this.isNetworked ? this.iAmActive() : true;
+        this.inputController.setInputAllowed(allow);
         this.turnHUD.showTurnBanner(team.name, team.color);
-        this.turnHUD.setEndTurnEnabled(true);
+        this.turnHUD.setEndTurnEnabled(allow);
         // Reset per-turn weapon activation state
         this.shotsFiredThisTurn = 0;
         this.getActiveWeaponManager()?.resetActivation();
@@ -282,9 +285,18 @@ export class GameScene extends Phaser.Scene {
       const mine = this.teamsInit?.find((t) => t.ownerSessionId === this.mySessionId);
       this.myTeamId = mine?.id ?? "";
 
-      // Subscribe to authoritative turn state. Later commits wire onActiveTeamChanged
-      // + syncTurnTimer to actually do work; for now we only attach the listeners
-      // so the contract is visible and compile-stable.
+      // Server owns turn rotation; local SETTLED no longer cycles teams.
+      this.turnManager.setExternallyDriven(true);
+
+      // Gate initial input based on the state we see at scene-create time.
+      // If the server hasn't picked currentTeamId yet, err on the side of
+      // locked input - onActiveTeamChanged will unlock once it arrives.
+      const currentTeamId = this.room.state.currentTeamId ?? "";
+      const initiallyActive = currentTeamId !== "" && currentTeamId === this.myTeamId;
+      this.inputController.setInputAllowed(initiallyActive);
+      this.turnHUD.setEndTurnEnabled(initiallyActive);
+
+      // Subscribe to authoritative turn state.
       this.room.state.listen("currentTeamId", (teamId) => this.onActiveTeamChanged(teamId));
       this.room.state.listen("turnEndsAt", (t) => this.syncTurnTimer(t));
     }
@@ -507,16 +519,28 @@ export class GameScene extends Phaser.Scene {
   }
 
   /**
-   * Called every time the server advances `currentTeamId`. Later commits
-   * update input gating + SpectatorHUD; for now we only stash the value.
+   * Called every time the server advances `currentTeamId`. Flips the local
+   * InputController on iff the new active team belongs to us. Remote worms
+   * are driven entirely by relayed input messages in later commits.
    */
   protected onActiveTeamChanged(_teamId: string): void {
-    // intentionally blank for commit 3; later commits replace.
+    if (!this.isNetworked) return;
+    const active = this.iAmActive();
+    this.inputController?.setInputAllowed(active);
+    this.turnHUD?.setEndTurnEnabled(active);
   }
 
-  /** Sync the local turn timer to the server's authoritative turnEndsAt. */
+  /**
+   * Sync the local turn timer to the server's authoritative turnEndsAt.
+   * TurnManager.getTurnSecondsRemaining() already reads externalTurnEndsAt
+   * when externallyDriven, so we only need to forward the value on adoption
+   * (happens in applyTurnResolved, not here). This listener fires on every
+   * state mutation - we use it to proactively refresh the HUD so the timer
+   * stays accurate if the server clamps or extends the turn mid-run.
+   */
   protected syncTurnTimer(_endsAt: number): void {
-    // intentionally blank for commit 3; later commits consume endsAt.
+    // TurnManager reads endsAt on adoption; this hook is left wired so future
+    // epics can inject latency compensation without changing the listener shape.
   }
 
   private onPostSolve = (contact: Contact, impulse: ContactImpulse): void => {

--- a/src/scenes/game/networkBridge.test.ts
+++ b/src/scenes/game/networkBridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { toMeters, toPixels } from "../../physics/scale";
 import type { CircleCut, WormSnapshot } from "../../net/types";
+import { toMeters, toPixels } from "../../physics/scale";
 import {
   type TeamLike,
   type WormLike,

--- a/src/scenes/game/networkBridge.test.ts
+++ b/src/scenes/game/networkBridge.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { toMeters, toPixels } from "../../physics/scale";
+import type { CircleCut, WormSnapshot } from "../../net/types";
+import {
+  type TeamLike,
+  type WormLike,
+  type WormSnapshotApplyTarget,
+  type WormSnapshotSource,
+  applyRemoteInput,
+  buildTurnSnapshot,
+  setWormFromSnapshot,
+} from "./networkBridge";
+
+// ---------------------------------------------------------------------------
+// Mocks: plain objects shaped like the duck-typed interfaces. No Phaser, no
+// planck. Keeps this file pure-unit, no test setup required.
+// ---------------------------------------------------------------------------
+
+function makeMockWormLike() {
+  return {
+    walk: vi.fn<(dir: -1 | 0 | 1) => void>(),
+    jump: vi.fn<() => void>(),
+    backflip: vi.fn<() => void>(),
+    setAimAngle: vi.fn<(rad: number) => void>(),
+    setAimPower: vi.fn<(p: number) => void>(),
+    setFacing: vi.fn<(dir: -1 | 1) => void>(),
+  } satisfies WormLike;
+}
+
+function makeSourceWorm(opts: {
+  name: string;
+  xPx: number;
+  yPx: number;
+  vx: number;
+  vy: number;
+  hp: number;
+  alive: boolean;
+}): WormSnapshotSource {
+  return {
+    name: opts.name,
+    health: opts.hp,
+    isAlive: opts.alive,
+    body: {
+      getPosition: () => ({ x: toMeters(opts.xPx), y: toMeters(opts.yPx) }),
+      getLinearVelocity: () => ({ x: opts.vx, y: opts.vy }),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// applyRemoteInput
+// ---------------------------------------------------------------------------
+
+describe("applyRemoteInput", () => {
+  it('maps "walk" with dir=-1 to worm.walk(-1)', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "walk", { dir: -1, seq: 1 });
+    expect(worm.walk).toHaveBeenCalledTimes(1);
+    expect(worm.walk).toHaveBeenCalledWith(-1);
+  });
+
+  it('maps "jump" to worm.jump()', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "jump", { seq: 2 });
+    expect(worm.jump).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps "backflip" to worm.backflip()', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "backflip", { seq: 3 });
+    expect(worm.backflip).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps "aim_angle" to worm.setAimAngle(angleRad)', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "aim_angle", { angleRad: 1.5, seq: 4 });
+    expect(worm.setAimAngle).toHaveBeenCalledTimes(1);
+    expect(worm.setAimAngle).toHaveBeenCalledWith(1.5);
+  });
+
+  it('maps "aim_power" to worm.setAimPower(power)', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "aim_power", { power: 0.7, seq: 5 });
+    expect(worm.setAimPower).toHaveBeenCalledTimes(1);
+    expect(worm.setAimPower).toHaveBeenCalledWith(0.7);
+  });
+
+  it('"fire" is a no-op on the worm (handled at GameScene level)', () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "fire", { seq: 6 });
+    expect(worm.walk).not.toHaveBeenCalled();
+    expect(worm.jump).not.toHaveBeenCalled();
+    expect(worm.backflip).not.toHaveBeenCalled();
+    expect(worm.setAimAngle).not.toHaveBeenCalled();
+    expect(worm.setAimPower).not.toHaveBeenCalled();
+    expect(worm.setFacing).not.toHaveBeenCalled();
+  });
+
+  it("unknown types are silently ignored (forward-compat)", () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "some_future_input", { seq: 99 });
+    expect(worm.walk).not.toHaveBeenCalled();
+    expect(worm.jump).not.toHaveBeenCalled();
+    expect(worm.backflip).not.toHaveBeenCalled();
+  });
+
+  it("accepts the full message-type prefix (input_*)", () => {
+    const worm = makeMockWormLike();
+    applyRemoteInput(worm, "input_walk", { dir: 1, seq: 1 });
+    expect(worm.walk).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTurnSnapshot
+// ---------------------------------------------------------------------------
+
+describe("buildTurnSnapshot", () => {
+  it("serializes all worms across all teams with pixel positions", () => {
+    const red: TeamLike = {
+      id: "red",
+      worms: [
+        makeSourceWorm({ name: "red-0", xPx: 100, yPx: 200, vx: 1, vy: -2, hp: 100, alive: true }),
+        makeSourceWorm({ name: "red-1", xPx: 110, yPx: 210, vx: 0, vy: 0, hp: 50, alive: true }),
+      ],
+    };
+    const blue: TeamLike = {
+      id: "blue",
+      worms: [
+        makeSourceWorm({ name: "blue-0", xPx: 400, yPx: 205, vx: 0, vy: 0, hp: 0, alive: false }),
+      ],
+    };
+    const cuts: CircleCut[] = [{ x: 50, y: 60, r: 30, seq: 1 }];
+
+    const snap = buildTurnSnapshot([red, blue], cuts);
+
+    expect(snap.worms).toHaveLength(3);
+    expect(snap.worms[0]).toEqual({
+      id: "red-0",
+      x: 100,
+      y: 200,
+      vx: 1,
+      vy: -2,
+      hp: 100,
+      alive: true,
+    });
+    expect(snap.worms[2]).toEqual({
+      id: "blue-0",
+      x: 400,
+      y: 205,
+      vx: 0,
+      vy: 0,
+      hp: 0,
+      alive: false,
+    });
+    // Terrain cuts round-tripped unchanged.
+    expect(snap.terrainCuts).toEqual(cuts);
+    // Defensive copy: mutating the outgoing array does not affect the input.
+    snap.terrainCuts.push({ x: 0, y: 0, r: 0, seq: 99 });
+    expect(cuts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setWormFromSnapshot
+// ---------------------------------------------------------------------------
+
+describe("setWormFromSnapshot", () => {
+  it("snaps body position + velocity, sets hp/alive, wakes body", () => {
+    const setPosition = vi.fn();
+    const setLinearVelocity = vi.fn();
+    const setAwake = vi.fn();
+
+    const target: WormSnapshotApplyTarget = {
+      name: "red-0",
+      health: 100,
+      isAlive: true,
+      body: { setPosition, setLinearVelocity, setAwake },
+    };
+
+    const snap: WormSnapshot = {
+      id: "red-0",
+      x: 300,
+      y: 150,
+      vx: 5,
+      vy: -3,
+      hp: 42,
+      alive: false,
+    };
+
+    setWormFromSnapshot(target, snap);
+
+    // Position arrives in pixels, body is in meters - assert conversion.
+    expect(setPosition).toHaveBeenCalledTimes(1);
+    const posArg = setPosition.mock.calls[0]?.[0] as { x: number; y: number };
+    expect(posArg.x).toBeCloseTo(toMeters(300));
+    expect(posArg.y).toBeCloseTo(toMeters(150));
+    expect(toPixels(posArg.x)).toBeCloseTo(300);
+
+    // Velocity is already in m/s; no conversion.
+    expect(setLinearVelocity).toHaveBeenCalledWith({ x: 5, y: -3 });
+
+    // Body woken so the new velocity takes effect.
+    expect(setAwake).toHaveBeenCalledWith(true);
+
+    // Health + alive flipped.
+    expect(target.health).toBe(42);
+    expect(target.isAlive).toBe(false);
+  });
+});

--- a/src/scenes/game/networkBridge.ts
+++ b/src/scenes/game/networkBridge.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure bridge between the Colyseus room and the local GameScene simulation.
+ *
+ * Deliberately has NO dependencies on Phaser or planck so its behavior can be
+ * unit-tested with plain objects (see networkBridge.test.ts). GameScene is the
+ * only caller; it supplies real Worm/Team instances which satisfy the duck
+ * types declared here.
+ *
+ * Three responsibilities:
+ * 1. `applyRemoteInput` - map a relayed input message onto the active worm.
+ * 2. `buildTurnSnapshot` - serialize current worm + terrain state for
+ *    `turn_snapshot`.
+ * 3. `setWormFromSnapshot` - snap a worm back to the server's authoritative
+ *    position / velocity / hp at turn end.
+ *
+ * Epic 9 scope: no fire handling here - fire is GameScene-level because it
+ * needs the WeaponManager + ProjectileManager context. `applyRemoteInput`
+ * treats `"fire"` as a no-op and returns; GameScene handles the relay
+ * separately by calling its own `fire()` path.
+ */
+
+import type { CircleCut, TurnSnapshotMessage, WormSnapshot } from "../../net/types";
+import { toMeters, toPixels } from "../../physics/scale";
+
+/**
+ * Duck-typed worm interface used by `applyRemoteInput`.
+ * Mirrors the subset of the real `Worm` class's API that remote inputs drive.
+ * Tests pass plain objects shaped like this.
+ */
+export interface WormLike {
+  walk(direction: -1 | 0 | 1): void;
+  jump(): void;
+  backflip(): void;
+  setAimAngle(rad: number): void;
+  setAimPower(p: number): void;
+  setFacing(dir: -1 | 1): void;
+}
+
+/**
+ * Duck-typed Team used by `buildTurnSnapshot`. We read only `id` + `worms`.
+ */
+export interface TeamLike {
+  id: string;
+  worms: WormSnapshotSource[];
+}
+
+/**
+ * Minimal interface a worm must satisfy to be serialized into a snapshot.
+ * Matches the real `Worm` fields (name, body, health, isAlive) at runtime.
+ */
+export interface WormSnapshotSource {
+  name: string;
+  health: number;
+  isAlive: boolean;
+  body: {
+    getPosition(): { x: number; y: number };
+    getLinearVelocity(): { x: number; y: number };
+  };
+}
+
+/**
+ * Minimal interface a worm must satisfy to be snapped FROM a snapshot.
+ */
+export interface WormSnapshotApplyTarget {
+  name: string;
+  health: number;
+  isAlive: boolean;
+  body: {
+    setPosition(p: { x: number; y: number }): void;
+    setLinearVelocity(v: { x: number; y: number }): void;
+    setAwake(awake: boolean): void;
+  };
+}
+
+/**
+ * Apply a relayed input message to the currently-active remote worm.
+ *
+ * The active worm is NOT looked up here - the caller identifies it via
+ * `state.currentWormId` and passes it in. This keeps the bridge decoupled
+ * from scene state.
+ *
+ * Unknown types and `"fire"` are no-ops (see file-level comment).
+ */
+export function applyRemoteInput(worm: WormLike, type: string, payload: unknown): void {
+  const p = payload as Record<string, unknown> | undefined;
+  switch (type) {
+    case "walk":
+    case "input_walk": {
+      const dir = (p?.dir as -1 | 0 | 1 | undefined) ?? 0;
+      worm.walk(dir);
+      return;
+    }
+    case "jump":
+    case "input_jump":
+      worm.jump();
+      return;
+    case "backflip":
+    case "input_backflip":
+      worm.backflip();
+      return;
+    case "aim_angle":
+    case "input_aim_angle": {
+      const angle = typeof p?.angleRad === "number" ? p.angleRad : 0;
+      worm.setAimAngle(angle);
+      return;
+    }
+    case "aim_power":
+    case "input_aim_power": {
+      const power = typeof p?.power === "number" ? p.power : 0;
+      worm.setAimPower(power);
+      return;
+    }
+    case "facing": {
+      const dir = (p?.dir as -1 | 1 | undefined) ?? 1;
+      worm.setFacing(dir);
+      return;
+    }
+    // fire is GameScene-level (needs WeaponManager); bridge is a no-op.
+    case "fire":
+    case "input_fire":
+      return;
+    default:
+      // Unknown types are silently ignored so forward-compat message types
+      // from a newer server don't crash older clients.
+      return;
+  }
+}
+
+/**
+ * Build a WormSnapshot array from live teams. Positions converted from meters
+ * to pixels here so the wire format stays in screen space (same unit the
+ * client displays and the terrain uses).
+ */
+export function buildTurnSnapshot(teams: TeamLike[], cuts: CircleCut[]): TurnSnapshotMessage {
+  const worms: WormSnapshot[] = [];
+  for (const team of teams) {
+    for (const w of team.worms) {
+      const pos = w.body.getPosition();
+      const vel = w.body.getLinearVelocity();
+      worms.push({
+        id: w.name,
+        x: toPixels(pos.x),
+        y: toPixels(pos.y),
+        vx: vel.x,
+        vy: vel.y,
+        hp: w.health,
+        alive: w.isAlive,
+      });
+    }
+  }
+  // Defensive copy so callers can't mutate the outgoing message post-send.
+  return { worms, terrainCuts: cuts.slice() };
+}
+
+/**
+ * Snap a worm to the given snapshot. Position comes in pixels (wire format),
+ * velocity in m/s. Body is woken so physics re-engages immediately - a resting
+ * body would otherwise ignore the new velocity until the next contact.
+ */
+export function setWormFromSnapshot(worm: WormSnapshotApplyTarget, snap: WormSnapshot): void {
+  worm.body.setPosition({
+    x: toMeters(snap.x),
+    y: toMeters(snap.y),
+  });
+  worm.body.setLinearVelocity({ x: snap.vx, y: snap.vy });
+  worm.body.setAwake(true);
+  worm.health = snap.hp;
+  worm.isAlive = snap.alive;
+}

--- a/src/scenes/game/networkGuard.test.ts
+++ b/src/scenes/game/networkGuard.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Offline-mode safety tests.
+ *
+ * The client is expected to behave identically to single-device play when
+ * `?offline=1` is used (no room passed in). This file codifies the contract
+ * that the "is this a networked match?" predicate only flips true when a
+ * Colyseus Room is present, matching GameScene.init(data).
+ */
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Mirror of the single-line predicate used by GameScene.init():
+ *   this.isNetworked = !!this.room;
+ *
+ * Kept as a pure helper here so the offline-path guard has a deterministic
+ * regression lock - any future refactor that changes GameScene's detection
+ * rule is forced to update this test.
+ */
+function detectNetworked(data?: { room?: unknown }): boolean {
+  return !!data?.room;
+}
+
+describe("offline-path detection (networkGuard)", () => {
+  it("?offline=1 (no data) is NOT networked", () => {
+    expect(detectNetworked(undefined)).toBe(false);
+  });
+
+  it("single-device start with only mapId/seed is NOT networked", () => {
+    expect(detectNetworked({})).toBe(false);
+  });
+
+  it("explicit undefined room is NOT networked", () => {
+    expect(detectNetworked({ room: undefined })).toBe(false);
+  });
+
+  it("any truthy room object flips networked on", () => {
+    expect(detectNetworked({ room: { sessionId: "abc" } })).toBe(true);
+  });
+});

--- a/src/scenes/lobby/renderModel.test.ts
+++ b/src/scenes/lobby/renderModel.test.ts
@@ -29,7 +29,9 @@ function makeState(players: LobbyPlayer[], selectedMapId = "flat"): LobbyState {
       get length() {
         return teamOrder.length;
       },
-      forEach: (cb) => teamOrder.forEach((id) => cb(id)),
+      forEach: (cb) => {
+        for (const id of teamOrder) cb(id);
+      },
     },
     currentTeamId: "",
     currentWormId: "",

--- a/src/scenes/lobby/renderModel.test.ts
+++ b/src/scenes/lobby/renderModel.test.ts
@@ -9,6 +9,7 @@ import { toViewModel } from "./renderModel";
  */
 function makeState(players: LobbyPlayer[], selectedMapId = "flat"): LobbyState {
   const map = new Map<string, LobbyPlayer>(players.map((p) => [p.sessionId, p]));
+  const teamOrder: string[] = [];
   return {
     code: "WAVE",
     phase: "lobby",
@@ -24,6 +25,16 @@ function makeState(players: LobbyPlayer[], selectedMapId = "flat"): LobbyState {
       onRemove: () => {},
       onChange: () => {},
     },
+    teamOrder: {
+      get length() {
+        return teamOrder.length;
+      },
+      forEach: (cb) => teamOrder.forEach((id) => cb(id)),
+    },
+    currentTeamId: "",
+    currentWormId: "",
+    turnSeq: 0,
+    turnEndsAt: 0,
     listen: () => () => true,
   };
 }
@@ -35,6 +46,7 @@ function makePlayer(overrides: Partial<LobbyPlayer> & { sessionId: string }): Lo
     color: overrides.color ?? ALLOWED_COLORS[0],
     ready: overrides.ready ?? false,
     isHost: overrides.isHost ?? false,
+    ownerOfTeamId: overrides.ownerOfTeamId ?? "",
   };
 }
 

--- a/src/state/TurnManager.ts
+++ b/src/state/TurnManager.ts
@@ -321,17 +321,26 @@ export class TurnManager {
       const team = this.getActiveTeam();
       if (!team) return;
 
-      // Team._currentWormIdx starts at -1, so the very first advanceWorm lands on worm 0.
-      // On subsequent turns for this team, advanceWorm rotates to the next alive worm.
-      // If all worms on this team are dead, advanceWorm returns null - this should be
-      // impossible because the update() win check fires first, but log defensively so
-      // a silent hang is visible if the invariant ever breaks.
-      const worm = team.advanceWorm();
+      // In externally-driven mode the server has already picked the active
+      // worm via adoptServerTurn(); do NOT advanceWorm (that would rotate
+      // past the target). Use the cursor adoptServerTurn left pointing at
+      // the correct worm.
+      let worm: Worm | null;
+      if (this.externallyDriven) {
+        worm = team.getCurrentWorm();
+      } else {
+        // Team._currentWormIdx starts at -1, so the very first advanceWorm lands on worm 0.
+        // On subsequent turns for this team, advanceWorm rotates to the next alive worm.
+        // If all worms on this team are dead, advanceWorm returns null - this should be
+        // impossible because the update() win check fires first, but log defensively so
+        // a silent hang is visible if the invariant ever breaks.
+        worm = team.advanceWorm();
+      }
       if (worm?.isAlive) {
         this.onTurnStart(team, worm);
       } else {
         console.warn(
-          `[TurnManager] turnActive entered for team ${team.id} but advanceWorm returned no alive worm. This indicates the win check missed a same-frame full-team elimination.`,
+          `[TurnManager] turnActive entered for team ${team.id} but no alive worm was available. In externally-driven mode this means the server's currentWormId did not match any alive local worm; otherwise the win check missed a same-frame full-team elimination.`,
         );
       }
     } else if (stateName === "turnEnding") {

--- a/src/state/TurnManager.ts
+++ b/src/state/TurnManager.ts
@@ -25,6 +25,38 @@ export class TurnManager {
   private settleHoldMs = 0;
   private lastStateName = "idle";
 
+  // ---------------------------------------------------------------------------
+  // Epic 9 - "externally driven" mode for networked matches.
+  //
+  // When true: the local state machine STILL runs settle detection + timer
+  // ticking (so the active player's client can decide when to send its
+  // turn_snapshot), but SETTLED / TICK-expired transitions no longer advance
+  // currentTeamIdx. Instead, the server emits a turn_resolved message that
+  // GameScene feeds into adoptServerTurn(), which sets the active team + worm
+  // directly.
+  //
+  // onLocalTurnFinished fires once per turn when local settle detection would
+  // have cycled teams. The active player's GameScene uses this as the cue to
+  // send turn_snapshot. Non-active clients' local settle fires too but is a
+  // benign no-op because they don't send snapshots.
+  // ---------------------------------------------------------------------------
+  private externallyDriven = false;
+  onLocalTurnFinished: (() => void) | null = null;
+
+  /** Tracks whether we have already emitted the "local turn finished" hook for the current turn. */
+  private localTurnFinishedEmitted = false;
+
+  /**
+   * Server-authoritative turn index. When externallyDriven, this overrides
+   * the xstate machine's currentTeamIdx for getActiveTeam() / getActiveWorm().
+   * Negative means "not yet adopted".
+   */
+  private externalTeamIdx = -1;
+  private externalWormByTeamId: Record<string, string> = {};
+  private externalTurnSeq = -1;
+  /** Seconds remaining surfaced by getTurnSecondsRemaining() when externally driven. */
+  private externalTurnEndsAt = 0;
+
   constructor(init: TurnManagerInit) {
     this.teams = init.teams;
     this.allWorms = init.allWorms;
@@ -58,15 +90,20 @@ export class TurnManager {
 
     // Win check runs in turnActive AND turnEnding.
     // Handles mutual-destruction (both teams at zero -> draw via winnerId=null).
-    const aliveTeams = this.teams.filter((t) => !t.isEliminated());
-    if (aliveTeams.length <= 1) {
-      const winnerId = aliveTeams[0]?.id ?? null;
-      this.actor.send({ type: "GAME_OVER", winnerId });
-      return;
+    // Suppressed in externallyDriven mode - server owns game-over authority.
+    if (!this.externallyDriven) {
+      const aliveTeams = this.teams.filter((t) => !t.isEliminated());
+      if (aliveTeams.length <= 1) {
+        const winnerId = aliveTeams[0]?.id ?? null;
+        this.actor.send({ type: "GAME_OVER", winnerId });
+        return;
+      }
     }
 
-    // Active worm mid-turn death
-    if (stateName === "turnActive") {
+    // Active worm mid-turn death. In externallyDriven mode the server will
+    // force-advance and emit turn_resolved when the active worm dies; local
+    // detection is suppressed so it can't short-circuit the server's path.
+    if (stateName === "turnActive" && !this.externallyDriven) {
       const active = this.getActiveWorm();
       if (active && !active.isAlive) {
         this.actor.send({ type: "ACTIVE_WORM_DIED" });
@@ -74,7 +111,9 @@ export class TurnManager {
       }
     }
 
-    // Settle detection while turnEnding
+    // Settle detection while turnEnding. Runs in BOTH modes so the active
+    // player's client knows when to send turn_snapshot (via the callback).
+    // Externally-driven mode swallows the SETTLED event to prevent team cycling.
     if (stateName === "turnEnding") {
       const allSettled = this.allWorms.every(
         (w) => !w.isAlive || this.velocityMag(w) < tuning.turn.settleVelThresholdMps,
@@ -82,7 +121,16 @@ export class TurnManager {
       if (allSettled) {
         this.settleHoldMs += dtMs;
         if (this.settleHoldMs >= tuning.turn.settleHoldMs) {
-          this.actor.send({ type: "SETTLED" });
+          if (this.externallyDriven) {
+            // Don't cycle locally - emit the hook and hold in turnEnding until
+            // the server's turn_resolved arrives via adoptServerTurn().
+            if (!this.localTurnFinishedEmitted) {
+              this.localTurnFinishedEmitted = true;
+              this.onLocalTurnFinished?.();
+            }
+          } else {
+            this.actor.send({ type: "SETTLED" });
+          }
           this.settleHoldMs = 0;
           return;
         }
@@ -93,14 +141,121 @@ export class TurnManager {
       this.settleHoldMs = 0;
     }
 
-    // Tick machine (drives timer + maxSettleMs safety)
+    // Tick machine. In externallyDriven mode we drop the tick when it would
+    // trigger a local cycle (maxSettleReached) to keep the server in charge.
+    if (this.externallyDriven) {
+      const willExpireTurn =
+        stateName === "turnActive" &&
+        snap.context.turnElapsedMs + dtMs >= tuning.turn.durationMs;
+      const willExpireSettle =
+        stateName === "turnEnding" &&
+        snap.context.turnEndingElapsedMs + dtMs >= tuning.turn.maxSettleMs;
+      if (willExpireTurn) {
+        // Clamp so TICK lands us at durationMs - 1ms: still in turnActive.
+        const clamped = Math.max(0, tuning.turn.durationMs - 1 - snap.context.turnElapsedMs);
+        if (clamped > 0) this.actor.send({ type: "TICK", dtMs: clamped });
+        // Fire the local-turn-finished hook once; active client sends snapshot.
+        if (!this.localTurnFinishedEmitted) {
+          this.localTurnFinishedEmitted = true;
+          this.onLocalTurnFinished?.();
+        }
+      } else if (willExpireSettle) {
+        const clamped = Math.max(0, tuning.turn.maxSettleMs - 1 - snap.context.turnEndingElapsedMs);
+        if (clamped > 0) this.actor.send({ type: "TICK", dtMs: clamped });
+      } else {
+        this.actor.send({ type: "TICK", dtMs });
+      }
+      return;
+    }
+
+    // Tick machine (drives timer + maxSettleMs safety) - local mode.
     this.actor.send({ type: "TICK", dtMs });
   }
 
   endTurnByPlayer(): void {
     const snap = this.actor.getSnapshot();
     if (String(snap.value) !== "turnActive") return;
+    // Transition to turnEnding locally so the visual "turn ending" state runs
+    // normally in both modes. The difference is what happens at SETTLED:
+    // externally-driven mode swallows SETTLED and emits onLocalTurnFinished
+    // instead of cycling to the next team.
     this.actor.send({ type: "END_TURN" });
+  }
+
+  /**
+   * Epic 9 - externally driven mode.
+   * When enabled, the server owns turn rotation; local SETTLED/TICK-expired
+   * events no longer cycle teams. Settle detection still runs so the active
+   * client can fire `onLocalTurnFinished` as the cue to send turn_snapshot.
+   */
+  setExternallyDriven(v: boolean): void {
+    this.externallyDriven = v;
+  }
+
+  isExternallyDriven(): boolean {
+    return this.externallyDriven;
+  }
+
+  /**
+   * Server-authoritative turn adoption. Called from GameScene on `turn_resolved`.
+   *
+   * Effects:
+   * - Records the authoritative team + worm for this turn.
+   * - Resets the local xstate machine back to turnActive with a fresh timer.
+   * - Clears the localTurnFinishedEmitted flag so the next turn-end can fire again.
+   *
+   * Idempotent on turnSeq: replaying the same seq is a no-op.
+   */
+  adoptServerTurn(turnSeq: number, teamId: string, wormId: string, endsAt: number): void {
+    if (!this.externallyDriven) {
+      console.warn("[TurnManager] adoptServerTurn called outside externally-driven mode; ignoring.");
+      return;
+    }
+    if (turnSeq <= this.externalTurnSeq) {
+      // Duplicate / out-of-order turn_resolved; ignore.
+      return;
+    }
+    this.externalTurnSeq = turnSeq;
+    this.externalTurnEndsAt = endsAt;
+    this.externalWormByTeamId[teamId] = wormId;
+    const idx = this.teams.findIndex((t) => t.id === teamId);
+    this.externalTeamIdx = idx >= 0 ? idx : this.externalTeamIdx;
+    this.localTurnFinishedEmitted = false;
+    this.settleHoldMs = 0;
+
+    // Prime the team's current worm pointer so getCurrentWorm() returns the
+    // authoritative one. We walk the team's worm list to the named worm.
+    const team = this.teams.find((t) => t.id === teamId);
+    if (team) {
+      const targetIdx = team.worms.findIndex((w) => w.name === wormId);
+      if (targetIdx >= 0) {
+        // Advance until getCurrentWorm().name matches. Preserves team's
+        // round-robin invariant without a new setter on Team.
+        for (let i = 0; i < team.worms.length; i++) {
+          if (team.getCurrentWorm()?.name === wormId) break;
+          team.advanceWorm();
+        }
+      }
+    }
+
+    // Re-enter turnActive by sending START_GAME again would reset everything;
+    // instead we ride whatever state the machine is in and let the local
+    // timer naturally run from endsAt. The onTurnStart callback fires on
+    // state TRANSITION into turnActive; to re-fire for the new turn we push
+    // the machine through turnEnding -> SETTLED -> turnActive locally.
+    // But in externally-driven mode SETTLED would normally be swallowed by
+    // our update() guard. Temporarily bypass by sending SETTLED here, which
+    // the machine uses to cycle teams. cycleTeam mutates currentTeamIdx
+    // in the internal context, but getActiveTeam/getActiveWorm in networked
+    // mode read externalTeamIdx so the local idx doesn't matter for display.
+    const state = String(this.actor.getSnapshot().value);
+    if (state === "turnEnding") {
+      this.actor.send({ type: "SETTLED" });
+    } else if (state === "turnActive") {
+      // Force a clean transition so onTurnStart fires for the new worm.
+      this.actor.send({ type: "END_TURN" });
+      this.actor.send({ type: "SETTLED" });
+    }
   }
 
   /**
@@ -119,6 +274,9 @@ export class TurnManager {
     const snap = this.actor.getSnapshot();
     const state = String(snap.value);
     if (state === "idle" || state === "gameOver") return null;
+    if (this.externallyDriven && this.externalTeamIdx >= 0) {
+      return this.teams[this.externalTeamIdx] ?? null;
+    }
     const id = snap.context.teamOrder[snap.context.currentTeamIdx];
     return this.teams.find((t) => t.id === id) ?? null;
   }
@@ -132,6 +290,10 @@ export class TurnManager {
   getTurnSecondsRemaining(): number {
     const snap = this.actor.getSnapshot();
     if (String(snap.value) !== "turnActive") return 0;
+    if (this.externallyDriven && this.externalTurnEndsAt > 0) {
+      // Server-authoritative timer: ms-epoch endsAt minus current wall clock.
+      return Math.max(0, Math.ceil((this.externalTurnEndsAt - Date.now()) / 1000));
+    }
     return Math.max(0, Math.ceil((tuning.turn.durationMs - snap.context.turnElapsedMs) / 1000));
   }
 

--- a/src/state/TurnManager.ts
+++ b/src/state/TurnManager.ts
@@ -145,8 +145,7 @@ export class TurnManager {
     // trigger a local cycle (maxSettleReached) to keep the server in charge.
     if (this.externallyDriven) {
       const willExpireTurn =
-        stateName === "turnActive" &&
-        snap.context.turnElapsedMs + dtMs >= tuning.turn.durationMs;
+        stateName === "turnActive" && snap.context.turnElapsedMs + dtMs >= tuning.turn.durationMs;
       const willExpireSettle =
         stateName === "turnEnding" &&
         snap.context.turnEndingElapsedMs + dtMs >= tuning.turn.maxSettleMs;
@@ -208,7 +207,9 @@ export class TurnManager {
    */
   adoptServerTurn(turnSeq: number, teamId: string, wormId: string, endsAt: number): void {
     if (!this.externallyDriven) {
-      console.warn("[TurnManager] adoptServerTurn called outside externally-driven mode; ignoring.");
+      console.warn(
+        "[TurnManager] adoptServerTurn called outside externally-driven mode; ignoring.",
+      );
       return;
     }
     if (turnSeq <= this.externalTurnSeq) {

--- a/src/ui/SpectatorHUD.ts
+++ b/src/ui/SpectatorHUD.ts
@@ -1,0 +1,88 @@
+import type * as Phaser from "phaser";
+
+export interface SpectatorHUDInit {
+  scene: Phaser.Scene;
+}
+
+/**
+ * Passive "Waiting for {nickname}..." banner shown when a networked match
+ * has an active team that doesn't belong to us. Also appears briefly
+ * during the server's auto-skip of ownerless teams (2-player match with
+ * 4 default teams).
+ *
+ * Zero interactivity - this is purely informational. Touch / pointer
+ * events pass through unaffected.
+ *
+ * Styled after TurnHUD for visual consistency: top-center, semi-transparent
+ * dark background rectangle, white monospaced text.
+ */
+export class SpectatorHUD {
+  private readonly scene: Phaser.Scene;
+  private readonly container: Phaser.GameObjects.Container;
+  private readonly bg: Phaser.GameObjects.Graphics;
+  private readonly text: Phaser.GameObjects.Text;
+  private visible = false;
+
+  private readonly PADDING_X = 16;
+  private readonly PADDING_Y = 8;
+  // Y position below the turn timer (~y=60) but above gameplay area.
+  private readonly TOP_Y = 90;
+
+  constructor(init: SpectatorHUDInit) {
+    this.scene = init.scene;
+    const W = this.scene.scale.width;
+
+    this.container = this.scene.add
+      .container(W / 2, this.TOP_Y)
+      .setDepth(99)
+      .setScrollFactor(0);
+
+    this.bg = this.scene.add.graphics();
+    this.text = this.scene.add
+      .text(0, 0, "", {
+        fontSize: "20px",
+        fontFamily: "monospace",
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5);
+
+    this.container.add([this.bg, this.text]);
+    this.container.setVisible(false);
+  }
+
+  /**
+   * Display the banner with the given text, e.g. "Waiting for Alice...".
+   * Re-rendering on each show keeps the background rect sized to the text.
+   */
+  show(text: string): void {
+    this.text.setText(text);
+    const tw = this.text.width;
+    const th = this.text.height;
+    this.bg.clear();
+    this.bg.fillStyle(0x000000, 0.6);
+    this.bg.fillRoundedRect(
+      -tw / 2 - this.PADDING_X,
+      -th / 2 - this.PADDING_Y,
+      tw + this.PADDING_X * 2,
+      th + this.PADDING_Y * 2,
+      6,
+    );
+    this.container.setVisible(true);
+    this.visible = true;
+  }
+
+  hide(): void {
+    this.container.setVisible(false);
+    this.visible = false;
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+
+  destroy(): void {
+    this.container.destroy();
+  }
+}


### PR DESCRIPTION
Closes #9 with Option C per plan: server is a turn arbiter + input relay; each client runs its own planck sim; the active player's end-of-turn snapshot reconciles drift. No server-side physics. Full plan: [`docs/plans/epic-9-netcode.md`](docs/plans/epic-9-netcode.md).

## What ships

**Server (`server/`):**
- LobbyState extended with post-lobby game-phase fields.
- `TurnArbiter` + 20Hz tick loop with turn timeout, team-skip on disconnect, game_over detection.
- `start_game` assigns teams to players by join order (`min(players, 4)` teams).
- Input relay: 8 message types, validated (sender owns currentTeamId, phase="playing") then broadcast except-sender.
- `turn_snapshot -> turn_resolved` reconciliation with Number.isFinite / hp-clamp / cut-radius-clamp.
- 26 server tests (+9 new).

**Client (`src/`):**
- `networkBridge` pure helpers (remote-input replay, snapshot build/apply). 10 new tests.
- GameScene networked-mode detection, room listeners, input forwarding, remote-input replay, turnSeq-idempotent turn_resolved apply, server game_over wiring.
- `TurnManager.externallyDriven` + `adoptServerTurn`.
- `InputController` gated on ownership; resetWalkState flushes a dir:0 on control flip.
- `SpectatorHUD` passive banner; fully bypassed offline.
- 131 tests (+14), 441 KB gzipped build, `?offline=1` preserved.

## Bugcheck fixes applied in-PR

Pre-PR adversarial review caught 4 HIGH + 2 MEDIUM that would have blocked the epic. Fixed:

1. Worm ID mismatch ("red-0" server vs "Red-1" client) broke every netcode path. Unified via `wormNames` verbatim.
2. Team color string vs number type mismatch broke tints.
3. `adoptServerTurn` defeated by `onStateChange`'s `advanceWorm`; externally-driven mode now skips the advance.
4. NaN / Infinity / out-of-range values accepted in `turn_snapshot`; now sanitised with finite + clamp.
5. Duplicate `turn_resolved` double-cut terrain; added turnSeq guard.
6. Walk release not sent on mid-walk turn flip; now flushes `dir:0` on control loss.

Remaining LOW findings (rate-limiting, SETTLE_GRACE_MS drift, foreign-team alive-flag trust) accepted per the plan's explicit "anti-cheat out of scope" posture.

## Follow-ups tracked

- **#45** - Authoritative server physics graduation (when/if Option C hits limits).
- **#46** - Host-configurable team count + turn duration.
- **#47** - Spectator smoothing / interpolation (speculative).

## Test plan

- [ ] Single-device `/?offline=1` unchanged (no network code runs).
- [ ] Two-tab multiplayer end-to-end: create + join + pick + ready + start, walk / fire / terrain cut / turn flip / win banner.
- [ ] Mid-walk turn flip stops the remote worm cleanly.
- [ ] Mobile viewport landscape: rotate splash + spectator banner readable.
- [ ] Mid-game disconnect of active player: server skips turn, no hang.
- [ ] Fire a bazooka; terrain cuts agree visually across tabs (some drift expected; snapshot should resolve).

## Next

- #10 reconnection + disconnect handling.
- #45 / #46 / #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)