### PR TITLE
fix(net): client API URLs include /worms base path

### DIFF
--- a/src/net/client.ts
+++ b/src/net/client.ts
@@ -20,22 +20,37 @@ export type { RoomHandle } from "./wsClient";
 export { createRoom, joinRoom } from "./wsClient";
 
 /**
- * WebSocket base URL (`ws://` or `wss://`) derived from the page origin.
- * Respects the page protocol so secure origins keep TLS on the socket too.
+ * Vite's configured base path, with the trailing slash trimmed so it
+ * concatenates cleanly with /api paths. Prod deploys under
+ * `mccarrison.me/worms/` so BASE_URL = "/worms/"; the trimmed value is
+ * "/worms" and API calls go to "/worms/api/room". In dev this is still
+ * "/worms/" (see vite.config.ts base), and Vite's proxy rewrites it to
+ * the worker's unprefixed path on :8787.
+ */
+function basePath(): string {
+  const raw = import.meta.env.BASE_URL ?? "/";
+  return raw.replace(/\/$/, "");
+}
+
+/**
+ * WebSocket base URL (`ws://` or `wss://`) derived from the page origin
+ * plus Vite's configured base path. The Worker is mounted at
+ * `mccarrison.me/worms/*` so WebSocket upgrades must target
+ * `wss://mccarrison.me/worms/api/room/...` - not the bare origin.
  */
 export function wsBaseUrl(): string {
   const { protocol, host } = window.location;
   const wsProto = protocol === "https:" ? "wss" : "ws";
-  return `${wsProto}://${host}`;
+  return `${wsProto}://${host}${basePath()}`;
 }
 
 /**
- * HTTP(S) base URL derived from the page origin. Used for `POST /api/room`
- * matchmaking + any future REST-shaped endpoints.
+ * HTTP(S) base URL derived from the page origin + Vite base path. Used
+ * for `POST /api/room` matchmaking + any future REST-shaped endpoints.
  */
 export function httpBaseUrl(): string {
   const { protocol, host } = window.location;
-  return `${protocol}//${host}`;
+  return `${protocol}//${host}${basePath()}`;
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,18 @@ export default defineConfig({
   server: {
     port: 5173,
     open: false,
+    // Dev proxy: the client computes API paths relative to BASE_URL
+    // (so "POST /worms/api/room" in both dev and prod). The worker
+    // running under `wrangler dev --local` serves at :8787 without the
+    // /worms prefix, so rewrite the path before proxying. WebSocket
+    // upgrades are proxied identically with ws: true.
+    proxy: {
+      "/worms/api": {
+        target: "http://localhost:8787",
+        ws: true,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/worms/, ""),
+      },
+    },
   },
 });


### PR DESCRIPTION
Production client was POSTing to `https://mccarrison.me/api/room` (bare origin), which hit the dead apex (192.0.2.1) instead of the Worker mounted at `/worms/*`. Request hung, Create Room never completed.

Fix: `httpBaseUrl()` + `wsBaseUrl()` now include `import.meta.env.BASE_URL`, so they return `https://mccarrison.me/worms`. API calls land at `/worms/api/room` -> Worker.

Also adds a Vite dev proxy so `/worms/api/*` rewrites to `localhost:8787/api/*` (wrangler-dev), keeping the dev flow parallel to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)