### PR TITLE
fix: remove touch long-press backflip + kill worms off any map edge

### DIFF
--- a/src/input/touchGestures.test.ts
+++ b/src/input/touchGestures.test.ts
@@ -88,13 +88,13 @@ describe("touchGestures state machine", () => {
     expect(up2).toEqual([{ kind: "walk_release" }]);
   });
 
-  it("long-press emits backflip on release", () => {
+  it("long hold releases as plain walk (no backflip gesture on touch)", () => {
     const t = createGestureTracker();
     const down = t.processDown(mkInput({ downXPx: 200, nowMs: 1000 }));
     expect(down).toEqual([{ kind: "walk", dir: -1 }]);
-    // Hold past longPressMs (400) -> release at 1500
+    // Hold past longPressMs (400) -> just release, no backflip.
     const up = t.processUp(1500);
-    expect(up).toEqual([{ kind: "walk_release" }, { kind: "backflip" }]);
+    expect(up).toEqual([{ kind: "walk_release" }]);
   });
 
   it("spectator (not my turn) returns ignored on down", () => {
@@ -131,14 +131,14 @@ describe("touchGestures state machine", () => {
     expect(t.processUp(1700)).toEqual([{ kind: "walk_release" }]);
   });
 
-  it("long-press on double-tap window prioritizes backflip over jump", () => {
+  it("held double-tap still emits jump (no backflip path on touch)", () => {
     const t = createGestureTracker();
-    // Seed a recent release so a double-tap would otherwise trigger.
+    // Seed a recent release so a double-tap triggers.
     t.processDown(mkInput({ downXPx: 200, nowMs: 1000 }));
     t.processUp(1100);
-    // Hold the second tap past longPressMs.
+    // Hold the second tap; previously this emitted backflip, now it jumps.
     t.processDown(mkInput({ downXPx: 200, nowMs: 1200 }));
     const up = t.processUp(1700);
-    expect(up).toEqual([{ kind: "walk_release" }, { kind: "backflip" }]);
+    expect(up).toEqual([{ kind: "walk_release" }, { kind: "jump" }]);
   });
 });

--- a/src/input/touchGestures.ts
+++ b/src/input/touchGestures.ts
@@ -65,8 +65,6 @@ export function createGestureTracker(): {
 } {
   let mode: Mode = "idle";
   let walkSide: -1 | 1 | 0 = 0;
-  let downTimeMs = 0;
-  let longPressMs = 0;
   // Tracked across gestures for double-tap detection.
   let lastWalkReleaseAtMs = Number.NEGATIVE_INFINITY;
   let lastWalkReleaseSide: -1 | 1 | 0 = 0;
@@ -86,9 +84,6 @@ export function createGestureTracker(): {
       if (!input.myTurn || input.wormXPx === null || input.wormYPx === null) {
         return [{ kind: "ignored" }];
       }
-
-      downTimeMs = input.nowMs;
-      longPressMs = input.longPressMs;
 
       // Worm hit test: on-worm touch enters AIM mode even if a utility is
       // active (so the user can re-aim while roped, matching keyboard).
@@ -130,7 +125,6 @@ export function createGestureTracker(): {
 
     processUp(nowMs: number): GestureOutcome[] {
       const currentMode = mode;
-      const heldMs = nowMs - downTimeMs;
       const side = walkSide;
       const wasDoubleTap = pendingDoubleTap;
 
@@ -144,13 +138,6 @@ export function createGestureTracker(): {
       }
 
       if (currentMode === "walk" && (side === -1 || side === 1)) {
-        // Long-press wins over double-tap (user held the finger down for
-        // 400ms+, they didn't mean "jump quickly").
-        if (heldMs >= longPressMs) {
-          lastWalkReleaseAtMs = Number.NEGATIVE_INFINITY;
-          lastWalkReleaseSide = 0;
-          return [{ kind: "walk_release" }, { kind: "backflip" }];
-        }
         if (wasDoubleTap) {
           // Consume the double-tap: reset timestamps so a triple-tap
           // doesn't also fire.
@@ -159,7 +146,8 @@ export function createGestureTracker(): {
           return [{ kind: "walk_release" }, { kind: "jump" }];
         }
         // Plain walk release. Record timestamp + side so the NEXT gesture
-        // can detect a double-tap.
+        // can detect a double-tap. Backflip intentionally has no touch
+        // gesture (tracked in #75); keyboard Backspace still works.
         lastWalkReleaseAtMs = nowMs;
         lastWalkReleaseSide = side;
         return [{ kind: "walk_release" }];

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -327,13 +327,15 @@ export class Simulation {
       this.projectiles.splice(i, 1);
     }
 
-    // 5. Off-map kill floor: any worm pushed below heightPx + margin
-    //    is marked dead. Absorbs issue #53.
-    const killY = (this.heightPx + OFF_MAP_MARGIN_PX) / 30; // meters
+    // 5. Off-map kill: any worm pushed outside the map (in any direction,
+    //    plus a margin) is marked dead. Absorbs issue #53.
+    const killMin = -OFF_MAP_MARGIN_PX / 30; // meters
+    const killMaxX = (this.widthPx + OFF_MAP_MARGIN_PX) / 30;
+    const killMaxY = (this.heightPx + OFF_MAP_MARGIN_PX) / 30;
     for (const worm of this.worms.values()) {
       if (!worm.alive) continue;
       const pos = worm.body.getPosition();
-      if (pos.y > killY) {
+      if (pos.x < killMin || pos.x > killMaxX || pos.y < killMin || pos.y > killMaxY) {
         worm.kill();
         if (!this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);


### PR DESCRIPTION
## Summary

Two playtest bugs from PR #74's mobile session.

**Bug 1 — "constantly jumping" on mobile.** `touchGestures.ts` emitted `backflip` on any walk-release held >400ms. Every normal walk-hold-and-release was producing a backflip, which visually reads as a jump. Removed the long-press branch entirely; double-tap same side still triggers jump and the server's `canJump()` already rejects airborne attempts. Backflip stays keyboard-only (`Backspace`); tracked in #75 for a re-added touch gesture.

**Bug 2 — worms blown off-screen didn't die.** `simulation.ts` only killed worms that crossed the bottom edge (`pos.y > killY`). Sideways ejections floated alive until gravity eventually pulled them below. Expanded the off-map check to all four sides + margin.

## Test plan

- [ ] Mobile: walk-hold-release for 500ms+, worm just stops walking (no backflip)
- [ ] Mobile: double-tap same side while grounded, worm jumps once
- [ ] Mobile: double-tap in mid-air, nothing happens (server rejects via canJump)
- [ ] Blow a worm sideways off the map, dies immediately, turn advances to next team
- [ ] Desktop: Backspace still triggers backflip

Closes #53 (expanded kill coverage)
Refs #75 (backflip-on-mobile tracking)