### PR TITLE
fix(worker): toRenderState emits pixels, not meters

### DIFF
--- a/worker/src/entities/projectile.ts
+++ b/worker/src/entities/projectile.ts
@@ -15,7 +15,7 @@
 
 import { Circle } from "planck";
 import type { Body, World } from "planck";
-import { toMeters } from "../physics/scale.js";
+import { toMeters, toPixels } from "../physics/scale.js";
 import type { WeaponConfig } from "../weapons/types.js";
 
 export interface ProjectileInit {
@@ -105,10 +105,10 @@ export class Projectile {
       id: this.id,
       ownerId: this.ownerId,
       type: this.config.id,
-      x: pos.x,
-      y: pos.y,
-      vx: vel.x,
-      vy: vel.y,
+      x: toPixels(pos.x),
+      y: toPixels(pos.y),
+      vx: toPixels(vel.x),
+      vy: toPixels(vel.y),
       fuseRemainingMs: this.fuseRemainingMs,
     };
   }

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -17,7 +17,7 @@
 
 import { Box, Circle } from "planck";
 import type { Body, Fixture, World } from "planck";
-import { toMeters } from "../physics/scale.js";
+import { toMeters, toPixels } from "../physics/scale.js";
 
 export const DEFAULT_MAX_HP = 100;
 export const DEFAULT_WORM_RADIUS_PX = 12;
@@ -213,15 +213,19 @@ export class Worm {
   // ---- Serialisation ----
 
   toRenderState(): WormRenderState {
+    // Render state is in PIXELS. Client multiplies nothing; it renders
+    // directly. Keeping physics in meters inside the world + converting
+    // at the serialisation boundary is simpler than threading units
+    // through every call site on both sides of the wire.
     const pos = this.body.getPosition();
     const vel = this.body.getLinearVelocity();
     return {
       id: this.id,
       teamId: this.teamId,
-      x: pos.x,
-      y: pos.y,
-      vx: vel.x,
-      vy: vel.y,
+      x: toPixels(pos.x),
+      y: toPixels(pos.y),
+      vx: toPixels(vel.x),
+      vy: toPixels(vel.y),
       facing: this.facing,
       aimAngle: this.aimAngle,
       aimPower: this.aimPower,

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -373,24 +373,28 @@ export class Simulation {
   }
 
   serialize(): SerializedSim {
+    // Serialized positions/velocities are in METERS (physics-body native).
+    // Only the wire format (`toRenderState`) is in pixels; internal
+    // storage stays in meters so restore() can set body position directly.
     return {
       tick: this.tickCount,
       worms: Array.from(this.worms.values()).map((w) => {
-        const r = w.toRenderState();
+        const pos = w.body.getPosition();
+        const vel = w.body.getLinearVelocity();
         return {
-          id: r.id,
-          teamId: r.teamId,
-          x: r.x,
-          y: r.y,
-          vx: r.vx,
-          vy: r.vy,
-          facing: r.facing,
-          aimAngle: r.aimAngle,
-          aimPower: r.aimPower,
-          hp: r.hp,
-          alive: r.alive,
-          activeWeapon: r.activeWeapon,
-          ammoLeft: r.ammoLeft,
+          id: w.id,
+          teamId: w.teamId,
+          x: pos.x,
+          y: pos.y,
+          vx: vel.x,
+          vy: vel.y,
+          facing: w.facing,
+          aimAngle: w.aimAngle,
+          aimPower: w.aimPower,
+          hp: w.health,
+          alive: w.alive,
+          activeWeapon: w.activeWeapon,
+          ammoLeft: w.ammoLeft,
         };
       }),
       projectiles: this.projectiles.map((p) => ({

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -94,8 +94,9 @@ describe("Simulation - movement", () => {
     expect(red1?.teamId).toBe("red");
     expect(red1?.alive).toBe(true);
     expect(red1?.hp).toBe(100);
-    // Position in meters; spawn was 200px => ~6.66m
-    expect(red1?.x).toBeCloseTo(toMeters(200), 2);
+    // Render state is in pixels; spawn was 200px so x ≈ 200 (bodies
+    // drift a hair during world.step, tolerate ±5px).
+    expect(red1?.x).toBeCloseTo(200, 0);
   });
 
   it("walk input moves the worm horizontally", () => {


### PR DESCRIPTION
Playtest caught worms rendering at (0,0). Server emitted body positions in meters; client assigned to xPx without conversion. Spawn at (200,680)px became (6.66, 22.66)px after the meter round-trip.

Fix: server converts to pixels at the serialisation boundary. `serialize()` explicitly stays in meters for hibernation-restore compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)