### PR TITLE
fix(lobby): silence biome noForEach on LobbyPlayersMap iterator

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -544,6 +544,7 @@ export class LobbyScene extends Phaser.Scene {
 
     // Players that joined before we attached the onAdd listener (ourselves,
     // typically) won't fire onAdd retroactively, so hook them up now.
+    // biome-ignore lint/complexity/noForEach: LobbyPlayersMap mirrors the colyseus.js 0.15 surface which only exposes forEach
     room.state.players.forEach((player) => perPlayerListen(player));
   }
 


### PR DESCRIPTION
Follow-up lint fix. #57 merged but CI failed on the `forEach` call it added. LobbyPlayersMap only exposes forEach (mirror of colyseus.js 0.15 surface), so biome-ignore is the right call here; same pattern used in renderModel.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)