### PR TITLE
fix(epic-45): server uses host-provided map geometry

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -235,7 +235,21 @@ export interface WormDiedEvent {
 export type ServerMsg =
   | { type: "welcome"; sessionId: string; resumeToken: string; state: LobbyState }
   | { type: "state"; state: LobbyState }
-  | { type: "game_started"; mapId: string; seed: number; teams: TeamInit[] }
+  | {
+      type: "game_started";
+      mapId: string;
+      seed: number;
+      teams: TeamInit[];
+      /** World dimensions (pixels). Clients create their visual terrain
+       *  canvas at this size. */
+      widthPx: number;
+      heightPx: number;
+      /** Authoritative map mask (base64 Uint8Array of solid/air bytes,
+       *  widthPx * heightPx bytes, row-major). Clients decode + render. */
+      mask: string;
+      /** Surface spawn points derived from the mask. */
+      spawnPoints: Array<{ xPx: number; yPx: number }>;
+    }
   | { type: "game_over"; winnerTeamId: string | null }
   | ({ type: "sim_state" } & SimState)
   | ({ type: "terrain_cut" } & TerrainCutEvent)
@@ -257,7 +271,17 @@ export type ClientMsg =
   | { type: "set_color"; color: string }
   | { type: "set_ready"; ready: boolean }
   | { type: "select_map"; mapId: string }
-  | { type: "start_game" }
+  | {
+      type: "start_game";
+      /** Host-generated map geometry (base64 Uint8Array of solid/air bytes,
+       *  WIDTH_PX * HEIGHT_PX bytes, row-major). Server uses this for
+       *  physics and forwards it via game_started so all clients render
+       *  pixel-identical terrain. Omitted for backcompat; server falls
+       *  back to its flat test map. */
+      mask?: string;
+      /** Host-generated surface spawn points derived from the mask. */
+      spawnPoints?: Array<{ xPx: number; yPx: number }>;
+    }
   // Input messages: server-authoritative. Post-Epic-45 these are NOT
   // relayed back to other clients; the server applies them to the
   // authoritative sim and everyone sees the result via sim_state.

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -81,6 +81,12 @@ export class GameScene extends Phaser.Scene {
   private isNetworked = false;
   private mySessionId = "";
   private myTeamId = "";
+  // Authoritative geometry from server's game_started. Networked mode uses
+  // these instead of calling loadMap() locally so server physics + client
+  // visuals align pixel-perfect.
+  private serverMask: string | null = null;
+  private serverWidthPx: number | null = null;
+  private serverHeightPx: number | null = null;
 
   // ---- Networked-mode: monotonic ids for server-spawned projectiles ----
 
@@ -112,6 +118,14 @@ export class GameScene extends Phaser.Scene {
     teams?: NetTeamInit[];
     room?: RoomHandle;
     netClient?: NetClient;
+    /** Base64 Uint8Array mask from the server's game_started. Networked
+     *  mode uses this as the source of truth for visual terrain; offline
+     *  falls back to loadMap(). */
+    mask?: string;
+    /** Authoritative spawn points from the server (paired with mask). */
+    spawnPoints?: Array<{ xPx: number; yPx: number }>;
+    widthPx?: number;
+    heightPx?: number;
   }): void {
     const candidate = data?.mapId ?? this.readMapQueryParam() ?? tuning.maps.defaultId ?? firstId();
     this.mapId = getById(candidate) ? candidate : firstId();
@@ -121,6 +135,11 @@ export class GameScene extends Phaser.Scene {
     this.netClient = data?.netClient;
     this.isNetworked = !!this.room;
     this.mySessionId = this.room?.sessionId ?? "";
+    this.serverMask = data?.mask ?? null;
+    this.serverWidthPx = data?.widthPx ?? null;
+    this.serverHeightPx = data?.heightPx ?? null;
+    // spawnPoints in game_started are for the server's physics only; the
+    // client doesn't need them since worm positions arrive via sim_state.
     registerMapCycleFn((id: string) => {
       this.scene.restart({ mapId: id });
     });
@@ -132,8 +151,6 @@ export class GameScene extends Phaser.Scene {
   }
 
   create(): void {
-    const loaded = loadMap(this.mapId, this.scale.width, this.scale.height, this.seedOverride);
-
     // Build the team roster once; both adapters use the same shape.
     const teamsForAdapter = this.buildAdapterTeams(this.teamsInit);
 
@@ -141,12 +158,20 @@ export class GameScene extends Phaser.Scene {
     // Pick the adapter. Everything sim-related flows through it.
     // ------------------------------------------------------------------
     if (this.isNetworked && this.room) {
-      // Networked path: server owns the sim. Scene owns the visual terrain.
+      // Networked path: the server is authoritative for geometry. Paint
+      // the received mask into a canvas for the visual terrain.
+      const maskCanvas = this.serverMask
+        ? decodeServerMaskToCanvas(
+            this.serverMask,
+            this.serverWidthPx ?? this.scale.width,
+            this.serverHeightPx ?? this.scale.height,
+          )
+        : loadMap(this.mapId, this.scale.width, this.scale.height, this.seedOverride).mask;
       this.terrainRenderer = new TerrainRenderer({
         scene: this,
-        widthPx: this.scale.width,
-        heightPx: this.scale.height,
-        sourceMask: loaded.mask,
+        widthPx: this.serverWidthPx ?? this.scale.width,
+        heightPx: this.serverHeightPx ?? this.scale.height,
+        sourceMask: maskCanvas,
       });
       this.networkedSim = new NetworkedSimAdapter({
         room: this.room,
@@ -155,6 +180,7 @@ export class GameScene extends Phaser.Scene {
       this.sim = this.networkedSim;
     } else {
       // Offline path: adapter owns everything physics-touching.
+      const loaded = loadMap(this.mapId, this.scale.width, this.scale.height, this.seedOverride);
       this.offlineSim = new OfflineSimAdapter({
         scene: this,
         loaded,
@@ -832,4 +858,41 @@ function adaptRenderableToWormFacade(view: RenderableWorm): Worm {
     },
   } as unknown as Worm;
   return facade;
+}
+
+/**
+ * Decode the server's base64 Uint8Array mask into an HTMLCanvasElement
+ * painted with the usual terrain color, ready for Terrain / TerrainRenderer
+ * to consume as its `sourceMask`. 1 byte per pixel: solid (1) or air (0).
+ */
+function decodeServerMaskToCanvas(
+  base64: string,
+  widthPx: number,
+  heightPx: number,
+): HTMLCanvasElement {
+  const raw = atob(base64);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = widthPx;
+  canvas.height = heightPx;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("decodeServerMaskToCanvas: no 2d context");
+
+  // Paint solid pixels using the default terrain green. Row-major byte
+  // layout matches the server's buildFlatMask / host's mask extraction.
+  const img = ctx.createImageData(widthPx, heightPx);
+  for (let i = 0; i < bytes.length; i++) {
+    const j = i * 4;
+    if (bytes[i]) {
+      img.data[j] = 0x5a;
+      img.data[j + 1] = 0x7a;
+      img.data[j + 2] = 0x3c;
+      img.data[j + 3] = 0xff;
+    }
+    // else: leave transparent (air).
+  }
+  ctx.putImageData(img, 0, 0);
+  return canvas;
 }

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -1,4 +1,5 @@
 import * as Phaser from "phaser";
+import { loadMap } from "../maps/loadMap";
 import { allIds, getById } from "../maps/registry";
 import type { NetClient } from "../net/client";
 import { clearRoomToken, readRoomToken, saveRoomToken } from "../net/clientStorage";
@@ -408,13 +409,17 @@ export class LobbyScene extends Phaser.Scene {
 
     this.roomUnsubs.push(
       room.onMessage("game_started", (msg: GameStartedMessage) => {
-        // Host clicked Start. Hand off to GameScene with authoritative map +
-        // seed + team roster; forward the RoomHandle + NetClient so Epic 9 +
-        // Epic 10 reconnect flows can drive from GameScene.
+        // Host clicked Start. Server includes the authoritative mask +
+        // spawn points so every client renders pixel-identical terrain
+        // (server's physics and client's visuals match).
         this.scene.start("GameScene", {
           mapId: msg.mapId,
           seed: msg.seed,
           teams: msg.teams,
+          mask: msg.mask,
+          spawnPoints: msg.spawnPoints,
+          widthPx: msg.widthPx,
+          heightPx: msg.heightPx,
           room,
           netClient: this.netClient,
         });
@@ -772,7 +777,30 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   private handleStart(): void {
-    this.room?.send({ type: "start_game" });
+    const room = this.room;
+    if (!room) return;
+    const mapId = room.state.selectedMapId || "flat";
+    // The map generators use Canvas2D which doesn't run on the Cloudflare
+    // Workers runtime. Host generates the mask + spawn points locally and
+    // ships them in start_game; server uses for physics + forwards them
+    // in game_started so every client renders pixel-identical terrain.
+    try {
+      const WORLD_W = 1280;
+      const WORLD_H = 720;
+      const loaded = loadMap(mapId, WORLD_W, WORLD_H);
+      const ctx = loaded.mask.getContext("2d");
+      if (!ctx) throw new Error("mask canvas has no 2d context");
+      const img = ctx.getImageData(0, 0, WORLD_W, WORLD_H);
+      const bytes = new Uint8Array(WORLD_W * WORLD_H);
+      // Alpha > 0 means solid terrain.
+      for (let i = 0; i < bytes.length; i++) bytes[i] = img.data[i * 4 + 3] > 0 ? 1 : 0;
+      const mask = bytesToBase64(bytes);
+      const spawnPoints = loaded.spawnPoints.map((s) => ({ xPx: s.xPx, yPx: s.yPx }));
+      room.send({ type: "start_game", mask, spawnPoints });
+    } catch (err) {
+      console.warn("[start_game] host could not generate mask, sending without:", err);
+      room.send({ type: "start_game" });
+    }
   }
 
   private async handleLeave(): Promise<void> {
@@ -802,6 +830,17 @@ export class LobbyScene extends Phaser.Scene {
       // Already closed.
     }
   }
+}
+
+/** Encode a Uint8Array as base64 for transport in a JSON message. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = "";
+  // Chunk to avoid blowing the arg stack on >1MB buffers.
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(s);
 }
 
 // Re-exported types used by other files importing this module.

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -400,7 +400,7 @@ export class Room implements DurableObject {
         this.onSelectMap(ws, player, msg);
         break;
       case "start_game":
-        await this.onStartGame(ws, player);
+        await this.onStartGame(ws, player, msg);
         break;
       case "input_walk":
       case "input_jump":
@@ -608,7 +608,7 @@ export class Room implements DurableObject {
     this.broadcastState();
   }
 
-  private async onStartGame(ws: WebSocket, player: LobbyPlayer): Promise<void> {
+  private async onStartGame(ws: WebSocket, player: LobbyPlayer, msg: unknown): Promise<void> {
     const lobby = this.ensureLobby();
     if (!player.isHost) {
       this.sendError(ws, "not_host", "Only the host may start the game.");
@@ -641,8 +641,6 @@ export class Room implements DurableObject {
     }
 
     const teamOrder = shuffle(teams.map((t) => t.id));
-    this.broadcast({ type: "game_started", mapId: lobby.selectedMapId, seed, teams });
-    lobby.phase = "playing";
 
     const rosters: TeamRoster[] = teams.map((t) => ({
       id: t.id,
@@ -652,19 +650,56 @@ export class Room implements DurableObject {
     this.rosters = rosters;
     await this.persistRosters();
 
-    // Instantiate the authoritative Simulation. The server builds a
-    // simple flat map mask (a thick floor strip) + fixed spawn points
-    // derived from team ordering. Clients build their own matching
-    // visual map from the broadcast seed + mapId; geometry consistency
-    // is W2/W3's integration problem.
-    const mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+    // Use the host-provided map mask + spawn points if they came with
+    // start_game. Host's client ran loadMap(selectedMapId, ...) which uses
+    // Canvas2D generators that don't run on the Workers runtime. The host
+    // ships the resulting mask and spawn points so all clients (including
+    // the server's physics sim) operate on pixel-identical geometry.
+    //
+    // Fallback to the flat test map is retained for backcompat / tests.
+    const startMsg = msg as {
+      mask?: string;
+      spawnPoints?: Array<{ xPx: number; yPx: number }>;
+    };
+    const hostMask = typeof startMsg.mask === "string" ? startMsg.mask : null;
+    const hostSpawns = Array.isArray(startMsg.spawnPoints) ? startMsg.spawnPoints : null;
+    let mask: Uint8Array;
+    let mapSpawns: Array<{ xPx: number; yPx: number }>;
+    if (hostMask && hostSpawns && hostSpawns.length > 0) {
+      try {
+        mask = base64ToBytes(hostMask);
+        if (mask.length !== WORLD_WIDTH_PX * WORLD_HEIGHT_PX) {
+          throw new Error(`mask length ${mask.length} != ${WORLD_WIDTH_PX * WORLD_HEIGHT_PX}`);
+        }
+        mapSpawns = hostSpawns;
+      } catch (err) {
+        console.warn("[start_game] bad mask from host, using flat fallback:", err);
+        mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+        mapSpawns = [];
+      }
+    } else {
+      mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+      mapSpawns = [];
+    }
+
+    // Distribute map spawn points round-robin across teams + worms. If we
+    // have fewer spawns than worms, wrap around - worms that share a slot
+    // will pile up then settle.
     const simTeams = rosters.map((r, teamIdx) => {
-      const spawns = r.wormIds.map((_, wormIdx) => ({
-        xPx: 120 + teamIdx * 260 + wormIdx * 80,
-        yPx: WORLD_HEIGHT_PX - 120,
-      }));
+      const spawns = r.wormIds.map((_, wormIdx) => {
+        if (mapSpawns.length > 0) {
+          const slot = mapSpawns[(teamIdx + wormIdx * rosters.length) % mapSpawns.length];
+          if (slot) return { xPx: slot.xPx, yPx: slot.yPx };
+        }
+        // Fallback fixed grid (matches the previous flat-map behavior).
+        return {
+          xPx: 120 + teamIdx * 260 + wormIdx * 80,
+          yPx: WORLD_HEIGHT_PX - 120,
+        };
+      });
       return { id: r.id, wormIds: r.wormIds.slice(), spawns };
     });
+
     this.simBootstrap = {
       widthPx: WORLD_WIDTH_PX,
       heightPx: WORLD_HEIGHT_PX,
@@ -682,6 +717,20 @@ export class Room implements DurableObject {
       seed,
     });
     await this.persistSim();
+
+    // Broadcast the authoritative geometry back to all clients so
+    // non-host tabs render the same terrain the server is simulating.
+    this.broadcast({
+      type: "game_started",
+      mapId: lobby.selectedMapId,
+      seed,
+      teams,
+      widthPx: WORLD_WIDTH_PX,
+      heightPx: WORLD_HEIGHT_PX,
+      mask: bytesToBase64(mask),
+      spawnPoints: mapSpawns,
+    });
+    lobby.phase = "playing";
 
     this.arbiter = new TurnArbiter(this.makeArbiterAdapter());
     this.arbiter.start(teamOrder, rosters, TURN_DURATION_MS);

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -8,7 +8,6 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { toMeters } from "../src/physics/scale.js";
 import { type SimEvent, type SimTeamInit, Simulation } from "../src/sim/simulation.js";
 
 const WIDTH = 1280;


### PR DESCRIPTION
Playtest showed worms spawning inside visual terrain. Server used a hardcoded flat mask for physics while clients rendered whatever map was picked (hills/island/cave). Collision ≠ visual.

Workers runtime has no Canvas2D. Fix: host's client generates the mask via loadMap, ships base64+spawns to server in start_game. Server uses for physics; forwards in game_started so all clients render identical geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)