### PR TITLE
fix(worker): end-turn button advances the turn

### DIFF
--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -790,7 +790,11 @@ export class Room implements DurableObject {
         this.pendingInputs.push({ kind: "fire", sessionId: senderSessionId });
         return;
       case "input_end_turn":
-        // No sim effect; the arbiter's settle-grace timeout handles it.
+        // Explicit end-turn press from the active player. Force-advance
+        // via the arbiter (validates ownership + pause state). Without
+        // this the End button was a no-op; server waited for the 45s
+        // turn timeout.
+        this.arbiter?.endTurnByPlayer(senderSessionId);
         return;
       default:
         return;

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -178,6 +178,20 @@ export class TurnArbiter {
     }
   }
 
+  /**
+   * Explicit "end turn" pressed by the active player. Advances immediately
+   * without waiting for the settle-grace timeout. Validated caller must
+   * own the currently-active team; other players are ignored.
+   */
+  endTurnByPlayer(sessionId: string): void {
+    if (this.gameOver) return;
+    if (this.pausedRemainingMs !== null) return;
+    const activeTeamId = this.room.state.currentTeamId;
+    const activeTeam = this.teamRosters.get(activeTeamId);
+    if (!activeTeam || activeTeam.ownerSessionId !== sessionId) return;
+    this.advanceTurn();
+  }
+
   onOwnerDisconnected(sessionId: string): void {
     if (this.gameOver) return;
     const activeTeamId = this.room.state.currentTeamId;


### PR DESCRIPTION
End Turn no-op fix - server now force-advances via arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)