### PR TITLE
fix: mobile playtest bugs (leave, pull-to-aim, reconnect speed)

### DIFF
--- a/src/net/reconnectLoop.ts
+++ b/src/net/reconnectLoop.ts
@@ -29,7 +29,11 @@ import type { RoomHandle } from "./wsClient";
  * fail we've exited the grace window anyway so the token is stale.
  */
 export const DEFAULT_BACKOFFS_MS: readonly number[] = [
-  500, 1000, 2000, 4000, 8000, 16000, 30000,
+  // First attempt fires immediately - a dropped WebSocket often recovers
+  // within a tick (wifi flicker, tab focus event) so there's no reason to
+  // wait half a second before probing. Subsequent attempts ramp up toward
+  // the 60s grace window.
+  0, 500, 1000, 2000, 4000, 8000, 15000, 30000,
 ] as const;
 
 export interface RunReconnectLoopParams {

--- a/src/net/wsClient.ts
+++ b/src/net/wsClient.ts
@@ -230,6 +230,21 @@ export async function joinRoom(
       // An error event typically precedes a close event; we let the close
       // handler finalize. Don't settleErr here because we'd double-settle.
     });
+
+    // Fail fast if the WebSocket stays stuck in CONNECTING / awaiting-welcome
+    // for too long. On flaky mobile networks a socket can hang indefinitely
+    // in CONNECTING without firing close/error, which would block the
+    // reconnect loop behind a dead attempt. 8s is generous relative to
+    // normal Cloudflare handshake latency (<1s).
+    setTimeout(() => {
+      if (settled) return;
+      try {
+        socket.close(4000, "welcome timeout");
+      } catch {
+        // already closing
+      }
+      settleErr(new Error("WebSocket welcome timeout"));
+    }, 8000);
   });
 
   await ready;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -487,17 +487,20 @@ export class GameScene extends Phaser.Scene {
       const worm = this.inputController.getActiveWorm();
       if (!worm || !this.turnManager.isInputAllowed()) return;
 
-      const dx = p.x - worm.xPx;
-      const dy = p.y - worm.yPx;
+      // Slingshot convention: the aim vector points FROM the pointer TO
+      // the worm, so dragging DOWN-LEFT of the worm aims UP-RIGHT. Matches
+      // Angry Birds / touch-first Worms clients. Negate both axes.
+      const dx = worm.xPx - p.x;
+      const dy = worm.yPx - p.y;
       const mag = Math.hypot(dx, dy);
       const cap = tuning.weapons.dragMaxLengthPx;
       const power = Math.min(1, mag / cap);
 
-      // Compute raw aim angle; flip facing if drag goes behind worm
+      // Flip facing if the pointer is on the opposite side of the worm
+      // from the current facing direction.
       const rawAngle = Math.atan2(dy, dx);
       const facingDot = Math.cos(rawAngle) * worm.facing;
       if (facingDot < 0) {
-        // Pointer is on the opposite side - flip facing
         worm.setFacing(-worm.facing as -1 | 1);
       }
       // Aim angle is relative to facing; atan2(dy, |dx|) gives correct up/down angle

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -777,14 +777,30 @@ export class LobbyScene extends Phaser.Scene {
 
   private async handleLeave(): Promise<void> {
     const room = this.room;
+    // Immediately flip back to home without waiting for the socket's close
+    // event. The close ack is async and on mobile/slow connections can take
+    // a perceptible beat, making the Leave button feel dead. Tear down
+    // listeners + render home synchronously, then fire-and-forget the close.
+    this.tearDownRoomListeners();
+    this.room = null;
+    this.currentRoomCode = "";
+    // Drop any cached reconnection token for this room - the user chose to
+    // leave, we don't want a page reload to silently rejoin.
+    try {
+      if (room) {
+        const code = room.code;
+        if (code) clearRoomToken(code);
+      }
+    } catch {
+      // Best-effort cleanup.
+    }
+    this.renderHome();
     if (!room) return;
     try {
       room.leave();
     } catch {
-      // onClose handler drops us back to home regardless.
+      // Already closed.
     }
-    // Provide a micro-delay so onClose (code 1000) fires on the same tick.
-    await Promise.resolve();
   }
 }
 


### PR DESCRIPTION
Three playtest bugs from mobile:

1. **Leave button** doesn't register / feels dead. `handleLeave` now flips to home view synchronously before the socket close ack. Clears the cached resume token so a reload doesn't silently rejoin the abandoned room.

2. **Pull-to-aim inverted**. Slingshot convention: dragging DOWN aims UP. Aim vector points FROM pointer TO worm rather than TO pointer. Matches Angry Birds / touch-first Worms clones.

3. **Reconnect slow / doesn't work**. First backoff is 0ms (was 500ms) so a transient drop recovers on the next tick. Added 8s welcome-timeout on `joinRoom` so a socket stuck in CONNECTING can't hang the retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)