### PR TITLE
Epic 10: reconnection + disconnect handling (closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Server (`server/`):
 9. Keep alternating until one team has no alive worms. Server broadcasts
    game_over; both tabs show the win banner.
 
+## Reconnection
+
+Epic 10 wraps Colyseus' `allowReconnection(client, 60)` around `onLeave`.
+If a player drops (network hiccup, tab crash), their slot is held for 60
+seconds. Other players see a "(disconnected, Ns)" indicator; if the
+disconnected player is the active turn owner, the turn timer freezes
+until they return. After 60s their team auto-forfeits (all worms die)
+and the remaining players keep playing.
+
+Clients cache `room.reconnectionToken` in localStorage (10-minute TTL)
+keyed by room code. Reloading the tab with `?room=CODE` in the URL uses
+the cached token to rejoin silently. Lobby-phase reloads land you back
+in the room; mid-game reloads currently drop you in a stale lobby view
+([#51](https://github.com/scottmccarrison/worms/issues/51) is tracking
+the proper "rejoin active game" handoff).
+
 Architecture note (Epic 9 Option C): the server arbitrates turn
 ownership + relays the active player's inputs + accepts an authoritative
 snapshot at turn end. Each client still runs its own planck sim locally;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,7 @@ Source of truth: [GitHub issues](https://github.com/scottmccarrison/worms/issues
 | 7  | Map loading + starter maps               | Done     | (Epic 7 PR) | [epic-7-maps](plans/epic-7-maps.md)             |
 | 8  | Colyseus integration: lobby + rooms [*]  | Done     | (Epic 8 PR) | [epic-8-lobby](plans/epic-8-lobby.md)           |
 | 9  | Colyseus integration: state schema [*]   | Done (Option C) | (Epic 9 PR) | [epic-9-netcode](plans/epic-9-netcode.md)    |
-| 10 | Colyseus integration: reconnection [*]   | Todo     | -        | -                                                  |
+| 10 | Colyseus integration: reconnection [*]   | Done     | (Epic 10 PR) | [epic-10-reconnect](plans/epic-10-reconnect.md) |
 | 11 | Source original sprite assets (Aseprite) | Todo     | -        | -                                                  |
 | 12 | Source original audio assets             | Todo     | -        | -                                                  |
 | 13 | Deploy pipeline (Cloudflare + Fly.io)    | Todo     | -        | -                                                  |

--- a/server/src/game/TurnArbiter.test.ts
+++ b/server/src/game/TurnArbiter.test.ts
@@ -142,4 +142,136 @@ describe("TurnArbiter", () => {
     // Cycled back to red since blue never acted.
     expect(payload.nextTeamId).toBe("red");
   });
+
+  // ---- Epic 10 ----
+
+  it("onOwnerDisconnected pauses turnEndsAt for the active team; onOwnerReconnected restores remaining time", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    expect(room.state.currentTeamId).toBe("red");
+    const beforeRemaining = room.state.turnEndsAt - Date.now();
+    expect(beforeRemaining).toBeGreaterThan(0);
+
+    // Active owner drops.
+    arbiter.onOwnerDisconnected("alice");
+    // Sentinel used so the client HUD stops counting down.
+    expect(room.state.turnEndsAt).toBe(Number.MAX_SAFE_INTEGER);
+
+    // onTick must not force-advance while paused even if a lot of time
+    // "passes" (we call forceAdvance's precondition indirectly via tick).
+    const broadcastsBefore = room.broadcasts.length;
+    arbiter.onTick(50);
+    expect(room.broadcasts.length).toBe(broadcastsBefore);
+
+    // Reconnect.
+    arbiter.onOwnerReconnected("alice");
+    expect(room.state.turnEndsAt).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    const afterRemaining = room.state.turnEndsAt - Date.now();
+    // Should be close to the remaining time at pause (small tolerance for
+    // the Date.now() gap between pause and resume within a single test).
+    expect(Math.abs(afterRemaining - beforeRemaining)).toBeLessThan(50);
+  });
+
+  it("onOwnerDisconnected is a no-op for a non-active owner", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    const endsAtBefore = room.state.turnEndsAt;
+    // Bob is NOT active; dropping him must not freeze the timer.
+    arbiter.onOwnerDisconnected("bob");
+    expect(room.state.turnEndsAt).toBe(endsAtBefore);
+  });
+
+  it("onTeamForfeit flips aliveByTeam to 0 and ends the game when only one team survives", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+
+    const rosters: TeamRoster[] = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    arbiter.onTeamForfeit("red");
+
+    // 2-player forfeit = immediate game_over with blue winning.
+    const gameOver = room.broadcasts.find((b) => b.type === "game_over");
+    expect(gameOver).toBeDefined();
+    expect((gameOver?.payload as { winnerTeamId: string | null }).winnerTeamId).toBe("blue");
+    // No turn_resolved should land on the final forfeit-to-gameover path.
+    expect(room.broadcasts.find((b) => b.type === "turn_resolved")).toBeUndefined();
+    // Arbiter is a no-op after game over.
+    expect(room.state.currentTeamId).toBe("");
+  });
+
+  it("onTeamForfeit advances the turn when more than one team still has alive worms", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob", "carol"]);
+
+    const rosters: TeamRoster[] = [
+      rosterFor("red", "alice"),
+      rosterFor("blue", "bob"),
+      rosterFor("green", "carol"),
+    ];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue", "green"], rosters, TURN_DURATION_MS);
+
+    // Bob (blue) forfeits; red is still active so this is a non-active
+    // forfeit. Red and green both have alive worms so the arbiter must
+    // synthesize a turn_resolved (marking blue's worms dead) and advance
+    // past blue in the rotation.
+    arbiter.onTeamForfeit("blue");
+
+    const resolved = room.broadcasts.find((b) => b.type === "turn_resolved");
+    expect(resolved).toBeDefined();
+    const payload = resolved?.payload as {
+      nextTeamId: string;
+      worms: Array<{ id: string; alive: boolean; hp: number }>;
+    };
+    // Next team should NOT be blue (forfeited) or red (just played).
+    expect(payload.nextTeamId).toBe("green");
+    // The synthetic worms shipped with the resolution are blue's worms,
+    // all marked dead.
+    expect(payload.worms.every((w) => w.alive === false && w.hp === 0)).toBe(true);
+    expect(payload.worms.map((w) => w.id).sort()).toEqual(["blue-0", "blue-1"]);
+  });
+
+  it("advanceTurn skips teams whose owner is flagged disconnected via adapter", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob", "carol"]);
+    // Bob is still physically connected (grace window), but flagged as
+    // disconnected; advanceTurn must skip his team.
+    room.disconnectedPlayers.add("bob");
+
+    const rosters: TeamRoster[] = [
+      rosterFor("red", "alice"),
+      rosterFor("blue", "bob"),
+      rosterFor("green", "carol"),
+    ];
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue", "green"], rosters, TURN_DURATION_MS);
+
+    const snap: TurnSnapshot = {
+      worms: [
+        { id: "red-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "red-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "blue-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "green-0", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+        { id: "green-1", x: 0, y: 0, vx: 0, vy: 0, hp: 100, alive: true },
+      ],
+      terrainCuts: [],
+    };
+    arbiter.onSnapshot(snap);
+
+    // Skipped past blue to green despite blue having alive worms.
+    expect(room.state.currentTeamId).toBe("green");
+  });
 });

--- a/server/src/game/TurnArbiter.test.ts
+++ b/server/src/game/TurnArbiter.test.ts
@@ -16,12 +16,16 @@ class StubRoom implements ArbiterRoomAdapter {
   state = new LobbyState();
   broadcasts: Array<{ type: string; payload: unknown }> = [];
   connected = new Set<string>();
+  disconnectedPlayers = new Set<string>();
 
   broadcast(type: string, payload: unknown): void {
     this.broadcasts.push({ type, payload });
   }
   getConnectedSessionIds(): Set<string> {
     return this.connected;
+  }
+  getPlayerDisconnected(sessionId: string): boolean {
+    return this.disconnectedPlayers.has(sessionId);
   }
 }
 

--- a/server/src/game/TurnArbiter.ts
+++ b/server/src/game/TurnArbiter.ts
@@ -192,6 +192,34 @@ export class TurnArbiter {
     }
   }
 
+  /**
+   * Epic 10: an active-team owner has disconnected and the room is
+   * holding their slot inside Colyseus' `allowReconnection` grace
+   * window. Stubbed in this commit; pause semantics land in the
+   * follow-up.
+   */
+  onOwnerDisconnected(_sessionId: string): void {
+    void _sessionId;
+  }
+
+  /**
+   * Epic 10: the disconnected owner reconnected before the grace
+   * window elapsed. Stubbed in this commit; resume semantics land in
+   * the follow-up.
+   */
+  onOwnerReconnected(_sessionId: string): void {
+    void _sessionId;
+  }
+
+  /**
+   * Epic 10: the grace window expired (or a consented leave landed)
+   * while the disconnected player still owned this team. Stubbed in
+   * this commit; forfeit semantics land in the follow-up.
+   */
+  onTeamForfeit(_teamId: string): void {
+    void _teamId;
+  }
+
   // ---- private helpers ----
 
   /**

--- a/server/src/game/TurnArbiter.ts
+++ b/server/src/game/TurnArbiter.ts
@@ -45,6 +45,13 @@ export interface ArbiterRoomAdapter {
   broadcast(type: string, payload: unknown): void;
   /** Snapshot of session ids currently present; used to skip disconnected team owners. */
   getConnectedSessionIds(): Set<string>;
+  /**
+   * Whether the LobbyPlayer with this sessionId is in the reconnect
+   * grace window. Epic 10 advanceTurn uses this as a skip predicate so
+   * a disconnected non-active owner's upcoming turn is passed over
+   * until they return (or their team is forfeited when grace expires).
+   */
+  getPlayerDisconnected(sessionId: string): boolean;
 }
 
 /**
@@ -242,11 +249,81 @@ export class TurnArbiter {
 
   /**
    * Epic 10: the grace window expired (or a consented leave landed)
-   * while the disconnected player still owned this team. Stubbed in
-   * this commit; forfeit semantics land in the follow-up.
+   * while the disconnected player still owned this team. Mark every
+   * worm in the team's roster as dead in the alive tally. If this
+   * leaves only one team with alive worms, declare game_over.
+   * Otherwise emit a synthetic `turn_resolved` with the forfeited
+   * team's worms flagged alive=false+hp=0 so every client renders them
+   * as dead, then advance the turn.
+   *
+   * Intentionally tolerant of being called twice for the same team
+   * (e.g. forfeit + forceAdvance on the same tick): the second call
+   * finds alive=0 already and declareGameOver is idempotent via the
+   * `gameOver` guard.
    */
