### PR TITLE
fix(lobby): own ready state updates live on click

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -499,18 +499,13 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   private wireRoomStateListeners(room: Room<LobbyState>): void {
-    // Colyseus 0.15: attach listeners directly on state. Every mutation path
-    // (add/remove/change/scalar listen) triggers a full re-render.
-    //
-    // Debounced to once per animation frame. Without this, bursts of schema
-    // patches (join/ready/color change during connect) fire renderRoom many
-    // times within a single frame. Each render tears down + recreates the
-    // Ready button; each new button lands in Phaser's input `_pendingInsertion`
-    // queue. The queue only drains at frame tick - so the current Ready
-    // button is never hit-testable. Clicks silently miss.
-    //
-    // rAF coalescing lets Phaser's input plugin run between renders and
-    // promote each new button to the active hit-test list.
+    // Debounce rerenders to once per animation frame. Without this, bursts
+    // of schema patches fire renderRoom many times within a single frame.
+    // Each render tears down + recreates the Ready button; each new button
+    // lands in Phaser's input `_pendingInsertion` queue. The queue only
+    // drains at frame tick, so the current Ready button is never
+    // hit-testable. rAF coalescing lets Phaser's input plugin run between
+    // renders and promote each new button to the active hit-test list.
     let pending = false;
     const rerender = () => {
       if (pending || this.view !== "room") return;
@@ -520,12 +515,36 @@ export class LobbyScene extends Phaser.Scene {
         if (this.view === "room") this.renderRoom();
       });
     };
-    room.state.players.onAdd(rerender);
+
+    // Colyseus 0.15: MapSchema.onChange fires for add/remove/replace of
+    // ENTRIES (whole player objects), NOT for field mutations on existing
+    // players. To catch `ready` / `color` / `nickname` / `disconnected`
+    // flipping, we have to attach a per-player onChange listener on every
+    // join. Without this the clicker's own tab never re-renders when they
+    // toggle Ready - their local Schema state has the new value, but no
+    // listener fires so `renderRoom` isn't called.
+    //
+    // Other tabs happened to rerender on Carol joining (onAdd fires),
+    // which is why it LOOKED like the ready flip propagated to everyone
+    // else but not the sender.
+    const perPlayerListen = (player: unknown) => {
+      // biome-ignore lint/suspicious/noExplicitAny: colyseus.js 0.15 Schema#onChange isn't in our hand-written mirror types
+      (player as any).onChange?.(rerender);
+    };
+
+    room.state.players.onAdd((player, _key) => {
+      rerender();
+      perPlayerListen(player);
+    });
     room.state.players.onRemove(rerender);
     room.state.players.onChange(rerender);
     room.state.listen("selectedMapId", rerender);
     room.state.listen("hostSessionId", rerender);
     room.state.listen("phase", rerender);
+
+    // Players that joined before we attached the onAdd listener (ourselves,
+    // typically) won't fire onAdd retroactively, so hook them up now.
+    room.state.players.forEach((player) => perPlayerListen(player));
   }
 
   private renderRoom(): void {


### PR DESCRIPTION
## Summary

When the user clicked their own Ready button, other tabs saw them as READY but their OWN tab never flipped the label / \"not ready\" text to \"Unready\" / \"ready\". Host's Start button still enabled correctly (server saw the flip) and the match could start; purely a client-side visual-state bug for the sender.

## Root cause

Colyseus 0.15's \`MapSchema.onChange\` fires for entry-level operations (add/remove/replace of whole player objects) but NOT for per-field mutations on existing entries. Our \`wireRoomStateListeners\` only listened at the map level:

\`\`\`ts
room.state.players.onChange(rerender);  // only fires on REPLACE ops
\`\`\`

When Bob clicks Ready:
1. Server updates \`player.ready = true\`.
2. Schema patch propagates.
3. Bob's local \`state.players.get(Bob.sessionId).ready\` becomes true.
4. **No listener fires.** \`rerender\` is never called on Bob's tab.
5. Bob's UI stays at \"Ready\" (stale).

Alice/Carol saw the update because unrelated events (another player joining, their own later actions) triggered their rerenders, masking the bug during multi-tab testing. Bob's own tab had no such trigger.

## Fix

Attach \`player.onChange(rerender)\` on every \`onAdd\`, and retroactively to any players already in the MapSchema when listeners are installed (the clicker's own entry, typically).

\`\`\`ts
const perPlayerListen = (player) => player.onChange?.(rerender);
room.state.players.onAdd((player) => { rerender(); perPlayerListen(player); });
room.state.players.forEach(perPlayerListen);  // catch existing entries
\`\`\`

Keeps the prior rAF-debounce from #56.

## Test plan
- [ ] Client tests green.
- [ ] Server tests green.
- [ ] Lint green.
- [ ] Typecheck green.
- [ ] Manual: 2-tab - Bob clicks Ready, Bob's own button flips to \"Unready\" immediately; \"not ready\" text becomes \"READY\".
- [ ] Manual: 3-tab - Bob and Carol each click Ready on their own tabs, both see their own buttons flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)