### PR TITLE
chore: one-step deploy that rebuilds client before wrangler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ Framework pivot happened 2026-04-20; see [ADR-001](docs/decisions/001-framework-
 
 **Deploy** (future): client to Cloudflare Pages (static CDN). Server (Colyseus) to Fly.io or co-located on brain's EC2 with nginx proxying `/worms/ws`. See Epic 13.
 
+**Deploy command (current, post-Epic 13)**: run `npm run deploy` from the repo root. This runs `npm run build` (Vite) FIRST, then `wrangler deploy` from `worker/`. Never run `cd worker && wrangler deploy` directly — wrangler uploads `../dist` as static assets without rebuilding, which can leave the client bundle stale while the DO/worker code is fresh. Symptom: server-side fixes work, client-side fixes silently don't ship.
+
 ## Drop-in philosophy
 
 Adding content should be a data file + sprite, not custom code. The stack is chosen so:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "deploy": "npm run build && cd worker && wrangler deploy"
   },
   "dependencies": {
     "phaser": "3.90.0",


### PR DESCRIPTION
## Why

\`cd worker && wrangler deploy\` uploads \`../dist\` as-is. If the client source changes but dist is not rebuilt, server code ships fresh while the client bundle stays stale. That's why PR #76 (touch backflip removal) did not reach production even though it merged to master - three deploys later, users were still seeing the old gesture tracker fire backflip on long-press.

## Fix

- Add \`"deploy": "npm run build && cd worker && wrangler deploy"\` to the root \`package.json\`.
- Document in \`CLAUDE.md\`. Never invoke wrangler directly.