### PR TITLE
fix: sustain active worm walking across sim ticks

### DIFF
--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -83,6 +83,7 @@ export class Worm {
   private footContactCount = 0;
   private readonly footSensor: Fixture;
   private readonly walkSpeedMps: number;
+  private walkingDir: -1 | 0 | 1 = 0;
 
   constructor(init: WormInit) {
     this.id = init.id;
@@ -132,9 +133,23 @@ export class Worm {
 
   walk(direction: -1 | 0 | 1): void {
     if (!this.alive) return;
+    this.walkingDir = direction;
     const vel = this.body.getLinearVelocity();
     this.body.setLinearVelocity({ x: direction * this.walkSpeedMps, y: vel.y });
     if (direction !== 0) this.facing = direction;
+  }
+
+  /**
+   * Sustain the current walk for one sim tick. Called from Simulation.tick
+   * on the active worm only; clients send input_walk edge-triggered (one
+   * message on press, one on release), and without this re-applying the
+   * velocity every tick, ground friction damps the worm to a halt in a
+   * few frames.
+   */
+  applyWalking(): void {
+    if (!this.alive || this.walkingDir === 0) return;
+    const vel = this.body.getLinearVelocity();
+    this.body.setLinearVelocity({ x: this.walkingDir * this.walkSpeedMps, y: vel.y });
   }
 
   jump(): void {
@@ -189,6 +204,7 @@ export class Worm {
   kill(): void {
     this.health = 0;
     this.alive = false;
+    this.walkingDir = 0;
   }
 
   // ---- Foot contact ----

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -514,7 +514,7 @@ export class Room implements DurableObject {
       let simTickState: Pick<SimState, "tick" | "worms" | "projectiles"> | null = null;
       if (lobby.phase === "playing" && this.sim) {
         this.drainInputs();
-        const result = this.sim.tick(SIM_TICK_MS);
+        const result = this.sim.tick(SIM_TICK_MS, lobby.currentWormId || null);
         simTickEvents = result.events;
         simTickState = this.sim.toSimState();
 

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -289,12 +289,21 @@ export class Simulation {
 
   // ---- Main tick ----
 
-  tick(dtMs: number): SimTickResult {
+  tick(dtMs: number, activeWormId: string | null = null): SimTickResult {
     // Keep any events that applyFire / other pre-tick inputs pushed;
     // they are logically part of this tick. Reset diedThisTick so
     // the dedup guard only spans the current tick.
     this.diedThisTick.clear();
     const beforeWormPositions = this.snapshotWormPositions();
+
+    // 0. Sustain the active worm's walking velocity. Clients send
+    //    input_walk edge-triggered, so without this step ground friction
+    //    would damp the worm to a halt between inputs. Non-active worms
+    //    with stale walkingDir are skipped, which also means turn
+    //    advance implicitly stops the previous walker.
+    if (activeWormId) {
+      this.worms.get(activeWormId)?.applyWalking();
+    }
 
     // 1. Step world. planck does fixed-step internally via the passed
     //    timestep; 50ms is a single step at 20Hz.

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -142,6 +142,40 @@ describe("Simulation - movement", () => {
     const after = requireWorm(sim, "Red-1").body.getLinearVelocity().y;
     expect(after).toBeLessThan(before);
   });
+
+  it("walk input sustains motion across ticks when only sent once (edge-triggered safe)", () => {
+    // Settle.
+    for (let i = 0; i < 20; i++) sim.tick(50);
+    const before = requireWorm(sim, "Red-1").body.getPosition().x;
+
+    // Simulate the real client behaviour: ONE input_walk (on press), then
+    // many ticks with no further input until release. The sim must keep
+    // re-applying walk velocity each tick on the active worm.
+    sim.applyWalkInput("Red-1", 1);
+    for (let i = 0; i < 20; i++) sim.tick(50, "Red-1");
+
+    const after = requireWorm(sim, "Red-1").body.getPosition().x;
+    // Positions are in meters. walkSpeedMps = 2.5, 20 ticks at 50ms = 1s.
+    // Sustained walking yields ~1.5-2m of travel after friction. Without
+    // sustained walk, friction damps the initial velocity in 2-3 ticks and
+    // the worm moves less than 0.2m.
+    expect(after - before).toBeGreaterThan(1);
+  });
+
+  it("non-active worms do not sustain walking (stale walkingDir is ignored)", () => {
+    for (let i = 0; i < 20; i++) sim.tick(50);
+    sim.applyWalkInput("Red-1", 1);
+    // Red-1 is active: walks.
+    for (let i = 0; i < 10; i++) sim.tick(50, "Red-1");
+    const afterActive = requireWorm(sim, "Red-1").body.getPosition().x;
+    // Turn advances; Blue-1 is now active. Red-1's walkingDir is still 1
+    // but applyWalking only runs for the active worm, so Red-1 stops.
+    for (let i = 0; i < 20; i++) sim.tick(50, "Blue-1");
+    const afterInactive = requireWorm(sim, "Red-1").body.getPosition().x;
+    // Residual velocity from the handoff tick plus friction glide should be
+    // well under half a meter (compare to >1m sustained travel above).
+    expect(afterInactive - afterActive).toBeLessThan(0.5);
+  });
 });
 
 describe("Simulation - fire / cut / damage", () => {


### PR DESCRIPTION
## Summary

Server bug: `worm.walk(dir)` applied velocity once per input, then ground friction damped it to zero within a few ticks. Clients send `input_walk` edge-triggered (one press, one release) per standard netcode, so holding walk produced a tiny step and stop.

Affected both keyboard and touch, but was most obvious on mobile because the "hold the button and it should keep going" intuition is stronger there.

## Fix

- New `walkingDir` state on the server `Worm`; `walk()` updates state + immediate velocity as before.
- New `Worm.applyWalking()` re-asserts the velocity each tick.
- `Simulation.tick(dtMs, activeWormId)` calls it on the active worm only. Non-active worms with stale `walkingDir` are skipped, which means turn advance implicitly stops the previous walker (no explicit cleanup path needed).
- `Room.alarm` passes `lobby.currentWormId` into `sim.tick`.
- `Worm.kill()` also clears `walkingDir` for completeness.

## Tests

Two new regression tests in `worker/test/sim.test.ts`:
- `walk input sustains motion across ticks when only sent once (edge-triggered safe)` — one `applyWalkInput` + 20 ticks should travel >1m.
- `non-active worms do not sustain walking (stale walkingDir is ignored)` — stale flag on a non-active worm does not move them.

All 52 worker tests + 183 client tests pass.

## Test plan

- [ ] Mobile: tap-and-hold walk side, worm walks continuously while held, stops on release
- [ ] Mobile: double-tap same side, jump fires in the walk direction (not opposite)
- [ ] Desktop: hold arrow/A/D, worm walks continuously
- [ ] Turn advance mid-walk: previously-active worm stops on the next tick