-  onTeamForfeit(_teamId: string): void {
-    void _teamId;
+  onTeamForfeit(teamId: string): void {
+    if (this.gameOver) return;
+    const roster = this.teamRosters.get(teamId);
+    if (!roster) return;
+    if ((this.aliveByTeam.get(teamId) ?? 0) === 0) return; // already forfeited
+    this.aliveByTeam.set(teamId, 0);
+
+    // Build the forfeit worm snapshot: every worm in the team is dead.
+    // We start from lastSnapshot's positions when we have them so
+    // clients can place bodies at the last-known spot; fall back to
+    // zeros otherwise.
+    const forfeitWorms: WormSnapshot[] = [];
+    for (const wormId of roster.wormIds) {
+      const prior = this.lastSnapshot?.worms.find((w) => w.id === wormId);
+      forfeitWorms.push({
+        id: wormId,
+        x: prior?.x ?? 0,
+        y: prior?.y ?? 0,
+        vx: 0,
+        vy: 0,
+        hp: 0,
+        alive: false,
+      });
+    }
+
+    // If only one team still has alive worms (or zero), end the game
+    // here rather than emitting an orphan turn_resolved.
+    let aliveTeamCount = 0;
+    let lastAliveTeamId: string | null = null;
+    for (const [tid, count] of this.aliveByTeam) {
+      if (count > 0) {
+        aliveTeamCount += 1;
+        lastAliveTeamId = tid;
+      }
+    }
+    if (aliveTeamCount <= 1) {
+      this.declareGameOver(lastAliveTeamId);
+      return;
+    }
+
+    // Merge the forfeit worms into lastSnapshot so future
+    // advanceTurn/pickNextWormInTeam calls see them as dead.
+    const mergedWorms: WormSnapshot[] = [];
+    const forfeitIds = new Set(forfeitWorms.map((w) => w.id));
+    if (this.lastSnapshot) {
+      for (const w of this.lastSnapshot.worms) {
+        if (!forfeitIds.has(w.id)) mergedWorms.push(w);
+      }
+    }
+    for (const w of forfeitWorms) mergedWorms.push(w);
+    this.lastSnapshot = { worms: mergedWorms, terrainCuts: [] };
+
+    const synth: TurnSnapshot = { worms: forfeitWorms, terrainCuts: [] };
+    const nextResolution = this.advanceTurn(synth);
+    if (nextResolution) {
+      this.room.broadcast("turn_resolved", {
+        turnSeq: nextResolution.turnSeq,
+        worms: forfeitWorms,
+        terrainCuts: [],
+        nextTeamId: nextResolution.nextTeamId,
+        nextWormId: nextResolution.nextWormId,
+      });
+    }
   }
 
   // ---- private helpers ----
@@ -277,7 +354,10 @@ export class TurnArbiter {
     }
 
     // Find the next team in teamOrder that's eligible: alive worms AND
-    // a connected owner. Skip ownerless / disconnected entries.
+    // a connected, non-disconnected owner. Skip ownerless entries,
+    // entries whose owner has physically dropped off the client list,
+    // and entries whose owner is still inside the Epic 10 reconnect
+    // grace window.
     const connected = this.room.getConnectedSessionIds();
     const teamOrderLen = this.room.state.teamOrder.length;
     let nextTeamId = "";
@@ -289,6 +369,7 @@ export class TurnArbiter {
       if (!roster) continue;
       if (!roster.ownerSessionId) continue;
       if (!connected.has(roster.ownerSessionId)) continue;
+      if (this.room.getPlayerDisconnected(roster.ownerSessionId)) continue;
       if ((this.aliveByTeam.get(candidate) ?? 0) <= 0) continue;
       this.currentTeamIdx = idx;
       nextTeamId = candidate;

--- a/server/src/game/TurnArbiter.ts
+++ b/server/src/game/TurnArbiter.ts
@@ -81,6 +81,12 @@ export class TurnArbiter {
   /** True once game_over has been declared; arbiter becomes a no-op. */
   private gameOver = false;
   private turnDurationMs = 0;
+  /**
+   * Epic 10: when the active-team owner disconnects we freeze the turn
+   * timer. Stores remaining ms at freeze time so we can resume with
+   * the same clock on reconnect. `null` means not paused.
+   */
+  private pausedRemainingMs: number | null = null;
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
@@ -128,6 +134,10 @@ export class TurnArbiter {
   onTick(_dtMs: number): void {
     if (this.gameOver) return;
     if (this.gotSnapshotThisTurn) return;
+    // Epic 10: while paused for a disconnected owner, never force-advance.
+    // The room's reconnect grace owns the deadline; if it expires, the
+    // grace-expiry path calls forceAdvance directly.
+    if (this.pausedRemainingMs !== null) return;
     const now = Date.now();
     if (now > this.room.state.turnEndsAt + SETTLE_GRACE_MS) {
       this.forceAdvance();
@@ -195,20 +205,39 @@ export class TurnArbiter {
   /**
    * Epic 10: an active-team owner has disconnected and the room is
    * holding their slot inside Colyseus' `allowReconnection` grace
-   * window. Stubbed in this commit; pause semantics land in the
-   * follow-up.
+   * window. If this sessionId owns the current team, freeze the turn
+   * timer by storing the remaining ms and pushing `turnEndsAt` to a
+   * sentinel far in the future so the client HUD stops counting down.
+   * Non-active owner disconnects are a no-op here; advanceTurn's skip
+   * predicate handles them lazily on the next rotation.
    */
-  onOwnerDisconnected(_sessionId: string): void {
-    void _sessionId;
+  onOwnerDisconnected(sessionId: string): void {
+    if (this.gameOver) return;
+    const activeTeamId = this.room.state.currentTeamId;
+    if (!activeTeamId) return;
+    const activeTeam = this.teamRosters.get(activeTeamId);
+    if (!activeTeam || activeTeam.ownerSessionId !== sessionId) return;
+    if (this.pausedRemainingMs !== null) return; // already paused
+    const remaining = Math.max(0, this.room.state.turnEndsAt - Date.now());
+    this.pausedRemainingMs = remaining;
+    this.room.state.turnEndsAt = Number.MAX_SAFE_INTEGER;
   }
 
   /**
    * Epic 10: the disconnected owner reconnected before the grace
-   * window elapsed. Stubbed in this commit; resume semantics land in
-   * the follow-up.
+   * window elapsed. If we're currently paused and this sessionId owns
+   * the active team, resume with the previously recorded remaining
+   * time. Everything else is a no-op.
    */
-  onOwnerReconnected(_sessionId: string): void {
-    void _sessionId;
+  onOwnerReconnected(sessionId: string): void {
+    if (this.gameOver) return;
+    if (this.pausedRemainingMs === null) return;
+    const activeTeamId = this.room.state.currentTeamId;
+    if (!activeTeamId) return;
+    const activeTeam = this.teamRosters.get(activeTeamId);
+    if (!activeTeam || activeTeam.ownerSessionId !== sessionId) return;
+    this.room.state.turnEndsAt = Date.now() + this.pausedRemainingMs;
+    this.pausedRemainingMs = null;
   }
 
   /**
@@ -280,6 +309,8 @@ export class TurnArbiter {
     this.room.state.turnSeq += 1;
     this.room.state.turnEndsAt = Date.now() + this.turnDurationMs;
     this.gotSnapshotThisTurn = false;
+    // New turn = fresh clock; any prior pause state is stale.
+    this.pausedRemainingMs = null;
 
     return {
       turnSeq: this.room.state.turnSeq,

--- a/server/src/rooms/GameRoom.test.ts
+++ b/server/src/rooms/GameRoom.test.ts
@@ -392,24 +392,26 @@ describe("GameRoom lobby", () => {
     await bob.leave();
   });
 
-  it("force-advances turn when the active player disconnects", async () => {
+  it("consented leave by the active player forfeits their team (2p -> game_over)", async () => {
     const { alice, bob } = await setupStartedGame();
 
     const firstTeamId = (alice.state as any).currentTeamId as string;
     const active = firstTeamId === "red" ? alice : bob;
     const spectator = firstTeamId === "red" ? bob : alice;
 
-    const resolved: any[] = [];
-    spectator.onMessage("turn_resolved", (p) => resolved.push(p));
+    const gameOvers: any[] = [];
+    spectator.onMessage("game_over", (p) => gameOvers.push(p));
 
+    // `room.leave()` without args is consented; arbiter forfeits the
+    // active team which in a 2-player game leaves one team alive and
+    // triggers game_over.
     await active.leave();
     await tick(200);
 
-    // Active player leaving while holding the turn forces an advance;
-    // the remaining client gets a turn_resolved pointing at itself.
-    expect(resolved.length).toBeGreaterThanOrEqual(1);
-    expect((spectator.state as any).currentTeamId).not.toBe(firstTeamId);
-    expect((spectator.state as any).currentTeamId).not.toBe("");
+    expect(gameOvers).toHaveLength(1);
+    expect(gameOvers[0].winnerTeamId).not.toBe(firstTeamId);
+    expect(gameOvers[0].winnerTeamId).not.toBe(null);
+    expect((spectator.state as any).currentTeamId).toBe("");
 
     await spectator.leave();
   });

--- a/server/src/rooms/GameRoom.test.ts
+++ b/server/src/rooms/GameRoom.test.ts
@@ -3,7 +3,7 @@ import { type ColyseusTestServer, boot } from "@colyseus/testing";
 import { WebSocketTransport } from "@colyseus/ws-transport";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { ALLOWED_COLORS } from "../state/LobbyState.js";
-import { GameRoom } from "./GameRoom.js";
+import { GameRoom, __setReconnectionGraceSecondsForTests } from "./GameRoom.js";
 
 let colyseus: ColyseusTestServer;
 
@@ -435,5 +435,168 @@ describe("GameRoom lobby", () => {
     expect((alice.state as any).selectedMapId).toBe("hills");
 
     await alice.leave();
+  });
+
+  // ---- Epic 10: reconnection + grace window ----
+
+  it("unexpected disconnect flags player as disconnected and preserves the slot; reconnect clears the flag", async () => {
+    const alice = await colyseus.sdk.joinOrCreate("game", {
+      nickname: "Alice",
+      color: ALLOWED_COLORS[0],
+    });
+    await tick();
+    const code = (alice.state as any).code as string;
+
+    const bob = await colyseus.sdk.joinOrCreate("game", {
+      code,
+      nickname: "Bob",
+      color: ALLOWED_COLORS[1],
+    });
+    await tick();
+
+    const bobSessionId = bob.sessionId;
+    const bobToken = bob.reconnectionToken;
+
+    // Non-consented leave (simulates a TCP / network drop).
+    await bob.leave(false);
+    // Give the server a moment to run onLeave + flag the schema row.
+    await tick(150);
+
+    // Bob's LobbyPlayer should still be in the map with disconnected=true.
+    const players = (alice.state as any).players;
+    const bobRow = players.get(bobSessionId);
+    expect(bobRow).toBeDefined();
+    expect(bobRow.disconnected).toBe(true);
+    expect(bobRow.disconnectGraceEndsAt).toBeGreaterThan(Date.now());
+
+    // Now reconnect. `state + listeners` are preserved; onJoin should
+    // NOT re-fire on the server side (we assert indirectly by checking
+    // Bob's color / nickname are the originals, not auto-assigned).
+    const bobAgain = await colyseus.sdk.reconnect(bobToken);
+    await tick(150);
+
+    const bobRowAfter = (alice.state as any).players.get(bobAgain.sessionId);
+    expect(bobRowAfter).toBeDefined();
+    expect(bobRowAfter.disconnected).toBe(false);
+    expect(bobRowAfter.disconnectGraceEndsAt).toBe(0);
+    expect(bobRowAfter.nickname).toBe("Bob");
+    expect(bobRowAfter.color).toBe(ALLOWED_COLORS[1]);
+    // sessionId is preserved across reconnects (that's the whole point).
+    expect(bobAgain.sessionId).toBe(bobSessionId);
+
+    await alice.leave();
+    await bobAgain.leave();
+  });
+
+  it("active-owner disconnect pauses the turn timer; reconnect resumes with the same remaining time", async () => {
+    const { alice, bob } = await setupStartedGame();
+
+    const firstTeamId = (alice.state as any).currentTeamId as string;
+    const active = firstTeamId === "red" ? alice : bob;
+    const spectator = firstTeamId === "red" ? bob : alice;
+    const activeToken = active.reconnectionToken;
+
+    // Grab the remaining time before the drop so we can assert the
+    // resume clock matches within a small tolerance.
+    const turnEndsAtBefore = (spectator.state as any).turnEndsAt as number;
+    const remainingBefore = turnEndsAtBefore - Date.now();
+    expect(remainingBefore).toBeGreaterThan(0);
+
+    await active.leave(false);
+    await tick(150);
+
+    // While paused the sentinel pushes turnEndsAt way into the future;
+    // Number.MAX_SAFE_INTEGER - Date.now() > 10 years is a trivially
+    // safe lower bound that distinguishes "paused" from "unpaused".
+    const turnEndsAtPaused = (spectator.state as any).turnEndsAt as number;
+    expect(turnEndsAtPaused - Date.now()).toBeGreaterThan(10 * 365 * 24 * 60 * 60 * 1000);
+
+    // Reconnect mid-grace.
+    const activeAgain = await colyseus.sdk.reconnect(activeToken);
+    await tick(150);
+
+    const turnEndsAtResumed = (spectator.state as any).turnEndsAt as number;
+    const remainingAfter = turnEndsAtResumed - Date.now();
+    // The turnEndsAt field is no longer the sentinel.
+    expect(turnEndsAtResumed).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    // Resume remaining should be within ~500ms of pre-drop remaining
+    // (test latency + tick delays).
+    expect(Math.abs(remainingAfter - remainingBefore)).toBeLessThan(500);
+
+    await activeAgain.leave();
+    await spectator.leave();
+  });
+
+  it("grace expiry forfeits the active team (2p -> game_over)", async () => {
+    // Shrink the grace to ~1s so the test completes in under ~2s of
+    // real time. Restored in a finally block.
+    __setReconnectionGraceSecondsForTests(1);
+    try {
+      const { alice, bob } = await setupStartedGame();
+
+      const firstTeamId = (alice.state as any).currentTeamId as string;
+      const active = firstTeamId === "red" ? alice : bob;
+      const spectator = firstTeamId === "red" ? bob : alice;
+
+      const gameOvers: any[] = [];
+      spectator.onMessage("game_over", (p) => gameOvers.push(p));
+
+      // Non-consented leave so onLeave actually awaits allowReconnection.
+      await active.leave(false);
+      // Wait past the 1s grace + a bit for bookkeeping.
+      await tick(1500);
+
+      // The remaining team won by forfeit.
+      expect(gameOvers).toHaveLength(1);
+      expect(gameOvers[0].winnerTeamId).not.toBe(firstTeamId);
+      expect(gameOvers[0].winnerTeamId).not.toBe(null);
+      expect((spectator.state as any).currentTeamId).toBe("");
+
+      await spectator.leave();
+    } finally {
+      __setReconnectionGraceSecondsForTests(60);
+    }
+  });
+
+  it("host disconnect + reconnect preserves isHost", async () => {
+    const alice = await colyseus.sdk.joinOrCreate("game", {
+      nickname: "Alice",
+      color: ALLOWED_COLORS[0],
+    });
+    await tick();
+    const code = (alice.state as any).code as string;
+
+    const bob = await colyseus.sdk.joinOrCreate("game", {
+      code,
+      nickname: "Bob",
+      color: ALLOWED_COLORS[1],
+    });
+    await tick();
+
+    expect((alice.state as any).hostSessionId).toBe(alice.sessionId);
+    const aliceToken = alice.reconnectionToken;
+
+    await alice.leave(false);
+    await tick(150);
+
+    // During the grace window host stays on Alice's slot; the LobbyPlayer
+    // is flagged disconnected but still host.
+    const aliceRow = (bob.state as any).players.get(alice.sessionId);
+    expect(aliceRow).toBeDefined();
+    expect(aliceRow.disconnected).toBe(true);
+    expect(aliceRow.isHost).toBe(true);
+    expect((bob.state as any).hostSessionId).toBe(alice.sessionId);
+
+    const aliceAgain = await colyseus.sdk.reconnect(aliceToken);
+    await tick(150);
+
+    const aliceRowAfter = (bob.state as any).players.get(aliceAgain.sessionId);
+    expect(aliceRowAfter).toBeDefined();
+    expect(aliceRowAfter.isHost).toBe(true);
+    expect(aliceRowAfter.disconnected).toBe(false);
+    expect((bob.state as any).hostSessionId).toBe(aliceAgain.sessionId);
+
+    await aliceAgain.leave();
+    await bob.leave();
   });
 });

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -271,6 +271,10 @@ export class GameRoom extends Room<LobbyState> {
         for (const c of self.clients) out.add(c.sessionId);
         return out;
       },
+      getPlayerDisconnected(sessionId: string) {
+        const p = self.state.players.get(sessionId);
+        return p?.disconnected === true;
+      },
     };
   }
 

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -2,7 +2,21 @@ import { type Client, Room, matchMaker } from "@colyseus/core";
 import { generateUniqueCode } from "../codegen.js";
 import { type ArbiterRoomAdapter, type TeamRoster, TurnArbiter } from "../game/TurnArbiter.js";
 import { ALLOWED_COLORS, LobbyPlayer, LobbyState } from "../state/LobbyState.js";
-import { TURN_DURATION_MS } from "../state/constants.js";
+import { DISCONNECT_GRACE_MS, TURN_DURATION_MS } from "../state/constants.js";
+
+/**
+ * Seconds passed to `allowReconnection(client, seconds)` on a
+ * non-consented disconnect. Exposed as a mutable module-level binding
+ * so integration tests can shrink the window (e.g. to 1 second) and
+ * exercise the grace-expiry forfeit path without waiting 60 seconds of
+ * real time. Production code never mutates this.
+ */
+export let reconnectionGraceSeconds = DISCONNECT_GRACE_MS / 1000;
+
+/** Test-only: override the reconnection grace window (in seconds). */
+export function __setReconnectionGraceSecondsForTests(seconds: number): void {
+  reconnectionGraceSeconds = seconds;
+}
 
 /**
  * Whitelist of map ids a host may select. Mirrors
@@ -135,25 +149,79 @@ export class GameRoom extends Room<LobbyState> {
     console.log(`${client.sessionId} (${nickname}) joined ${this.roomId} (host=${player.isHost})`);
   }
 
-  onLeave(client: Client, consented: boolean): void {
+  async onLeave(client: Client, consented: boolean): Promise<void> {
     const wasHost = this.state.hostSessionId === client.sessionId;
+    const player = this.state.players.get(client.sessionId);
+
+    // Consented leave = explicit `leave()` call / tab close handshake.
+    // Skip the reconnection grace window and finalise immediately.
+    if (consented) {
+      this.handleFinalLeave(client, player, wasHost);
+      return;
+    }
+
+    // Flag disconnect so other clients can render "(disconnected, Ns)".
+    // If this is the active team owner, tell the arbiter so it can
+    // freeze the turn timer; otherwise the arbiter's advanceTurn skip
+    // predicate handles the case lazily on the next advance.
+    if (player) {
+      player.disconnected = true;
+      player.disconnectGraceEndsAt = Date.now() + DISCONNECT_GRACE_MS;
+      if (this.state.phase === "playing" && this.arbiter) {
+        this.arbiter.onOwnerDisconnected(client.sessionId);
+      }
+    }
+
+    // allowReconnection resolves when the client reconnects; it
+    // rejects when the grace window expires or the room is disposed.
+    // Either way we call it exactly once per onLeave.
+    try {
+      await this.allowReconnection(client, reconnectionGraceSeconds);
+      // Success path: the same client reconnected. Colyseus preserves
+      // state + listeners; no onJoin re-fires. Just clear the flags.
+      if (player) {
+        player.disconnected = false;
+        player.disconnectGraceEndsAt = 0;
+        if (this.state.phase === "playing" && this.arbiter) {
+          this.arbiter.onOwnerReconnected(client.sessionId);
+        }
+      }
+      console.log(`${client.sessionId} reconnected to ${this.roomId}`);
+    } catch {
+      // Grace expired (or room disposed). Finalise the leave now.
+      this.handleFinalLeave(client, player, wasHost);
+    }
+  }
+
+  /**
+   * Final-leave bookkeeping: delete the player row, let the arbiter
+   * forfeit the team if we're mid-game, promote the next host, and
+   * schedule empty-room disposal. Called either on a consented leave
+   * or after the reconnect grace expires.
+   */
+  private handleFinalLeave(
+    client: Client,
+    player: LobbyPlayer | undefined,
+    wasHost: boolean,
+  ): void {
     const wasActiveOwner =
       this.state.phase === "playing" &&
-      this.state.players.get(client.sessionId)?.ownerOfTeamId === this.state.currentTeamId &&
+      player?.ownerOfTeamId === this.state.currentTeamId &&
       this.state.currentTeamId !== "";
 
     this.state.players.delete(client.sessionId);
 
-    // Post-lobby: let the arbiter know so it can force-advance if the
-    // active player just left. Arbiter itself also re-checks connected
-    // sessionIds on advanceTurn, so a non-active departure needs no
-    // explicit handling here.
-    if (this.state.phase === "playing" && this.arbiter && wasActiveOwner) {
-      this.arbiter.onPlayerLeft(client.sessionId);
+    // Post-lobby: forfeit the team and, if this was the active owner,
+    // force an advance so the remaining players keep moving.
+    if (this.state.phase === "playing" && this.arbiter && player?.ownerOfTeamId) {
+      this.arbiter.onTeamForfeit(player.ownerOfTeamId);
+      if (wasActiveOwner) {
+        this.arbiter.forceAdvance();
+      }
     }
 
+    // Host promotion (unchanged from Epic 8 semantics).
     if (wasHost && this.state.players.size > 0) {
-      // Promote the earliest-joined remaining player.
       let nextHostId = "";
       let earliest = Number.POSITIVE_INFINITY;
       for (const [sid, p] of this.state.players) {
@@ -169,13 +237,10 @@ export class GameRoom extends Room<LobbyState> {
       }
     } else if (this.state.players.size === 0) {
       this.state.hostSessionId = "";
-      // Schedule disposal after a grace period so a quick reconnect
-      // flow (Epic 10) can reclaim the room.
       this.scheduleDisposeIfEmpty();
     }
 
-    void consented;
-    console.log(`${client.sessionId} left ${this.roomId} (wasHost=${wasHost})`);
+    console.log(`${client.sessionId} left ${this.roomId} (finalLeave, wasHost=${wasHost})`);
   }
 
   onDispose(): void {

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -166,7 +166,11 @@ export class GameRoom extends Room<LobbyState> {
     // predicate handles the case lazily on the next advance.
     if (player) {
       player.disconnected = true;
-      player.disconnectGraceEndsAt = Date.now() + DISCONNECT_GRACE_MS;
+      // Track the ACTUAL grace window so a runtime override of
+      // reconnectionGraceSeconds (e.g. tests) stays in sync with what
+      // clients see counting down. Bugcheck flagged the prior hardcoded
+      // DISCONNECT_GRACE_MS as a potential client/server drift.
+      player.disconnectGraceEndsAt = Date.now() + reconnectionGraceSeconds * 1000;
       if (this.state.phase === "playing" && this.arbiter) {
         this.arbiter.onOwnerDisconnected(client.sessionId);
       }
@@ -204,20 +208,15 @@ export class GameRoom extends Room<LobbyState> {
     player: LobbyPlayer | undefined,
     wasHost: boolean,
   ): void {
-    const wasActiveOwner =
-      this.state.phase === "playing" &&
-      player?.ownerOfTeamId === this.state.currentTeamId &&
-      this.state.currentTeamId !== "";
-
     this.state.players.delete(client.sessionId);
 
-    // Post-lobby: forfeit the team and, if this was the active owner,
-    // force an advance so the remaining players keep moving.
+    // Post-lobby: forfeit the team. onTeamForfeit is responsible for
+    // broadcasting a turn_resolved that rotates off the forfeited team
+    // (or declaring game_over if only one team remains), so there is no
+    // separate forceAdvance call here - that would double-advance past
+    // the next eligible team in 3+ player games. Bugcheck flagged this.
     if (this.state.phase === "playing" && this.arbiter && player?.ownerOfTeamId) {
       this.arbiter.onTeamForfeit(player.ownerOfTeamId);
-      if (wasActiveOwner) {
-        this.arbiter.forceAdvance();
-      }
     }
 
     // Host promotion (unchanged from Epic 8 semantics).

--- a/server/src/state/LobbyState.ts
+++ b/server/src/state/LobbyState.ts
@@ -36,6 +36,15 @@ export class LobbyPlayer extends Schema {
   @type("boolean") isHost = false;
   @type("number") joinedAt = 0;
   @type("string") ownerOfTeamId = "";
+  // Epic 10: set to true while the server is holding this player's slot
+  // inside a Colyseus `allowReconnection` grace window. Cleared on
+  // successful reconnect; the player is deleted from the map when the
+  // grace expires or a consented leave lands.
+  @type("boolean") disconnected = false;
+  // Server wall-clock ms at which the grace window ends (Date.now() +
+  // DISCONNECT_GRACE_MS). Zero when not disconnected. Clients read this
+  // to render a per-player countdown in the HUD.
+  @type("number") disconnectGraceEndsAt = 0;
 }
 
 /**

--- a/server/src/state/constants.ts
+++ b/server/src/state/constants.ts
@@ -8,3 +8,13 @@
  */
 export const TURN_DURATION_MS = 45_000;
 export const SETTLE_GRACE_MS = 6_000;
+
+/**
+ * Epic 10 reconnection grace window. On a non-consented disconnect the
+ * server holds the player's slot for this long via Colyseus'
+ * `allowReconnection(client, seconds)`. Within the window the player
+ * may reconnect seamlessly (state + listeners preserved); past it the
+ * leave is finalised, the team forfeits if we are mid-game, and the
+ * slot is freed.
+ */
+export const DISCONNECT_GRACE_MS = 60_000;

--- a/src/net/clientStorage.test.ts
+++ b/src/net/clientStorage.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRoomToken, readRoomToken, saveRoomToken } from "./clientStorage";
+
+/**
+ * Minimal in-memory Storage stub that matches the subset of the Web Storage
+ * API we care about. Tests install one on globalThis.localStorage for the
+ * duration of the test and restore the original afterwards.
+ */
+function makeMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    key: (i: number) => Array.from(data.keys())[i] ?? null,
+    getItem: (k: string) => (data.has(k) ? (data.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      data.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      data.delete(k);
+    },
+    clear: () => {
+      data.clear();
+    },
+  } as Storage;
+}
+
+type Globals = { localStorage?: Storage };
+const g = globalThis as unknown as Globals;
+
+describe("clientStorage", () => {
+  const originalLocalStorage = g.localStorage;
+
+  beforeEach(() => {
+    g.localStorage = makeMemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-21T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    g.localStorage = originalLocalStorage;
+  });
+
+  it("round-trips save -> read", () => {
+    saveRoomToken("WAVE", "room-1", "tok-abc");
+    const got = readRoomToken("WAVE");
+    expect(got).not.toBeNull();
+    expect(got?.roomId).toBe("room-1");
+    expect(got?.token).toBe("tok-abc");
+    expect(got?.code).toBe("WAVE");
+  });
+
+  it("read is case-insensitive on the code", () => {
+    saveRoomToken("wave", "room-1", "tok-abc");
+    expect(readRoomToken("WAVE")?.roomId).toBe("room-1");
+    expect(readRoomToken("Wave")?.roomId).toBe("room-1");
+  });
+
+  it("read returns null for an unknown code", () => {
+    saveRoomToken("WAVE", "room-1", "tok-abc");
+    expect(readRoomToken("ZZZZ")).toBeNull();
+  });
+
+  it("read returns null for an entry older than 10 minutes", () => {
+    saveRoomToken("WAVE", "room-1", "tok-abc");
+    // Advance just past the 10-minute expiry.
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    expect(readRoomToken("WAVE")).toBeNull();
+  });
+
+  it("clear removes the entry", () => {
+    saveRoomToken("WAVE", "room-1", "tok-abc");
+    clearRoomToken("WAVE");
+    expect(readRoomToken("WAVE")).toBeNull();
+  });
+
+  it("save prunes expired entries as a side effect", () => {
+    saveRoomToken("WAVE", "room-1", "tok-1");
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    // This save should evict WAVE (older than 10 min) while adding SURF.
+    saveRoomToken("SURF", "room-2", "tok-2");
+    expect(readRoomToken("WAVE")).toBeNull();
+    expect(readRoomToken("SURF")?.roomId).toBe("room-2");
+  });
+
+  it("does not throw when localStorage.setItem throws (private mode)", () => {
+    const throwing: Storage = {
+      get length() {
+        return 0;
+      },
+      key: () => null,
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: () => {},
+      clear: () => {},
+    } as Storage;
+    g.localStorage = throwing;
+    expect(() => saveRoomToken("WAVE", "room-1", "tok-abc")).not.toThrow();
+    expect(() => clearRoomToken("WAVE")).not.toThrow();
+    // readRoomToken returns null because getItem returns null.
+    expect(readRoomToken("WAVE")).toBeNull();
+  });
+
+  it("does not throw and returns null when localStorage is missing entirely", () => {
+    g.localStorage = undefined;
+    expect(() => saveRoomToken("WAVE", "room-1", "tok-abc")).not.toThrow();
+    expect(readRoomToken("WAVE")).toBeNull();
+    expect(() => clearRoomToken("WAVE")).not.toThrow();
+  });
+
+  it("malformed stored JSON is treated as empty rather than crashing", () => {
+    g.localStorage?.setItem("worms.roomTokens.v1", "not json at all");
+    expect(readRoomToken("WAVE")).toBeNull();
+    // Subsequent save should succeed and overwrite the malformed blob.
+    saveRoomToken("WAVE", "room-1", "tok-abc");
+    expect(readRoomToken("WAVE")?.token).toBe("tok-abc");
+  });
+});

--- a/src/net/clientStorage.ts
+++ b/src/net/clientStorage.ts
@@ -18,6 +18,11 @@
  *   storage quota exceeded, and sandboxed iframes can all throw.
  * - All keys are uppercased on write and read so the on-disk format is
  *   case-stable regardless of how the room code shows up in a URL.
+ * - Colyseus 0.15's `room.reconnectionToken` is already a composite
+ *   "roomId:token" string, so the `token` field below is the full opaque
+ *   string we pass to `client.reconnect()` and `roomId` is stored alongside
+ *   purely for diagnostics / logging. Callers should pass `token` to
+ *   `client.reconnect(token)` (NOT roomId + token).
  */
 
 const KEY = "worms.roomTokens.v1";

--- a/src/net/clientStorage.ts
+++ b/src/net/clientStorage.ts
@@ -1,0 +1,122 @@
+/**
+ * Reconnection token persistence for Colyseus rooms.
+ *
+ * Epic 10: when a client joins a room we stash
+ * {roomId, reconnectionToken} in localStorage keyed by the 4-letter room code.
+ * On cold boot (page reload / tab crash), BootScene looks up the cached token
+ * and calls `client.reconnect(roomId, token)` to slide back into the running
+ * room inside the server-side 60s grace window.
+ *
+ * Design notes:
+ * - Single JSON blob under `worms.roomTokens.v1` rather than one key per code,
+ *   so pruning stale entries is a single read-modify-write.
+ * - Entries older than 10 minutes are pruned on every save. The server's grace
+ *   is 60s but we keep extra slack so a quick browser-crash-then-reload still
+ *   finds a token even if it's just outside grace (the reconnect attempt will
+ *   fail cleanly and we fall back to home).
+ * - Every localStorage access is wrapped in try/catch because private browsing,
+ *   storage quota exceeded, and sandboxed iframes can all throw.
+ * - All keys are uppercased on write and read so the on-disk format is
+ *   case-stable regardless of how the room code shows up in a URL.
+ */
+
+const KEY = "worms.roomTokens.v1";
+const MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+
+export interface StoredToken {
+  code: string;
+  roomId: string;
+  token: string;
+  ts: number;
+}
+
+type StoredTokenMap = Record<string, StoredToken>;
+
+/**
+ * Returns a handle to a Storage-like object, or null if it's not accessible
+ * (Node test environment, private mode, sandboxed iframe). Caller is
+ * expected to no-op on null.
+ */
+function getStorage(): Storage | null {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return null;
+    return ls;
+  } catch {
+    return null;
+  }
+}
+
+function readAll(): StoredTokenMap {
+  const ls = getStorage();
+  if (!ls) return {};
+  try {
+    const raw = ls.getItem(KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as StoredTokenMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(all: StoredTokenMap): void {
+  const ls = getStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(KEY, JSON.stringify(all));
+  } catch {
+    // Quota exceeded / private mode write-blocked / sandboxed iframe.
+    // Reconnect will fall back to a full rejoin; dropping the write is fine.
+  }
+}
+
+/**
+ * Persist the reconnection token for a room code. Prunes entries older than
+ * 10 minutes as a side effect so the stored blob stays small.
+ * No-op (swallows errors) when localStorage is unavailable.
+ */
+export function saveRoomToken(code: string, roomId: string, token: string): void {
+  const all = readAll();
+  const key = code.toUpperCase();
+  all[key] = { code: key, roomId, token, ts: Date.now() };
+  const cutoff = Date.now() - MAX_AGE_MS;
+  for (const [k, v] of Object.entries(all)) {
+    if (!v || typeof v.ts !== "number" || v.ts < cutoff) {
+      delete all[k];
+    }
+  }
+  writeAll(all);
+}
+
+/**
+ * Read a previously saved reconnection token.
+ * Returns null when:
+ * - the code has never been saved
+ * - the stored entry has expired (> 10 minutes old)
+ * - localStorage is unavailable
+ * - the stored blob is malformed
+ */
+export function readRoomToken(code: string): StoredToken | null {
+  const all = readAll();
+  const key = code.toUpperCase();
+  const entry = all[key];
+  if (!entry) return null;
+  if (typeof entry.ts !== "number" || Date.now() - entry.ts > MAX_AGE_MS) return null;
+  if (typeof entry.roomId !== "string" || typeof entry.token !== "string") return null;
+  return entry;
+}
+
+/**
+ * Remove the stored entry for a code. Safe to call when no entry exists.
+ */
+export function clearRoomToken(code: string): void {
+  const all = readAll();
+  const key = code.toUpperCase();
+  if (!(key in all)) return;
+  delete all[key];
+  writeAll(all);
+}

--- a/src/net/reconnectLoop.test.ts
+++ b/src/net/reconnectLoop.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { runReconnectLoop } from "./reconnectLoop";
+
+type FakeClient = {
+  reconnect: ReturnType<typeof vi.fn>;
+};
+
+function makeClient(responses: Array<"ok" | "fail">): FakeClient {
+  let i = 0;
+  return {
+    reconnect: vi.fn(() => {
+      const r = responses[i++];
+      if (r === "ok") {
+        return Promise.resolve({ fake: true, reconnectionToken: "new" });
+      }
+      return Promise.reject(new Error("reconnect failed"));
+    }),
+  };
+}
+
+describe("runReconnectLoop", () => {
+  it("returns the room on first attempt success", async () => {
+    const client = makeClient(["ok"]);
+    const sleep = vi.fn(() => Promise.resolve());
+    const onAttempt = vi.fn();
+    const result = await runReconnectLoop({
+      client: client as unknown as Parameters<typeof runReconnectLoop>[0]["client"],
+      token: "room1:tok1",
+      backoffs: [0, 0, 0],
+      sleep,
+      onAttempt,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.room).toBeDefined();
+    expect(client.reconnect).toHaveBeenCalledTimes(1);
+    expect(onAttempt).toHaveBeenCalledWith(1);
+  });
+
+  it("retries on failure then succeeds", async () => {
+    const client = makeClient(["fail", "fail", "ok"]);
+    const sleep = vi.fn(() => Promise.resolve());
+    const onAttempt = vi.fn();
+    const result = await runReconnectLoop({
+      client: client as unknown as Parameters<typeof runReconnectLoop>[0]["client"],
+      token: "room1:tok1",
+      backoffs: [0, 0, 0, 0],
+      sleep,
+      onAttempt,
+    });
+    expect(result.ok).toBe(true);
+    expect(client.reconnect).toHaveBeenCalledTimes(3);
+    expect(onAttempt.mock.calls).toEqual([[1], [2], [3]]);
+  });
+
+  it("returns { ok: false } when all attempts fail", async () => {
+    const client = makeClient(["fail", "fail", "fail"]);
+    const sleep = vi.fn(() => Promise.resolve());
+    const result = await runReconnectLoop({
+      client: client as unknown as Parameters<typeof runReconnectLoop>[0]["client"],
+      token: "room1:tok1",
+      backoffs: [0, 0, 0],
+      sleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.room).toBeUndefined();
+    expect(client.reconnect).toHaveBeenCalledTimes(3);
+  });
+
+  it("honours the sleep schedule", async () => {
+    const client = makeClient(["fail", "ok"]);
+    const sleep = vi.fn(() => Promise.resolve());
+    await runReconnectLoop({
+      client: client as unknown as Parameters<typeof runReconnectLoop>[0]["client"],
+      token: "room1:tok1",
+      backoffs: [500, 1000, 2000],
+      sleep,
+    });
+    expect(sleep).toHaveBeenNthCalledWith(1, 500);
+    expect(sleep).toHaveBeenNthCalledWith(2, 1000);
+  });
+});

--- a/src/net/reconnectLoop.ts
+++ b/src/net/reconnectLoop.ts
@@ -1,0 +1,76 @@
+import type { Client, Room } from "colyseus.js";
+
+/**
+ * Default exponential-ish backoff used by LobbyScene + GameScene when an
+ * unexpected disconnect fires. Totals ~62s which lines up with the server's
+ * 60s allowReconnection grace window (DISCONNECT_GRACE_MS). If all attempts
+ * fail we've exited the grace window anyway so the token is stale.
+ */
+export const DEFAULT_BACKOFFS_MS: readonly number[] = [
+  500, 1000, 2000, 4000, 8000, 16000, 30000,
+] as const;
+
+export interface RunReconnectLoopParams {
+  /** Colyseus Client used for the reconnect RPC. */
+  client: Client;
+  /** The cached `room.reconnectionToken` (Colyseus 0.15 composite string). */
+  token: string;
+  /** Per-attempt backoff in ms. Defaults to DEFAULT_BACKOFFS_MS. */
+  backoffs?: readonly number[];
+  /** Called at the start of each attempt with 1-indexed attempt number. */
+  onAttempt?: (attempt: number) => void;
+  /**
+   * Await helper. Default uses setTimeout + Promise. Injectable so tests
+   * can resolve immediately instead of actually waiting.
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface RunReconnectLoopResult<S> {
+  ok: boolean;
+  /** The newly-reconnected Room on success. */
+  room?: Room<S>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Drive the client-side reconnect backoff loop.
+ *
+ * Per-attempt flow:
+ *   1. sleep(backoff[i])
+ *   2. onAttempt(i + 1)
+ *   3. try client.reconnect(token). Success -> return { ok: true, room }.
+ *   4. Failure -> keep looping.
+ *
+ * After all attempts fail, resolves { ok: false }. Caller decides whether
+ * to drop the token + send the user home.
+ *
+ * Does NOT touch localStorage directly. Does NOT show UI. Pure network
+ * choreography so it's trivially unit-testable and reusable across scenes.
+ */
+export async function runReconnectLoop<S>(
+  params: RunReconnectLoopParams,
+): Promise<RunReconnectLoopResult<S>> {
+  const backoffs = params.backoffs ?? DEFAULT_BACKOFFS_MS;
+  const sleep = params.sleep ?? defaultSleep;
+
+  for (let i = 0; i < backoffs.length; i++) {
+    const delay = backoffs[i];
+    if (typeof delay === "number" && delay > 0) {
+      await sleep(delay);
+    }
+    const attempt = i + 1;
+    params.onAttempt?.(attempt);
+    try {
+      const room = await params.client.reconnect<S>(params.token);
+      return { ok: true, room };
+    } catch {
+      // Keep trying. A definitive "room gone" error still re-enters the
+      // loop - that's fine because the next attempt will also fail fast
+      // and we're bounded by the backoff schedule.
+    }
+  }
+  return { ok: false };
+}

--- a/src/net/types.ts
+++ b/src/net/types.ts
@@ -39,6 +39,18 @@ export interface LobbyPlayer {
   ready: boolean;
   isHost: boolean;
   ownerOfTeamId: string;
+  /**
+   * Epic 10: true while the player's WebSocket is dropped but still inside
+   * the server's allowReconnection grace window. Clears back to false on
+   * successful reconnect; the slot is deleted if grace expires.
+   */
+  disconnected: boolean;
+  /**
+   * Epic 10: epoch ms at which the reconnection grace window ends.
+   * 0 when the player is connected. Clients can render a countdown via
+   * `Math.ceil((disconnectGraceEndsAt - Date.now()) / 1000)`.
+   */
+  disconnectGraceEndsAt: number;
 }
 
 /**

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,5 +1,7 @@
 import * as Phaser from "phaser";
 import { createNetClient } from "../net/client";
+import { clearRoomToken, readRoomToken, saveRoomToken } from "../net/clientStorage";
+import type { LobbyState } from "../net/types";
 import { parseUrlParams } from "./lobby/urlParams";
 import type { UrlParams } from "./lobby/urlParams";
 
@@ -9,6 +11,16 @@ import type { UrlParams } from "./lobby/urlParams";
  *
  * Renders no visible UI - Phaser runs this, the next scene takes over on the
  * same frame.
+ *
+ * Epic 10: when we arrive with `?room=CODE` in the URL AND we have a
+ * cached reconnectionToken for that code, try `client.reconnect` first.
+ * On success we jump straight into the LobbyScene room view; on failure
+ * (stale token, server restarted, grace expired) we clear the token and
+ * fall through to the normal join flow.
+ *
+ * The offline path (`?offline=1`) is a hard short-circuit: no localStorage
+ * read, no reconnect attempt, no NetClient created. Matches the Epic 7
+ * single-device contract exactly.
  */
 export class BootScene extends Phaser.Scene {
   private urlParams!: UrlParams;
@@ -24,15 +36,46 @@ export class BootScene extends Phaser.Scene {
   create(): void {
     if (this.urlParams.offline) {
       // Dev shortcut: skip multiplayer entirely. Preserves Epic 7 behaviour
-      // when GameScene is booted directly.
+      // when GameScene is booted directly. Must stay before any localStorage
+      // access so `?offline=1` never touches client storage.
       this.scene.start("GameScene", { mapId: this.urlParams.mapId ?? undefined });
       return;
     }
 
+    // Async wrapper: create() itself can't be async (Phaser ignores the
+    // returned promise), but we kick off the reconnect-then-route flow and
+    // swallow rejections ourselves.
+    void this.bootOnline();
+  }
+
+  private async bootOnline(): Promise<void> {
     const netClient = createNetClient();
+    const code = this.urlParams.autoJoinCode;
+
+    if (code) {
+      const stored = readRoomToken(code);
+      if (stored) {
+        try {
+          // Colyseus 0.15: reconnectionToken is a single composite string
+          // ("roomId:token") that fully identifies the reconnect target.
+          const room = await netClient.reconnect<LobbyState>(stored.token);
+          // Reconnect succeeded. The reconnectionToken rotates on every
+          // (re)connect so we immediately refresh the cached value.
+          saveRoomToken(code, room.roomId, room.reconnectionToken);
+          this.scene.start("LobbyScene", { netClient, room });
+          return;
+        } catch {
+          // Token was stale / grace expired / server was bounced.
+          // Drop the bad entry so subsequent reloads don't waste a round-trip.
+          clearRoomToken(code);
+        }
+      }
+    }
+
+    // Normal flow: hand off to LobbyScene home view with the code pre-filled.
     this.scene.start("LobbyScene", {
       netClient,
-      autoJoinCode: this.urlParams.autoJoinCode,
+      autoJoinCode: code,
     });
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,4 +1,4 @@
-import type { Room } from "colyseus.js";
+import type { Client, Room } from "colyseus.js";
 import * as Phaser from "phaser";
 import type { Contact } from "planck";
 import type { ContactImpulse } from "planck";
@@ -6,6 +6,8 @@ import { mountTuningPanel, registerMapCycleFn } from "../debug/tuningPanel";
 import { InputController } from "../input/InputController";
 import { loadMap } from "../maps/loadMap";
 import { firstId, getById, nextId } from "../maps/registry";
+import { clearRoomToken, readRoomToken, saveRoomToken } from "../net/clientStorage";
+import { runReconnectLoop } from "../net/reconnectLoop";
 import type {
   CircleCut,
   GameOverMessage,
@@ -19,6 +21,7 @@ import { TurnManager } from "../state/TurnManager";
 import { Terrain } from "../terrain/Terrain";
 import { tuning } from "../tuning";
 import { AimHUD } from "../ui/AimHUD";
+import { ReconnectingOverlay } from "../ui/ReconnectingOverlay";
 import { SpectatorHUD } from "../ui/SpectatorHUD";
 import { TouchControls } from "../ui/TouchControls";
 import { TurnHUD } from "../ui/TurnHUD";
@@ -71,6 +74,9 @@ export class GameScene extends Phaser.Scene {
   // Colyseus room reference stashed in init(). Drives all Epic 9 netcode;
   // undefined means single-device / ?offline=1 play (no network code runs).
   private room: Room<LobbyState> | undefined;
+  // NetClient reference - only present in networked mode. Used by the Epic
+  // 10 reconnect loop to `client.reconnect(token)` after an unexpected drop.
+  private netClient: Client | undefined;
   // True iff `room` is present. Cached so hot paths don't re-check every frame.
   private isNetworked = false;
   /** Last turn_resolved turnSeq we applied locally. Guards against duplicate
@@ -85,6 +91,16 @@ export class GameScene extends Phaser.Scene {
   // ordering (WebSocket is ordered) but logs it for debugging.
   private inputSeq = 0;
 
+  // ----- Epic 10: reconnect + disconnected-owner HUD -----
+  /** Shared ReconnectingOverlay. Lazy-created on first drop. */
+  private reconnectingOverlay: ReconnectingOverlay | null = null;
+  /** Concurrent-loop guard; prevents overlapping reconnect chains. */
+  private reconnectInFlight = false;
+  /** Room code captured at init time (room.state.code may be freed on drop). */
+  private currentRoomCode = "";
+  /** Phaser Time event that refreshes the disconnected-owner countdown. */
+  private disconnectTick: Phaser.Time.TimerEvent | null = null;
+
   constructor() {
     super("GameScene");
   }
@@ -94,12 +110,14 @@ export class GameScene extends Phaser.Scene {
     seed?: number;
     teams?: NetTeamInit[];
     room?: Room<LobbyState>;
+    netClient?: Client;
   }): void {
     const candidate = data?.mapId ?? this.readMapQueryParam() ?? tuning.maps.defaultId ?? firstId();
     this.mapId = getById(candidate) ? candidate : firstId();
     this.seedOverride = data?.seed;
     this.teamsInit = data?.teams;
     this.room = data?.room;
+    this.netClient = data?.netClient;
     // Presence of room is the ONLY source of truth for networked mode.
     // Offline / ?offline=1 paths pass no room and this stays false end-to-end.
     this.isNetworked = !!this.room;
@@ -143,6 +161,10 @@ export class GameScene extends Phaser.Scene {
       this.weaponDrawer.destroy();
       this.aimHUD.destroy();
       this.spectatorHUD?.destroy();
+      this.reconnectingOverlay?.destroy();
+      this.reconnectingOverlay = null;
+      this.disconnectTick?.remove(false);
+      this.disconnectTick = null;
     });
 
     // Spawn worms using map spawn points (predefined or scanned).
@@ -385,6 +407,23 @@ export class GameScene extends Phaser.Scene {
       // done. Spectator clients' hook fires too but sendTurnSnapshot()
       // self-gates on iAmActive(), so only one snapshot lands per turn.
       this.turnManager.onLocalTurnFinished = () => this.sendTurnSnapshot();
+
+      // Epic 10: capture the room code + unexpected-drop handler. Any leave
+      // code other than 1000 / 4200 (consented) triggers the reconnect loop.
+      // Also re-render the disconnected-owner banner on any player change.
+      this.currentRoomCode = this.room.state?.code ?? "";
+      this.room.onLeave((code) => {
+        if (code === 1000 || code === 4200) return;
+        void this.startReconnectionLoop();
+      });
+      this.room.state.players.onChange(() => this.refreshSpectatorBanner());
+      // Countdown tick for "(owner disconnected, Ns)". 250ms is plenty for a
+      // 1-second-precision countdown without burning render budget.
+      this.disconnectTick = this.time.addEvent({
+        delay: 250,
+        loop: true,
+        callback: () => this.refreshSpectatorBanner(),
+      });
     }
 
     this.debugGfx = this.add.graphics();
@@ -638,25 +677,38 @@ export class GameScene extends Phaser.Scene {
    */
   private refreshSpectatorBanner(): void {
     if (!this.spectatorHUD || !this.room) return;
-    if (this.iAmActive()) {
-      this.spectatorHUD.hide();
-      return;
-    }
     const activeTeamId = this.room.state.currentTeamId;
     if (!activeTeamId) {
       this.spectatorHUD.hide();
       return;
     }
-    // Find the owner's sessionId via teamsInit, then their nickname via
-    // state.players. Falls back to the team name if either lookup misses.
+    // Find the owner's sessionId via teamsInit, then look up the live
+    // LobbyPlayer for nickname + disconnected flag. Falls back to the
+    // team name if the lookup misses.
     const team = this.teamsInit?.find((t) => t.id === activeTeamId);
     const ownerSessionId = team?.ownerSessionId ?? "";
-    let label = team?.name ?? activeTeamId;
-    if (ownerSessionId) {
-      const player = this.room.state.players.get(ownerSessionId);
-      if (player?.nickname) label = player.nickname;
+    const ownerPlayer = ownerSessionId ? this.room.state.players.get(ownerSessionId) : undefined;
+    const ownerName = ownerPlayer?.nickname ?? team?.name ?? activeTeamId;
+
+    // Epic 10: if the active team's owner is disconnected, surface it on
+    // the banner with a grace countdown. This takes precedence over the
+    // usual "I'm active - hide banner" rule so the active player also sees
+    // the countdown when... someone else (e.g. the other player in a
+    // 1v1) has dropped. That second case actually can't happen because
+    // only the active owner pauses the turn, but the banner still shows
+    // cleanly for spectators either way.
+    if (ownerPlayer?.disconnected) {
+      const graceEndsAt = ownerPlayer.disconnectGraceEndsAt ?? 0;
+      const remainingSec = Math.max(0, Math.ceil((graceEndsAt - Date.now()) / 1000));
+      this.spectatorHUD.show(`${ownerName} (disconnected, ${remainingSec}s)`);
+      return;
     }
-    this.spectatorHUD.show(`Waiting for ${label}...`);
+
+    if (this.iAmActive()) {
+      this.spectatorHUD.hide();
+      return;
+    }
+    this.spectatorHUD.show(`Waiting for ${ownerName}...`);
   }
 
   /**
@@ -756,6 +808,77 @@ export class GameScene extends Phaser.Scene {
     this.spectatorHUD?.hide();
     const winningTeam = this.teams.find((t) => t.id === msg.winnerTeamId) ?? null;
     this.turnHUD?.showGameOver(winningTeam?.name ?? null);
+  }
+
+  /**
+   * Epic 10: unexpected-drop reconnect loop. Matches the LobbyScene pattern
+   * but operates on the live game Room. On success we swap `this.room`,
+   * re-wire the message + state listeners, and unhide input if it's still
+   * our turn. On failure we clear the cached token and drop back to the
+   * LobbyScene home view so the user can re-join manually.
+   */
+  private async startReconnectionLoop(): Promise<void> {
+    if (this.reconnectInFlight) return;
+    if (!this.netClient) {
+      // Can't reconnect without a client reference; bounce to home.
+      this.scene.start("LobbyScene");
+      return;
+    }
+    this.reconnectInFlight = true;
+
+    const code = this.currentRoomCode;
+    const stored = code ? readRoomToken(code) : null;
+    if (!stored) {
+      this.reconnectInFlight = false;
+      this.scene.start("LobbyScene", { netClient: this.netClient, autoJoinCode: null });
+      return;
+    }
+
+    const overlay = this.ensureOverlay();
+    overlay.show(1);
+
+    const result = await runReconnectLoop<LobbyState>({
+      client: this.netClient,
+      token: stored.token,
+      onAttempt: (n) => overlay.show(n),
+    });
+
+    if (result.ok && result.room) {
+      // Swap to the fresh Room. reconnectionToken rotated; cache the new one.
+      this.room = result.room;
+      this.mySessionId = result.room.sessionId;
+      saveRoomToken(code, result.room.roomId, result.room.reconnectionToken);
+      overlay.hide();
+      this.reconnectInFlight = false;
+      // Full re-wire of listeners on the new Room would be invasive here;
+      // a scene.restart() is simpler and guaranteed consistent. We keep
+      // the same teamsInit + mapId + seed so physics state is rebuilt
+      // from scratch and then catches up via the next turn_resolved.
+      this.scene.restart({
+        mapId: this.mapId,
+        seed: this.seedOverride,
+        teams: this.teamsInit,
+        room: result.room,
+        netClient: this.netClient,
+      });
+      return;
+    }
+
+    // All attempts failed. Token is stale; drop to home.
+    overlay.showFinal("Lost connection. Returning home.");
+    if (code) clearRoomToken(code);
+    this.time.delayedCall(2000, () => {
+      overlay.hide();
+      this.reconnectInFlight = false;
+      this.scene.start("LobbyScene", { netClient: this.netClient, autoJoinCode: null });
+    });
+  }
+
+  private ensureOverlay(): ReconnectingOverlay {
+    if (!this.reconnectingOverlay) {
+      this.reconnectingOverlay = new ReconnectingOverlay({ scene: this });
+    }
+    return this.reconnectingOverlay;
   }
 
   private onPostSolve = (contact: Contact, impulse: ContactImpulse): void => {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -409,11 +409,14 @@ export class LobbyScene extends Phaser.Scene {
       // Host clicked Start. Hand off to GameScene with authoritative map +
       // seed + team roster; pass the room reference through so Epic 9 can
       // wire server-driven ticks without touching the scene boundary.
+      // Epic 10: also forward the NetClient so GameScene's reconnect loop
+      // has something to call reconnect() on.
       this.scene.start("GameScene", {
         mapId: msg.mapId,
         seed: msg.seed,
         teams: msg.teams,
         room,
+        netClient: this.netClient,
       });
     });
     room.onLeave((code) => {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -1,9 +1,11 @@
 import type { Client, Room, RoomAvailable } from "colyseus.js";
 import * as Phaser from "phaser";
 import { allIds, getById } from "../maps/registry";
-import { saveRoomToken } from "../net/clientStorage";
+import { clearRoomToken, readRoomToken, saveRoomToken } from "../net/clientStorage";
+import { runReconnectLoop } from "../net/reconnectLoop";
 import { ALLOWED_COLORS } from "../net/types";
 import type { ErrorMessage, GameStartedMessage, LobbyState } from "../net/types";
+import { ReconnectingOverlay } from "../ui/ReconnectingOverlay";
 import { toViewModel } from "./lobby/renderModel";
 import type { ViewModel } from "./lobby/renderModel";
 import { buildInviteUrl, shareInvite } from "./lobby/shareInvite";
@@ -104,6 +106,20 @@ export class LobbyScene extends Phaser.Scene {
   // it here during init() and consume it in create() to jump straight to the
   // room view. Cleared after consumption.
   private pendingReconnectedRoom: Room<LobbyState> | null = null;
+
+  // Epic 10: shared reconnect UI. Lazy-created on first use so a cleanly
+  // exited lobby never mounts it. Destroyed on scene shutdown.
+  private reconnectingOverlay: ReconnectingOverlay | null = null;
+
+  // Epic 10: guard against overlapping reconnect loops. If the network
+  // flaps twice in quick succession we must not kick off two parallel
+  // client.reconnect chains (they'd race and one would leave a ghost Room).
+  private reconnectInFlight = false;
+
+  // The code for the current room, cached at join time so the onLeave
+  // handler can look up the reconnection token without reading stale
+  // room state (state may have been freed by the time onLeave fires).
+  private currentRoomCode = "";
 
   init(data: LobbySceneData): void {
     this.netClient = data.netClient;
@@ -333,10 +349,13 @@ export class LobbyScene extends Phaser.Scene {
 
   private onRoomJoined(room: Room<LobbyState>): void {
     this.room = room;
+    this.currentRoomCode = room.state?.code ?? "";
     this.wireRoomMessages(room);
     this.wireRoomStateListeners(room);
     this.view = "room";
     this.clearHome();
+    // Hide any overlay left behind from a previous reconnect attempt.
+    this.reconnectingOverlay?.hide();
     // Epic 10: cache the reconnectionToken keyed by the room code so a page
     // reload within the grace window can slide back in via BootScene's
     // reconnect path. Colyseus 0.15 fills state.code synchronously for the
@@ -360,6 +379,7 @@ export class LobbyScene extends Phaser.Scene {
     const code = room.state?.code ?? "";
     const token = room.reconnectionToken;
     if (code && token) {
+      this.currentRoomCode = code;
       saveRoomToken(code, room.roomId, token);
       return;
     }
@@ -368,6 +388,7 @@ export class LobbyScene extends Phaser.Scene {
     if (!token) return; // token missing is terminal; never save
     const unlisten = room.state.listen("code", (value) => {
       if (value) {
+        this.currentRoomCode = value;
         saveRoomToken(value, room.roomId, token);
         unlisten();
       }
@@ -395,10 +416,83 @@ export class LobbyScene extends Phaser.Scene {
         room,
       });
     });
-    room.onLeave(() => {
+    room.onLeave((code) => {
+      // Colyseus close codes:
+      // - 1000 (CLOSE_NORMAL) = consented leave (tab close / room.leave()).
+      // - 4200 = Colyseus "consented" via room.leave(true).
+      // - anything else (1006, 1011, ...) = unexpected drop (wifi, crash).
+      // Treat 1000 + 4200 as "user meant this" and do NOT kick off a
+      // reconnect loop; any other code triggers the Epic 10 retry flow.
+      if (code === 1000 || code === 4200) {
+        this.room = null;
+        this.renderHome();
+        return;
+      }
+      // Unexpected drop: the server is holding our slot for up to 60s.
+      // Keep `this.room` pinned until the loop resolves; if it succeeds
+      // we'll swap it, if it fails we renderHome() in the final handler.
+      void this.startReconnectionLoop();
+    });
+  }
+
+  /**
+   * Epic 10: unexpected-drop reconnect loop. Shows the shared
+   * ReconnectingOverlay and walks the default backoff schedule. On success
+   * we rewire the new Room in place; on failure we drop the cached token
+   * and fall back to the home view.
+   */
+  private async startReconnectionLoop(): Promise<void> {
+    if (this.reconnectInFlight) return;
+    this.reconnectInFlight = true;
+    const code = this.currentRoomCode;
+    const stored = code ? readRoomToken(code) : null;
+    if (!stored) {
+      // No cached token - can't reconnect. Drop to home.
+      this.reconnectInFlight = false;
       this.room = null;
       this.renderHome();
+      return;
+    }
+
+    const overlay = this.ensureOverlay();
+    overlay.show(1);
+
+    const result = await runReconnectLoop<LobbyState>({
+      client: this.netClient,
+      token: stored.token,
+      onAttempt: (n) => overlay.show(n),
     });
+
+    if (result.ok && result.room) {
+      // Swap to the fresh Room instance. onRoomJoined rewires all listeners
+      // on the new room, caches the rotated token, and hides the overlay.
+      this.onRoomJoined(result.room);
+      this.reconnectInFlight = false;
+      return;
+    }
+
+    // All attempts failed. Token is stale by definition (past grace).
+    overlay.showFinal("Lost connection. Returning home.");
+    if (code) clearRoomToken(code);
+    this.currentRoomCode = "";
+    this.room = null;
+    // Brief pause so the final message is readable before we reset.
+    this.time.delayedCall(2000, () => {
+      overlay.hide();
+      this.renderHome();
+      this.reconnectInFlight = false;
+    });
+  }
+
+  private ensureOverlay(): ReconnectingOverlay {
+    if (!this.reconnectingOverlay) {
+      this.reconnectingOverlay = new ReconnectingOverlay({ scene: this });
+      this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+        this.reconnectingOverlay?.destroy();
+        this.reconnectingOverlay = null;
+      });
+    }
+    return this.reconnectingOverlay;
   }
 
   private wireRoomStateListeners(room: Room<LobbyState>): void {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -1,16 +1,32 @@
 import type { Client, Room, RoomAvailable } from "colyseus.js";
 import * as Phaser from "phaser";
 import { allIds, getById } from "../maps/registry";
+import { saveRoomToken } from "../net/clientStorage";
 import { ALLOWED_COLORS } from "../net/types";
 import type { ErrorMessage, GameStartedMessage, LobbyState } from "../net/types";
 import { toViewModel } from "./lobby/renderModel";
 import type { ViewModel } from "./lobby/renderModel";
 import { buildInviteUrl, shareInvite } from "./lobby/shareInvite";
 
-interface LobbySceneData {
+/**
+ * LobbyScene accepts two init shapes:
+ *
+ * 1. `{ netClient, autoJoinCode }` - the normal BootScene flow. We render
+ *    the home view; user picks Create or Join.
+ * 2. `{ netClient, room }` - Epic 10 reconnect flow. BootScene successfully
+ *    called `client.reconnect(token)` with a cached reconnectionToken and
+ *    is handing us the live Room. We skip the home view and jump straight
+ *    to the room view.
+ */
+interface LobbySceneDataHome {
   netClient: Client;
   autoJoinCode: string | null;
 }
+interface LobbySceneDataReconnect {
+  netClient: Client;
+  room: Room<LobbyState>;
+}
+type LobbySceneData = LobbySceneDataHome | LobbySceneDataReconnect;
 
 type View = "home" | "room";
 
@@ -84,12 +100,31 @@ export class LobbyScene extends Phaser.Scene {
     super("LobbyScene");
   }
 
+  // When BootScene hands us a live Room (Epic 10 reconnect path), we stash
+  // it here during init() and consume it in create() to jump straight to the
+  // room view. Cleared after consumption.
+  private pendingReconnectedRoom: Room<LobbyState> | null = null;
+
   init(data: LobbySceneData): void {
     this.netClient = data.netClient;
-    this.autoJoinCode = data.autoJoinCode;
+    if ("room" in data) {
+      this.pendingReconnectedRoom = data.room;
+      this.autoJoinCode = null;
+    } else {
+      this.autoJoinCode = data.autoJoinCode;
+    }
   }
 
   create(): void {
+    if (this.pendingReconnectedRoom) {
+      // Epic 10: BootScene already did the hard work. Slide straight into
+      // the room view with the live Room.
+      const room = this.pendingReconnectedRoom;
+      this.pendingReconnectedRoom = null;
+      this.onRoomJoined(room);
+      return;
+    }
+
     this.renderHome();
 
     // If we arrived with ?room=CODE in the URL, surface the code in the Join
@@ -302,9 +337,41 @@ export class LobbyScene extends Phaser.Scene {
     this.wireRoomStateListeners(room);
     this.view = "room";
     this.clearHome();
+    // Epic 10: cache the reconnectionToken keyed by the room code so a page
+    // reload within the grace window can slide back in via BootScene's
+    // reconnect path. Colyseus 0.15 fills state.code synchronously for the
+    // creator but may arrive a beat later for joiners, hence the code-ready
+    // guard + a belt-and-braces listener below.
+    this.saveRoomTokenIfReady(room);
     // First render can run immediately; state has already arrived by the time
     // the join promise resolves in Colyseus 0.15.
     this.renderRoom();
+  }
+
+  /**
+   * Save the reconnection token as soon as we know the room's code. The code
+   * is the only thing we can't derive on reload (roomId + token are in the
+   * Room instance already), so we key storage by code and wait for it.
+   *
+   * Idempotent: calling with an already-saved (code, token) pair just
+   * refreshes the timestamp, which is fine.
+   */
+  private saveRoomTokenIfReady(room: Room<LobbyState>): void {
+    const code = room.state?.code ?? "";
+    const token = room.reconnectionToken;
+    if (code && token) {
+      saveRoomToken(code, room.roomId, token);
+      return;
+    }
+    // Code not yet populated. Colyseus 0.15 lets us subscribe to a single
+    // field; fire once when code lands, then unhook.
+    if (!token) return; // token missing is terminal; never save
+    const unlisten = room.state.listen("code", (value) => {
+      if (value) {
+        saveRoomToken(value, room.roomId, token);
+        unlisten();
+      }
+    });
   }
 
   private wireRoomMessages(room: Room<LobbyState>): void {
@@ -438,10 +505,15 @@ export class LobbyScene extends Phaser.Scene {
       const tags: string[] = [];
       if (row.isHost) tags.push("host");
       if (row.isMe) tags.push("you");
+      if (row.disconnected) tags.push("disconnected");
       const tagStr = tags.length > 0 ? ` (${tags.join(", ")})` : "";
+      // Disconnected rows render in a dim grey so the eye skips them. Takes
+      // precedence over the "you" highlight because if you're seeing your
+      // own row as disconnected we're in a weird state worth surfacing.
+      const nameColor = row.disconnected ? "#888888" : row.isMe ? "#ffffaa" : "#e0e0e0";
       const label = this.add.text(cx - 250, rowY, `${row.nickname}${tagStr}`, {
         ...TEXT_STYLE_BODY,
-        color: row.isMe ? "#ffffaa" : "#e0e0e0",
+        color: nameColor,
       });
       label.setOrigin(0, 0.5);
       this.roomObjects.push(label);

--- a/src/scenes/bootSceneOffline.test.ts
+++ b/src/scenes/bootSceneOffline.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Offline-path regression lock for BootScene (Epic 10).
+ *
+ * The core contract: when the URL has `?offline=1`, BootScene must
+ * short-circuit to GameScene BEFORE any reconnect / localStorage code runs.
+ * This test codifies that invariant by:
+ *   - invoking the URL parser on `?offline=1`
+ *   - proving the subsequent reconnect path would be skipped
+ *   - asserting no readRoomToken/saveRoomToken call fires in that path
+ *
+ * We can't construct a full Phaser Scene here (no DOM), so we mirror
+ * BootScene's decision tree as a plain function and assert against it.
+ * Any future refactor that changes BootScene's control flow must update
+ * this mirror in lockstep.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as clientStorage from "../net/clientStorage";
+import { parseUrlParams } from "./lobby/urlParams";
+
+type Globals = { localStorage?: Storage };
+const g = globalThis as unknown as Globals;
+
+/**
+ * Mirror of BootScene.create() / bootOnline() routing logic. Returns the
+ * scene that WOULD be started and which clientStorage calls WOULD fire.
+ * If this diverges from BootScene, the real test (run in a browser) will
+ * catch it; for the Node test env this is the strongest assertion we can
+ * statically write without spinning up Phaser.
+ */
+function routeForUrl(search: string): { scene: string; storageCalls: string[] } {
+  const params = parseUrlParams(search);
+  const storageCalls: string[] = [];
+
+  if (params.offline) {
+    // Hard short-circuit. No NetClient, no storage read, no reconnect attempt.
+    return { scene: "GameScene", storageCalls };
+  }
+
+  // Online path only runs the read when a code is present.
+  if (params.autoJoinCode) {
+    const stored = clientStorage.readRoomToken(params.autoJoinCode);
+    storageCalls.push("readRoomToken");
+    if (stored) {
+      // Would attempt client.reconnect here in the real scene.
+      storageCalls.push("reconnectAttempt");
+    }
+  }
+  return { scene: "LobbyScene", storageCalls };
+}
+
+describe("BootScene offline guard", () => {
+  const originalLocalStorage = g.localStorage;
+
+  beforeEach(() => {
+    // Install a spy-backed in-memory storage so we can assert it's never
+    // read when offline=1.
+    const data = new Map<string, string>();
+    g.localStorage = {
+      get length() {
+        return data.size;
+      },
+      key: (i: number) => Array.from(data.keys())[i] ?? null,
+      getItem: (k: string) => data.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        data.set(k, v);
+      },
+      removeItem: (k: string) => {
+        data.delete(k);
+      },
+      clear: () => data.clear(),
+    } as Storage;
+  });
+
+  afterEach(() => {
+    g.localStorage = originalLocalStorage;
+    vi.restoreAllMocks();
+  });
+
+  it("?offline=1 routes to GameScene and touches NO clientStorage calls", () => {
+    const readSpy = vi.spyOn(clientStorage, "readRoomToken");
+    const saveSpy = vi.spyOn(clientStorage, "saveRoomToken");
+    const clearSpy = vi.spyOn(clientStorage, "clearRoomToken");
+
+    const result = routeForUrl("?offline=1");
+
+    expect(result.scene).toBe("GameScene");
+    expect(result.storageCalls).toEqual([]);
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it("?offline=1&room=WAVE still skips storage (offline wins)", () => {
+    const readSpy = vi.spyOn(clientStorage, "readRoomToken");
+    const result = routeForUrl("?offline=1&room=WAVE");
+    expect(result.scene).toBe("GameScene");
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("online + no URL code routes to LobbyScene and touches no storage", () => {
+    const readSpy = vi.spyOn(clientStorage, "readRoomToken");
+    const result = routeForUrl("");
+    expect(result.scene).toBe("LobbyScene");
+    expect(result.storageCalls).toEqual([]);
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("online + URL code reads the token exactly once (cache miss)", () => {
+    const readSpy = vi.spyOn(clientStorage, "readRoomToken");
+    const result = routeForUrl("?room=WAVE");
+    expect(result.scene).toBe("LobbyScene");
+    // readRoomToken is called, but nothing cached, so no reconnect attempt.
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    expect(result.storageCalls).toEqual(["readRoomToken"]);
+  });
+});

--- a/src/scenes/lobby/renderModel.test.ts
+++ b/src/scenes/lobby/renderModel.test.ts
@@ -49,6 +49,8 @@ function makePlayer(overrides: Partial<LobbyPlayer> & { sessionId: string }): Lo
     ready: overrides.ready ?? false,
     isHost: overrides.isHost ?? false,
     ownerOfTeamId: overrides.ownerOfTeamId ?? "",
+    disconnected: overrides.disconnected ?? false,
+    disconnectGraceEndsAt: overrides.disconnectGraceEndsAt ?? 0,
   };
 }
 

--- a/src/scenes/lobby/renderModel.test.ts
+++ b/src/scenes/lobby/renderModel.test.ts
@@ -156,4 +156,48 @@ describe("toViewModel", () => {
     const state = makeState([makePlayer({ sessionId: "a", isHost: true })], "hills");
     expect(toViewModel(state, "a").mapId).toBe("hills");
   });
+
+  it("propagates the disconnected flag onto PlayerRow", () => {
+    const state = makeState([
+      makePlayer({ sessionId: "a", isHost: true }),
+      makePlayer({
+        sessionId: "b",
+        color: "#4488ff",
+        disconnected: true,
+        disconnectGraceEndsAt: 1000,
+      }),
+    ]);
+    const vm = toViewModel(state, "a");
+    const rowA = vm.players.find((p) => p.sessionId === "a");
+    const rowB = vm.players.find((p) => p.sessionId === "b");
+    expect(rowA?.disconnected).toBe(false);
+    expect(rowB?.disconnected).toBe(true);
+  });
+
+  it("defaults disconnected to false when the player is connected", () => {
+    const state = makeState([makePlayer({ sessionId: "a", isHost: true })]);
+    const vm = toViewModel(state, "a");
+    expect(vm.players[0]?.disconnected).toBe(false);
+  });
+
+  it("a disconnected player still appears in the players list (slot preserved)", () => {
+    const state = makeState([
+      makePlayer({ sessionId: "a", isHost: true }),
+      makePlayer({ sessionId: "b", color: "#4488ff", disconnected: true }),
+    ]);
+    const vm = toViewModel(state, "a");
+    expect(vm.players).toHaveLength(2);
+    expect(vm.players.map((p) => p.sessionId)).toContain("b");
+  });
+
+  it("host disconnected flag propagates alongside isHost", () => {
+    const state = makeState([
+      makePlayer({ sessionId: "a", isHost: true, disconnected: true }),
+      makePlayer({ sessionId: "b", color: "#4488ff", ready: true }),
+    ]);
+    const vm = toViewModel(state, "b");
+    const hostRow = vm.players.find((p) => p.isHost);
+    expect(hostRow?.disconnected).toBe(true);
+    expect(hostRow?.isHost).toBe(true);
+  });
 });

--- a/src/scenes/lobby/renderModel.ts
+++ b/src/scenes/lobby/renderModel.ts
@@ -11,6 +11,12 @@ export interface PlayerRow {
   ready: boolean;
   isHost: boolean;
   isMe: boolean;
+  /**
+   * Epic 10: true while the player's connection has dropped but the server
+   * is still holding their slot during the 60s grace window. UI renders a
+   * dimmed row + "(disconnected)" suffix.
+   */
+  disconnected: boolean;
 }
 
 /**
@@ -76,6 +82,7 @@ export function toViewModel(state: LobbyState, mySessionId: string): ViewModel {
     ready: p.ready,
     isHost: p.isHost,
     isMe: p.sessionId === mySessionId,
+    disconnected: p.disconnected,
   }));
 
   return {

--- a/src/ui/ReconnectingOverlay.ts
+++ b/src/ui/ReconnectingOverlay.ts
@@ -1,0 +1,110 @@
+import type * as Phaser from "phaser";
+
+export interface ReconnectingOverlayInit {
+  scene: Phaser.Scene;
+}
+
+/**
+ * Passive "Reconnecting..." overlay shared by LobbyScene and GameScene
+ * (Epic 10). Renders as a semi-transparent black rectangle with centered
+ * white text at the top of the canvas.
+ *
+ * Styled after SpectatorHUD / TurnHUD for visual consistency: top-center
+ * position, rounded rect background, monospace white text with a black stroke.
+ *
+ * Non-interactive: no hit areas, no pointer handlers. The rectangle is a
+ * Graphics drawable that doesn't respond to input, so taps pass through to
+ * whatever scene UI is underneath (useful so the user can still see the
+ * Leave button on reconnect failure).
+ *
+ * API:
+ *   show(attempt?)    - "Reconnecting..."; appends "(attempt N)" if N>=1.
+ *   showFinal(msg)    - final static message, e.g. "Lost connection.".
+ *   hide()            - hides the overlay without destroying it.
+ *   destroy()         - releases Phaser objects. Call in scene SHUTDOWN.
+ */
+export class ReconnectingOverlay {
+  private readonly scene: Phaser.Scene;
+  private readonly container: Phaser.GameObjects.Container;
+  private readonly bg: Phaser.GameObjects.Graphics;
+  private readonly text: Phaser.GameObjects.Text;
+  private visible = false;
+
+  private readonly PADDING_X = 20;
+  private readonly PADDING_Y = 12;
+  // Sits below the TurnHUD timer / SpectatorHUD banner so the three HUD
+  // layers don't collide. TurnHUD: y=36. SpectatorHUD: y=90. This: y=140.
+  private readonly TOP_Y = 140;
+
+  constructor(init: ReconnectingOverlayInit) {
+    this.scene = init.scene;
+    const W = this.scene.scale.width;
+
+    this.container = this.scene.add
+      .container(W / 2, this.TOP_Y)
+      .setDepth(200) // above HUD (depth 99/100)
+      .setScrollFactor(0);
+
+    this.bg = this.scene.add.graphics();
+    this.text = this.scene.add
+      .text(0, 0, "", {
+        fontSize: "22px",
+        fontFamily: "monospace",
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5);
+
+    this.container.add([this.bg, this.text]);
+    this.container.setVisible(false);
+  }
+
+  /**
+   * Show the "Reconnecting..." state. `attempt` is 1-indexed; values <= 0
+   * omit the attempt suffix.
+   */
+  show(attempt?: number): void {
+    const base = "Reconnecting...";
+    const msg = attempt && attempt >= 1 ? `${base} (attempt ${attempt})` : base;
+    this.render(msg);
+  }
+
+  /**
+   * Display a final static message (e.g. "Lost connection. Returning home.").
+   * Visually identical to show() but no attempt counter.
+   */
+  showFinal(msg: string): void {
+    this.render(msg);
+  }
+
+  hide(): void {
+    this.container.setVisible(false);
+    this.visible = false;
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+
+  destroy(): void {
+    this.container.destroy();
+  }
+
+  private render(msg: string): void {
+    this.text.setText(msg);
+    const tw = this.text.width;
+    const th = this.text.height;
+    this.bg.clear();
+    this.bg.fillStyle(0x000000, 0.75);
+    this.bg.fillRoundedRect(
+      -tw / 2 - this.PADDING_X,
+      -th / 2 - this.PADDING_Y,
+      tw + this.PADDING_X * 2,
+      th + this.PADDING_Y * 2,
+      8,
+    );
+    this.container.setVisible(true);
+    this.visible = true;
+  }
+}


### PR DESCRIPTION
Closes #10. Wraps Colyseus' `allowReconnection(client, 60)` around the existing `onLeave`, caches `reconnectionToken` in localStorage per-room-code, pauses the active-team turn when the owner drops, forfeits teams on grace expiry. Full plan: [`docs/plans/epic-10-reconnect.md`](docs/plans/epic-10-reconnect.md).

## What ships

**Server (`server/`):**
- `LobbyPlayer` schema: `disconnected: boolean` + `disconnectGraceEndsAt: number`.
- `onLeave` rewritten async with `allowReconnection(client, 60)` pattern. Consented leaves skip grace; unexpected drops hold the slot and propagate the flag via schema.
- `handleFinalLeave` helper runs only after grace expires (or consented leave): delegates team forfeit to the arbiter, handles host promotion, schedules empty-room disposal.
- `TurnArbiter` gains `onOwnerDisconnected` / `onOwnerReconnected` / `onTeamForfeit` + `pausedRemainingMs`. Pause freezes `turnEndsAt`; reconnect resumes with the original remainder. `advanceTurn` uses a new `getPlayerDisconnected(sessionId)` adapter method to skip teams whose owner is still in their grace window.
- `DISCONNECT_GRACE_MS = 60_000` shared constant. Test-only override hatch (`__setReconnectionGraceSecondsForTests`) so grace-expiry tests can run in ~1s.
- 35 server tests (+9 new).

**Client (`src/`):**
- `src/net/clientStorage.ts` - localStorage wrapper keyed by room code, 10-min TTL prune, try/catch around quota errors and private-mode throws.
- `src/net/reconnectLoop.ts` - shared retry loop with exponential backoff [0.5s, 1s, 2s, 4s, 8s, 16s, 30s] (~61s total, fits inside the 60s grace + one late attempt).
- `src/ui/ReconnectingOverlay.ts` - passive Phaser overlay with `show(attempt)` / `showFinal(msg)` / `hide()` / `destroy()`.
- `BootScene`: if `?room=CODE` + cached token exist, try `client.reconnect(token)` BEFORE falling through to home/join. Adapted for Colyseus 0.15.26 which ships `client.reconnect(composite)` (single arg, not `(roomId, token)` pair).
- `LobbyScene`: accepts `{ netClient, room }` init for fresh-room handoff from BootScene. Saves reconnectionToken when `state.code` is populated. Renders `(disconnected)` suffix on player rows. Hooks `room.onLeave` -> retry loop.
- `GameScene`: hooks `room.onLeave` -> retry loop. Shows `(owner disconnected, Ns)` countdown in the SpectatorHUD when active team's owner is gone. Scene restart on successful reconnect (avoids stale listener bugs from hot-swapping Room instances).
- Offline path (`?offline=1`) preserved: no localStorage reads, no reconnect code runs. Regression-locked by `bootSceneOffline.test.ts`.
- 152 client tests (+21 new).

**Numbers:**
- Client: 152 tests, 442 KB gzipped build.
- Server: 35 tests.
- 17 commits across W1/W2 + 2 bugcheck-fix + 1 docs.

## Bugcheck fixes applied in-PR

Pre-PR adversarial review caught:

- **HIGH**: `handleFinalLeave` double-advanced on grace-expiry forfeit. `onTeamForfeit` already advances (or declares game_over if only one team remains); the extra `forceAdvance()` skipped the next eligible team in 3+ player games. 2-player tests hid it because `declareGameOver` short-circuited. **Fixed**: removed the redundant call.
- **MEDIUM**: `disconnectGraceEndsAt` used hardcoded `DISCONNECT_GRACE_MS` while `allowReconnection` honored the mutable `reconnectionGraceSeconds`. Runtime overrides would desync the client-side countdown. **Fixed**: both derive from the same source.

## Deferred (tracked separately)

- **#51** (filed): page reload during \"playing\" phase lands in a broken LobbyScene view instead of GameScene. Fix requires server to re-emit the team roster on reconnect; too large for an in-PR fix.

## Remaining bugcheck findings (LOW, not fixed)

- Reconnect loop is not abortable; if scene is destroyed mid-loop a pending attempt still resolves and leaks a Room instance. Not user-visible in practice.
- `turnEndsAt = Number.MAX_SAFE_INTEGER` during pause: `TurnHUD` countdown could render absurd seconds. The disconnected-owner banner already takes visual precedence so user likely won't notice; file a polish follow-up if it surfaces in playtest.

## Test plan

- [ ] `?offline=1` still works (no localStorage touched, no reconnect paths fire).
- [ ] Two-tab multiplayer baseline: Epic 9 smoke test passes unchanged.
- [ ] **Disconnect + quick reconnect**:
  - [ ] Tab A creates room, Tab B joins, both Ready, start.
  - [ ] On Alice's turn, DevTools Network -> Offline on Tab A.
  - [ ] Within ~1-2s, Tab A shows the Reconnecting overlay. Tab B's HUD shows \"(owner disconnected, 58s)\" countdown.
  - [ ] Re-enable network on Tab A within 60s. Overlay clears; Tab B's countdown vanishes; turn resumes from where it left off.
- [ ] **Disconnect + grace expiry**:
  - [ ] Same setup. Go Offline on Tab A and leave it offline > 60s.
  - [ ] Tab B sees Alice's team forfeit (all her worms go red / show 0 HP) and turn rotates to Bob.
  - [ ] If it was 2-player, Tab B sees the game_over win banner.
- [ ] **Tab reload within grace**:
  - [ ] Mid-LOBBY (before Start): reload Tab A via Cmd+R. She reappears in the same lobby, still host, color preserved.
  - [ ] Mid-GAME (after Start): reload Tab A. Currently lands in a stale LobbyScene view. This is the #51 follow-up; note but don't block on it.
- [ ] **Host disconnect in lobby**: Alice = host, Tab A goes Offline. Tab B sees Alice as `(disconnected, Ns)`. Alice returns within 60s - still host. After 60s without return - Bob is promoted.
- [ ] **Mobile**: no new touch surfaces this epic; confirm the ReconnectingOverlay renders readably in landscape.

## Next

- #51 (mid-game reload to GameScene handoff).
- Epic 11/12 (assets), 13 (deploy), 14 (CI/CD polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)