### PR TITLE
Nickname persistence + jetpack netcode (phase 1 of #65)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -152,6 +152,8 @@ export interface WormRenderState {
   alive: boolean;
   activeWeapon: string;
   ammoLeft: number;
+  jetPackActive: boolean;
+  jetPackFuel: number; // 0-100
 }
 
 /**
@@ -293,4 +295,7 @@ export type ClientMsg =
   | { type: "input_select_weapon"; weaponId: string; seq: number }
   | { type: "input_fire"; seq: number }
   | { type: "input_end_turn"; seq: number }
+  | { type: "input_jetpack_toggle"; seq: number }
+  | { type: "input_jetpack_thrust"; active: boolean; seq: number }
+  | { type: "input_jetpack_horizontal"; dir: -1 | 0 | 1; seq: number }
   | { type: "leave" };

--- a/src/net/clientStorage.ts
+++ b/src/net/clientStorage.ts
@@ -122,3 +122,45 @@ export function clearRoomToken(code: string): void {
   delete all[key];
   writeAll(all);
 }
+
+// ---------------------------------------------------------------------------
+// Nickname persistence
+// ---------------------------------------------------------------------------
+
+const NICKNAME_KEY = "worms.nickname.v1";
+
+/**
+ * Persist a validated nickname. Silently no-ops if the value is empty,
+ * exceeds 16 characters, or localStorage is unavailable (private browsing,
+ * quota exceeded, sandboxed iframe).
+ */
+export function saveNickname(nickname: string): void {
+  try {
+    const trimmed = nickname.trim();
+    if (trimmed.length === 0 || trimmed.length > 16) return;
+    const storage = getStorage();
+    if (!storage) return;
+    storage.setItem(NICKNAME_KEY, trimmed);
+  } catch {
+    // private-browsing / quota: swallow
+  }
+}
+
+/**
+ * Read the previously saved nickname.
+ * Returns "" when localStorage is unavailable, no value is stored,
+ * or the stored value fails validation.
+ */
+export function readNickname(): string {
+  try {
+    const storage = getStorage();
+    if (!storage) return "";
+    const raw = storage.getItem(NICKNAME_KEY);
+    if (typeof raw !== "string") return "";
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > 16) return "";
+    return trimmed;
+  } catch {
+    return "";
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -292,7 +292,8 @@ export class GameScene extends Phaser.Scene {
     this.touchControls = new TouchControls({
       scene: this,
       getActiveWorm: () => this.getActiveWormAdapter(),
-      networked: this.isNetworked,
+      ropeEnabled: !this.isNetworked,
+      jetPackEnabled: true,
     });
     this.weaponDrawer = new WeaponDrawer({
       scene: this,
@@ -312,16 +313,17 @@ export class GameScene extends Phaser.Scene {
       onEndTurnPressed: () => this.sim.endTurn(),
     });
 
-    // Utility d-pad is offline-only. In networked mode rope + jetpack are
-    // disabled per plan #65, so we never mount it.
-    if (this.offlineSim) {
-      this.utilityDPad = new UtilityDPad({
-        scene: this,
-        onLeft: (dir) => this.dispatchUtilityHorizontal(dir),
-        onUp: (active) => this.dispatchUtilityUp(active),
-        onDown: (active) => this.dispatchUtilityDown(active),
-      });
-    }
+    // Utility d-pad: always mounted in both modes. Networked mode routes
+    // through the sim adapter (sends to server); offline routes to the
+    // local worm directly. Down button stays offline-only (rope extend).
+    this.utilityDPad = new UtilityDPad({
+      scene: this,
+      onLeft: (dir) => this.sim.setJetPackHorizontal(dir),
+      onUp: (active) => this.sim.setJetPackThrust(active),
+      onDown: (_active) => {
+        if (this.offlineSim) this.dispatchUtilityDown(_active);
+      },
+    });
 
     // Replay the current turn so the HUD + input gates are correctly
     // primed. Offline mode's TurnManager.start() fires its onTurnStart
@@ -543,7 +545,9 @@ export class GameScene extends Phaser.Scene {
       // to read xPx / facing / aimAngle from. The facade's mutator methods
       // are no-ops because the on* callbacks drive the actual wire sends.
       const view = this.networkedSim.allWorms.find((w) => w.id === _wormId);
-      this.inputController?.setActiveWorm(view ? adaptRenderableToWormFacade(view) : null);
+      this.inputController?.setActiveWorm(
+        view ? adaptRenderableToWormFacade(view, () => this.sim.isJetPacking(), this.sim) : null,
+      );
     }
   }
 
@@ -586,55 +590,24 @@ export class GameScene extends Phaser.Scene {
       const id = this.networkedSim.getActiveWormId();
       const view = this.networkedSim.allWorms.find((w) => w.id === id);
       if (!view || !view.isAlive) return null;
-      return adaptRenderableToWormFacade(view);
+      return adaptRenderableToWormFacade(view, () => this.sim.isJetPacking(), this.sim);
     }
     return null;
   }
 
-  /** Offline-only: show the d-pad when the active worm has a utility engaged,
-   *  hide it when idle. Runs every frame from `update`; cheap because all work
-   *  is gated by the visibility flag. */
+  /** Show the d-pad when the active worm has a utility engaged, hide when idle.
+   *  Works in both offline and networked mode. Runs every frame from `update`. */
   private refreshUtilityDPad(): void {
-    if (!this.utilityDPad || !this.offlineSim) return;
-    const worm = this.offlineSim.turns.getActiveWorm();
-    const active = !!worm && (worm.isRoped() || worm.isJetPacking());
+    if (!this.utilityDPad) return;
+    const isJetPacking = this.sim.isJetPacking();
+    const isRoped = this.offlineSim ? !!this.offlineSim.turns.getActiveWorm()?.isRoped() : false;
+    const active = isJetPacking || isRoped;
     if (active && !this.utilityDPadVisible) {
       this.utilityDPad.show();
       this.utilityDPadVisible = true;
     } else if (!active && this.utilityDPadVisible) {
       this.utilityDPad.hide();
       this.utilityDPadVisible = false;
-    }
-  }
-
-  /** Route horizontal d-pad input to rope (no-op horizontal) or jetpack.
-   *  Rope doesn't use horizontal directly (swing drives it); we still call
-   *  worm.walk for completeness since the offline Worm.walk guards against
-   *  roped state internally. */
-  private dispatchUtilityHorizontal(dir: -1 | 0 | 1): void {
-    if (!this.offlineSim) return;
-    const worm = this.offlineSim.turns.getActiveWorm();
-    if (!worm) return;
-    if (worm.isJetPacking()) {
-      worm.jetPackUtility.setHorizontalInput(dir);
-    }
-    // Rope: horizontal inputs don't steer the rope swing; the player swings
-    // by timing the up/down length changes. Intentionally a no-op here.
-  }
-
-  /** Up-button: jetpack thrust, or rope retract. */
-  private dispatchUtilityUp(active: boolean): void {
-    if (!this.offlineSim) return;
-    const worm = this.offlineSim.turns.getActiveWorm();
-    if (!worm) return;
-    if (worm.isJetPacking()) {
-      worm.jetPackUtility.setVerticalInput(active);
-    } else if (worm.isRoped() && active) {
-      // One-shot retract tick per frame the button is held. Update loop
-      // would be more precise but rope.adjust is called every pointer tick
-      // from the keyboard path too, so we match that contract.
-      const rate = tuning.rope.adjustRateMps / 60; // approximate per-frame nudge
-      worm.ropeUtility.adjust(-rate);
     }
   }
 
@@ -940,7 +913,11 @@ function parseTeamColor(input: string | number): number {
  * + InputController signatures type their worm params as `Worm`. The
  * only fields they read are covered by this facade.
  */
-function adaptRenderableToWormFacade(view: RenderableWorm): Worm {
+function adaptRenderableToWormFacade(
+  view: RenderableWorm,
+  isJetPackingFn?: () => boolean,
+  simRef?: SimAdapter,
+): Worm {
   const stubUtility = {
     isActive: () => false,
     activate: () => {},
@@ -950,7 +927,15 @@ function adaptRenderableToWormFacade(view: RenderableWorm): Worm {
     adjust: () => {},
     setHorizontalInput: () => {},
     setVerticalInput: () => {},
+    getFuel: () => 0,
   };
+  const jetPackUtility = simRef
+    ? {
+        ...stubUtility,
+        setHorizontalInput: (dir: -1 | 0 | 1) => simRef.setJetPackHorizontal(dir),
+        setVerticalInput: (active: boolean) => simRef.setJetPackThrust(active),
+      }
+    : stubUtility;
   const facade = {
     get xPx() {
       return view.xPx;
@@ -980,7 +965,7 @@ function adaptRenderableToWormFacade(view: RenderableWorm): Worm {
       return view.hp;
     },
     ropeUtility: stubUtility,
-    jetPackUtility: stubUtility,
+    jetPackUtility,
     // Input-method stubs: adapter-routed callbacks drive the wire sends.
     walk: (_dir: -1 | 0 | 1) => {
       void _dir;
@@ -1003,7 +988,7 @@ function adaptRenderableToWormFacade(view: RenderableWorm): Worm {
       void _dir;
     },
     isRoped: () => false,
-    isJetPacking: () => false,
+    isJetPacking: isJetPackingFn ?? (() => false),
     setActive: (_b: boolean) => {
       void _b;
     },

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -2,7 +2,13 @@ import * as Phaser from "phaser";
 import { loadMap } from "../maps/loadMap";
 import { allIds, getById } from "../maps/registry";
 import type { NetClient } from "../net/client";
-import { clearRoomToken, readRoomToken, saveRoomToken } from "../net/clientStorage";
+import {
+  clearRoomToken,
+  readNickname,
+  readRoomToken,
+  saveNickname,
+  saveRoomToken,
+} from "../net/clientStorage";
 import { runReconnectLoop } from "../net/reconnectLoop";
 import { ALLOWED_COLORS } from "../net/types";
 import type { ErrorMessage, GameStartedMessage, LobbyState } from "../net/types";
@@ -154,6 +160,9 @@ export class LobbyScene extends Phaser.Scene {
       return;
     }
 
+    // Pre-fill nickname from localStorage so returning players don't re-type.
+    this.nickname = readNickname();
+
     this.renderHome();
 
     // If we arrived with ?room=CODE in the URL, surface the code in the Join
@@ -271,6 +280,7 @@ export class LobbyScene extends Phaser.Scene {
   private async handleCreate(): Promise<void> {
     const nick = this.validateNickname();
     if (!nick) return;
+    saveNickname(nick);
 
     try {
       this.setHomeError("Creating room...");
@@ -306,6 +316,7 @@ export class LobbyScene extends Phaser.Scene {
 
     const nick = this.validateNickname();
     if (!nick) return;
+    saveNickname(nick);
 
     try {
       this.setHomeError("Looking up room...");

--- a/src/sim/NetworkedSimAdapter.test.ts
+++ b/src/sim/NetworkedSimAdapter.test.ts
@@ -145,6 +145,8 @@ function makeSimState(overrides: Partial<SimStateMessage> = {}): SimStateMessage
         alive: true,
         activeWeapon: "bazooka",
         ammoLeft: -1,
+        jetPackActive: false,
+        jetPackFuel: 100,
       },
     ],
     projectiles: [],
@@ -241,6 +243,8 @@ describe("NetworkedSimAdapter", () => {
               alive: true,
               activeWeapon: "bazooka",
               ammoLeft: -1,
+              jetPackActive: false,
+              jetPackFuel: 100,
             },
           ],
         }),
@@ -266,6 +270,8 @@ describe("NetworkedSimAdapter", () => {
               alive: true,
               activeWeapon: "bazooka",
               ammoLeft: -1,
+              jetPackActive: false,
+              jetPackFuel: 100,
             },
           ],
         }),
@@ -310,6 +316,8 @@ describe("NetworkedSimAdapter", () => {
               alive: true,
               activeWeapon: "bazooka",
               ammoLeft: -1,
+              jetPackActive: false,
+              jetPackFuel: 100,
             },
           ],
         }),
@@ -331,6 +339,8 @@ describe("NetworkedSimAdapter", () => {
               alive: true,
               activeWeapon: "bazooka",
               ammoLeft: -1,
+              jetPackActive: false,
+              jetPackFuel: 100,
             },
           ],
         }),
@@ -525,15 +535,19 @@ describe("NetworkedSimAdapter", () => {
     }
   });
 
-  it("rope + jetpack warn but do not crash (plan #65 disabled in networked mode)", () => {
+  it("rope warns but does not crash; jetpack toggle sends input_jetpack_toggle", () => {
     const room = makeFakeRoom();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const sim = new NetworkedSimAdapter({ room, teams: makeTeams() });
     try {
       sim.toggleRope();
       sim.toggleJetPack();
-      expect(warn).toHaveBeenCalledTimes(2);
-      // No room.send for either call.
+      // Rope still warns (not yet ported to networked mode).
+      expect(warn).toHaveBeenCalledTimes(1);
+      // Jetpack sends rather than warns.
+      const jpMsgs = room.sent.filter((m) => m.type === "input_jetpack_toggle");
+      expect(jpMsgs).toHaveLength(1);
+      // No rope sends.
       expect(room.sent.filter((m) => m.type.startsWith("input_rope")).length).toBe(0);
     } finally {
       sim.destroy();

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -108,6 +108,10 @@ export class NetworkedSimAdapter implements SimAdapter {
   private pendingAimPower: number | null = null;
   /** Cache last walk dir so a second walk(0) after a walk(1) doesn't re-send. */
   private lastWalkDir: -1 | 0 | 1 | null = null;
+  /** Cache last jetpack thrust so sustained presses don't re-send every frame. */
+  private lastJetThrustV: boolean | null = null;
+  /** Cache last jetpack horizontal dir for the same reason. */
+  private lastJetThrustH: -1 | 0 | 1 | null = null;
 
   constructor(init: NetworkedSimAdapterInit) {
     this.room = init.room;
@@ -242,7 +246,29 @@ export class NetworkedSimAdapter implements SimAdapter {
   }
 
   toggleJetPack(): void {
-    console.warn("[NetworkedSimAdapter] JetPack is not available in networked mode (plan #65).");
+    this.send({ type: "input_jetpack_toggle", seq: this.nextSeq() });
+  }
+
+  setJetPackThrust(active: boolean): void {
+    if (active === this.lastJetThrustV) return;
+    this.lastJetThrustV = active;
+    this.send({ type: "input_jetpack_thrust", active, seq: this.nextSeq() });
+  }
+
+  setJetPackHorizontal(dir: -1 | 0 | 1): void {
+    if (dir === this.lastJetThrustH) return;
+    this.lastJetThrustH = dir;
+    this.send({ type: "input_jetpack_horizontal", dir, seq: this.nextSeq() });
+  }
+
+  isJetPacking(): boolean {
+    const activeId = this.getActiveWormId();
+    return this.currFrame?.state.worms.find((w) => w.id === activeId)?.jetPackActive ?? false;
+  }
+
+  getJetPackFuel(): number {
+    const activeId = this.getActiveWormId();
+    return this.currFrame?.state.worms.find((w) => w.id === activeId)?.jetPackFuel ?? 0;
   }
 
   update(_dtMs: number): void {

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -309,6 +309,24 @@ export class OfflineSimAdapter implements SimAdapter {
       : worm.jetPackUtility?.activate();
   }
 
+  setJetPackThrust(active: boolean): void {
+    this.turnManager.getActiveWorm()?.jetPackUtility?.setVerticalInput(active);
+  }
+
+  setJetPackHorizontal(dir: -1 | 0 | 1): void {
+    this.turnManager.getActiveWorm()?.jetPackUtility?.setHorizontalInput(dir);
+  }
+
+  isJetPacking(): boolean {
+    return this.turnManager.getActiveWorm()?.isJetPacking() ?? false;
+  }
+
+  getJetPackFuel(): number {
+    const worm = this.turnManager.getActiveWorm();
+    if (!worm) return 0;
+    return worm.jetPackUtility?.getFuel() ?? 0;
+  }
+
   update(dtMs: number): void {
     this.physicsSystem.step(dtMs);
     this.terrainInstance.flushPendingCuts();

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -81,6 +81,11 @@ export interface SimAdapter {
   /** Rope / jetpack toggle. Offline-only per plan #65; networked adapter no-ops. */
   toggleRope(): void;
   toggleJetPack(): void;
+  setJetPackThrust(active: boolean): void;
+  setJetPackHorizontal(dir: -1 | 0 | 1): void;
+  isJetPacking(): boolean;
+  /** Current jetpack fuel level, 0..100. */
+  getJetPackFuel(): number;
 
   // ---- Lifecycle ----
   /** Per-frame update. Offline: drives planck step + settle. Networked: advances interpolation clock. */

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -1,23 +1,36 @@
 import * as Phaser from "phaser";
+import type { SimAdapter } from "../sim/SimAdapter";
 import { tuning } from "../tuning";
 import type { Worm } from "../worm/Worm";
 
 export interface TouchControlsInit {
   scene: Phaser.Scene;
   getActiveWorm: () => Worm | null;
-  /** When true, rope + jetpack are no-ops (per plan #65) so we skip rendering
-   * any buttons. When false (offline), buttons render in the top-right corner. */
+  /**
+   * When false (default true), the rope button is not rendered.
+   * Use this to disable rope in networked mode until the rope port ships.
+   */
+  ropeEnabled?: boolean;
+  /**
+   * When false (default true), the jetpack button is not rendered.
+   */
+  jetPackEnabled?: boolean;
+  /** @deprecated Use ropeEnabled/jetPackEnabled instead. */
   networked?: boolean;
+  /** Sim adapter used for jetpack toggle in networked mode. */
+  sim?: SimAdapter;
 }
 
 /**
  * On-screen touch overlay with rope + jetpack buttons.
  *
- * Offline mode: small buttons top-right, out of the walk / aim area. Tap rope
- * to toggle, hold jet to thrust.
+ * Button visibility is controlled per-utility via `ropeEnabled` and
+ * `jetPackEnabled` (both default true). In networked mode, pass
+ * `ropeEnabled: false` to hide rope (not yet ported) while keeping
+ * the jetpack button active.
  *
- * Networked mode: buttons are hidden entirely. Utilities aren't wired to the
- * server yet (plan #65), so showing inert buttons would be misleading.
+ * The container is always constructed so `destroy()` and `hitsButton()`
+ * work regardless of which buttons were created.
  */
 export class TouchControls {
   private readonly container: Phaser.GameObjects.Container;
@@ -33,75 +46,73 @@ export class TouchControls {
     this.container.setDepth(100);
     this.container.setScrollFactor(0);
 
-    if (init.networked) {
-      // Networked mode: no rope / jet buttons. The container stays empty so
-      // hitsButton() always returns false and the gesture layer sees every
-      // pointerdown.
-      return;
-    }
+    // Resolve flags: new per-utility flags take precedence; legacy `networked`
+    // flag maps to ropeEnabled=false, jetPackEnabled=true for backward compat.
+    const ropeEnabled = init.ropeEnabled ?? !init.networked;
+    const jetPackEnabled = init.jetPackEnabled ?? true;
 
     const { getActiveWorm } = init;
     const radius = tuning.touch.buttonRadiusPx;
     const sw = this.scene.scale.width;
 
-    // --- Rope button (top-right, inboard) ---
-    const ropeBtn = this._makeButton({
-      fillColor: 0x2266cc,
-      strokeColor: 0x88aaff,
-      label: "R",
-      radius,
-    });
-    ropeBtn.setPosition(sw - 60 - (radius * 2 + 10), 60);
-    this.ropeBtn = ropeBtn;
+    if (ropeEnabled) {
+      // --- Rope button (top-right, inboard) ---
+      const ropeBtn = this._makeButton({
+        fillColor: 0x2266cc,
+        strokeColor: 0x88aaff,
+        label: "R",
+        radius,
+      });
+      ropeBtn.setPosition(sw - 60 - (radius * 2 + 10), 60);
+      this.ropeBtn = ropeBtn;
+      this.container.add(ropeBtn);
 
-    // --- JetPack button (top-right corner) ---
-    const jetBtn = this._makeButton({
-      fillColor: 0xcc6600,
-      strokeColor: 0xff9933,
-      label: "J",
-      radius,
-    });
-    jetBtn.setPosition(sw - 60, 60);
-    this.jetBtn = jetBtn;
+      ropeBtn.setInteractive({
+        hitArea: new Phaser.Geom.Circle(0, 0, radius),
+        hitAreaCallback: Phaser.Geom.Circle.Contains,
+      });
+      ropeBtn.on("pointerdown", () => {
+        const w = getActiveWorm();
+        if (!w) return;
+        w.ropeUtility.isActive() ? w.ropeUtility.deactivate() : w.ropeUtility.activate();
+        this._flashButton(ropeBtn, w.ropeUtility.isActive());
+      });
+      ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+    }
 
-    this.container.add([ropeBtn, jetBtn]);
+    if (jetPackEnabled) {
+      // --- JetPack button (top-right corner) ---
+      const jetBtn = this._makeButton({
+        fillColor: 0xcc6600,
+        strokeColor: 0xff9933,
+        label: "J",
+        radius,
+      });
+      jetBtn.setPosition(sw - 60, 60);
+      this.jetBtn = jetBtn;
+      this.container.add(jetBtn);
 
-    // --- Rope: tap to toggle ---
-    ropeBtn.setInteractive({
-      hitArea: new Phaser.Geom.Circle(0, 0, radius),
-      hitAreaCallback: Phaser.Geom.Circle.Contains,
-    });
-    ropeBtn.on("pointerdown", () => {
-      const w = getActiveWorm();
-      if (!w) return;
-      w.ropeUtility.isActive() ? w.ropeUtility.deactivate() : w.ropeUtility.activate();
-      this._flashButton(ropeBtn, w.ropeUtility.isActive());
-    });
-
-    // --- JetPack: hold to thrust (pointerdown = activate, pointerup = deactivate) ---
-    jetBtn.setInteractive({
-      hitArea: new Phaser.Geom.Circle(0, 0, radius),
-      hitAreaCallback: Phaser.Geom.Circle.Contains,
-    });
-    const jetDeactivate = (): void => {
-      const w = getActiveWorm();
-      if (!w) return;
-      if (w.jetPackUtility.isActive()) w.jetPackUtility.deactivate();
-      this._setButtonAlpha(jetBtn, false);
-    };
-    jetBtn.on("pointerdown", () => {
-      const w = getActiveWorm();
-      if (!w) return;
-      if (!w.jetPackUtility.isActive()) w.jetPackUtility.activate();
-      this._setButtonAlpha(jetBtn, true);
-    });
-    jetBtn.on("pointerup", jetDeactivate);
-    jetBtn.on("pointerupoutside", jetDeactivate);
-    jetBtn.on("pointerout", jetDeactivate);
-
-    // Set idle alpha on both
-    ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
-    jetBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+      jetBtn.setInteractive({
+        hitArea: new Phaser.Geom.Circle(0, 0, radius),
+        hitAreaCallback: Phaser.Geom.Circle.Contains,
+      });
+      const jetDeactivate = (): void => {
+        const w = getActiveWorm();
+        if (!w) return;
+        if (w.jetPackUtility.isActive()) w.jetPackUtility.deactivate();
+        this._setButtonAlpha(jetBtn, false);
+      };
+      jetBtn.on("pointerdown", () => {
+        const w = getActiveWorm();
+        if (!w) return;
+        if (!w.jetPackUtility.isActive()) w.jetPackUtility.activate();
+        this._setButtonAlpha(jetBtn, true);
+      });
+      jetBtn.on("pointerup", jetDeactivate);
+      jetBtn.on("pointerupoutside", jetDeactivate);
+      jetBtn.on("pointerout", jetDeactivate);
+      jetBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+    }
   }
 
   /**

--- a/src/utilities/JetPack.ts
+++ b/src/utilities/JetPack.ts
@@ -35,6 +35,14 @@ export class JetPack implements Utility {
   }
 
   /**
+   * Returns the current fuel level as a 0-100 percentage.
+   * Used by SimAdapter to expose a normalized value.
+   */
+  getFuel(): number {
+    return this._fuel;
+  }
+
+  /**
    * Toggle jetpack. Activate if fuel > 0 and worm not roped.
    * Deactivate if already active.
    */

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -62,6 +62,8 @@ export interface WormRenderState {
   alive: boolean;
   activeWeapon: string;
   ammoLeft: number;
+  jetPackActive: boolean;
+  jetPackFuel: number; // 0-100
 }
 
 export class Worm {
@@ -84,6 +86,10 @@ export class Worm {
   private readonly footSensor: Fixture;
   private readonly walkSpeedMps: number;
   private walkingDir: -1 | 0 | 1 = 0;
+  private jetPackActive = false;
+  private jetPackFuel = 100;
+  private jetPackThrustV = false;
+  private jetPackThrustH: -1 | 0 | 1 = 0;
 
   constructor(init: WormInit) {
     this.id = init.id;
@@ -186,6 +192,70 @@ export class Worm {
     this.facing = dir;
   }
 
+  // ---- JetPack ----
+
+  toggleJetPack(): void {
+    if (!this.alive) return;
+    if (this.jetPackActive) {
+      this.jetPackActive = false;
+      this.jetPackThrustV = false;
+      this.jetPackThrustH = 0;
+    } else {
+      if (this.jetPackFuel <= 0) return;
+      this.jetPackActive = true;
+    }
+  }
+
+  setJetPackThrust(active: boolean): void {
+    this.jetPackThrustV = active;
+  }
+
+  setJetPackHorizontal(dir: -1 | 0 | 1): void {
+    this.jetPackThrustH = dir;
+  }
+
+  /**
+   * Apply jetpack force for one sim tick. Called from Simulation.tick
+   * on the active worm before world.step(). Drains fuel and auto-deactivates
+   * when empty.
+   */
+  applyJetPackForce(dtMs: number): void {
+    if (!this.alive || !this.jetPackActive) return;
+    if (this.jetPackFuel <= 0) {
+      this.jetPackActive = false;
+      this.jetPackThrustV = false;
+      this.jetPackThrustH = 0;
+      return;
+    }
+
+    const UP_FORCE = 18; // Newtons (planck units)
+    const SIDE_FORCE = 10;
+    const FUEL_PER_SECOND = 30; // percent per second
+
+    const fx = this.jetPackThrustH * SIDE_FORCE;
+    const fy = this.jetPackThrustV ? -UP_FORCE : 0;
+
+    if (fx !== 0 || fy !== 0) {
+      this.body.applyForce({ x: fx, y: fy }, this.body.getPosition(), true);
+      this.jetPackFuel -= FUEL_PER_SECOND * (dtMs / 1000);
+    }
+
+    if (this.jetPackFuel <= 0) {
+      this.jetPackFuel = 0;
+      this.jetPackActive = false;
+      this.jetPackThrustV = false;
+      this.jetPackThrustH = 0;
+    }
+  }
+
+  /** Reset all utility state. Called when a new turn starts for a worm. */
+  resetUtilitiesForTurnStart(): void {
+    this.jetPackActive = false;
+    this.jetPackFuel = 100;
+    this.jetPackThrustV = false;
+    this.jetPackThrustH = 0;
+  }
+
   // ---- Health ----
 
   takeDamage(amount: number): number {
@@ -205,6 +275,9 @@ export class Worm {
     this.health = 0;
     this.alive = false;
     this.walkingDir = 0;
+    this.jetPackActive = false;
+    this.jetPackThrustV = false;
+    this.jetPackThrustH = 0;
   }
 
   // ---- Foot contact ----
@@ -249,6 +322,8 @@ export class Worm {
       alive: this.alive,
       activeWeapon: this.activeWeapon,
       ammoLeft: this.ammoLeft,
+      jetPackActive: this.jetPackActive,
+      jetPackFuel: Math.round(this.jetPackFuel),
     };
   }
 }

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -86,10 +86,13 @@ export class Worm {
   private readonly footSensor: Fixture;
   private readonly walkSpeedMps: number;
   private walkingDir: -1 | 0 | 1 = 0;
-  private jetPackActive = false;
-  private jetPackFuel = 100;
-  private jetPackThrustV = false;
-  private jetPackThrustH: -1 | 0 | 1 = 0;
+  // Jetpack fields are public so serialize/restore can round-trip them
+  // without a separate API surface. Writes from outside are rare and
+  // happen only on hibernation restore.
+  jetPackActive = false;
+  jetPackFuel = 100;
+  jetPackThrustV = false;
+  jetPackThrustH: -1 | 0 | 1 = 0;
 
   constructor(init: WormInit) {
     this.id = init.id;
@@ -228,8 +231,9 @@ export class Worm {
       return;
     }
 
-    const UP_FORCE = 18; // Newtons (planck units)
-    const SIDE_FORCE = 10;
+    // Mirrors src/tuning.ts jetpack section so offline + networked feel the same.
+    const UP_FORCE = 15; // Newtons (planck units)
+    const SIDE_FORCE = 8;
     const FUEL_PER_SECOND = 30; // percent per second
 
     const fx = this.jetPackThrustH * SIDE_FORCE;

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -78,7 +78,10 @@ type PendingInput =
   | { kind: "aim_angle"; sessionId: string; angleRad: number }
   | { kind: "aim_power"; sessionId: string; power: number }
   | { kind: "select_weapon"; sessionId: string; weaponId: string }
-  | { kind: "fire"; sessionId: string };
+  | { kind: "fire"; sessionId: string }
+  | { kind: "jetpack_toggle"; sessionId: string }
+  | { kind: "jetpack_thrust"; sessionId: string; active: boolean }
+  | { kind: "jetpack_horizontal"; sessionId: string; dir: -1 | 0 | 1 };
 
 /** Sim-kickoff metadata persisted so hibernation can rebuild. */
 interface SimBootstrap {
@@ -426,6 +429,9 @@ export class Room implements DurableObject {
       case "input_select_weapon":
       case "input_fire":
       case "input_end_turn":
+      case "input_jetpack_toggle":
+      case "input_jetpack_thrust":
+      case "input_jetpack_horizontal":
         this.queueInput(attachment.sessionId, type, msg);
         break;
       case "leave":
@@ -526,7 +532,12 @@ export class Room implements DurableObject {
       }
 
       if (lobby.phase === "playing" && this.arbiter) {
+        const prevWormId = lobby.currentWormId;
         this.arbiter.onTick(SIM_TICK_MS);
+        const nextWormId = lobby.currentWormId;
+        if (nextWormId && nextWormId !== prevWormId && this.sim) {
+          this.sim.resetUtilitiesForTurnStart(nextWormId);
+        }
       }
 
       if (this.arbiter) await this.persistArbiter();
@@ -831,6 +842,21 @@ export class Room implements DurableObject {
       case "input_fire":
         this.pendingInputs.push({ kind: "fire", sessionId: senderSessionId });
         return;
+      case "input_jetpack_toggle":
+        this.pendingInputs.push({ kind: "jetpack_toggle", sessionId: senderSessionId });
+        return;
+      case "input_jetpack_thrust": {
+        const active = raw.active;
+        if (typeof active !== "boolean") return;
+        this.pendingInputs.push({ kind: "jetpack_thrust", sessionId: senderSessionId, active });
+        return;
+      }
+      case "input_jetpack_horizontal": {
+        const dir = raw.dir;
+        if (dir !== -1 && dir !== 0 && dir !== 1) return;
+        this.pendingInputs.push({ kind: "jetpack_horizontal", sessionId: senderSessionId, dir });
+        return;
+      }
       case "input_end_turn":
         // Explicit end-turn press from the active player. Force-advance
         // via the arbiter (validates ownership + pause state). Without
@@ -878,6 +904,15 @@ export class Room implements DurableObject {
         case "fire":
           this.sim.applyFire(activeWormId);
           this.arbiter?.onFireCommitted();
+          break;
+        case "jetpack_toggle":
+          this.sim.applyJetPackToggle(activeWormId);
+          break;
+        case "jetpack_thrust":
+          this.sim.applyJetPackThrust(activeWormId, input.active);
+          break;
+        case "jetpack_horizontal":
+          this.sim.applyJetPackHorizontal(activeWormId, input.dir);
           break;
       }
     }

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -497,6 +497,11 @@ export class Room implements DurableObject {
       const lobby = this.ensureLobby();
       const now = Date.now();
 
+      // Capture the active worm BEFORE any mutation points in this alarm
+      // cycle (handleFinalLeave / drainInputs / arbiter.onTick can all
+      // advance the turn). Compared at the end to trigger utility reset.
+      const prevWormId = lobby.currentWormId;
+
       // Grace expiry forfeits.
       const expiredSessionIds: string[] = [];
       for (const [sid, player] of Object.entries(lobby.players)) {
@@ -532,10 +537,15 @@ export class Room implements DurableObject {
       }
 
       if (lobby.phase === "playing" && this.arbiter) {
-        const prevWormId = lobby.currentWormId;
         this.arbiter.onTick(SIM_TICK_MS);
+      }
+
+      // Turn-change utility reset: prevWormId was captured at the top of
+      // the alarm, so this catches advances from handleFinalLeave (forfeit),
+      // drainInputs (endTurnByPlayer), and arbiter.onTick (timer / pending).
+      if (lobby.phase === "playing" && this.sim) {
         const nextWormId = lobby.currentWormId;
-        if (nextWormId && nextWormId !== prevWormId && this.sim) {
+        if (nextWormId && nextWormId !== prevWormId) {
           this.sim.resetUtilitiesForTurnStart(nextWormId);
         }
       }

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -428,10 +428,10 @@ export class Simulation {
           alive: w.alive,
           activeWeapon: w.activeWeapon,
           ammoLeft: w.ammoLeft,
-          jetPackActive: w.toRenderState().jetPackActive,
-          jetPackFuel: w.toRenderState().jetPackFuel,
-          jetPackThrustV: false,
-          jetPackThrustH: 0 as -1 | 0 | 1,
+          jetPackActive: w.jetPackActive,
+          jetPackFuel: w.jetPackFuel,
+          jetPackThrustV: w.jetPackThrustV,
+          jetPackThrustH: w.jetPackThrustH,
         };
       }),
       projectiles: this.projectiles.map((p) => ({
@@ -468,9 +468,12 @@ export class Simulation {
       worm.alive = ws.alive;
       worm.activeWeapon = ws.activeWeapon;
       worm.ammoLeft = ws.ammoLeft;
-      // Reset jetpack to safe defaults on restore (mid-flight hibernation is
-      // an acceptable edge case; the alternative is serializing thrust state).
-      worm.resetUtilitiesForTurnStart();
+      // Round-trip jetpack state across hibernation. Defaults cover pre-PR
+      // persisted shapes that didn't have these fields.
+      worm.jetPackActive = ws.jetPackActive ?? false;
+      worm.jetPackFuel = ws.jetPackFuel ?? 100;
+      worm.jetPackThrustV = ws.jetPackThrustV ?? false;
+      worm.jetPackThrustH = ws.jetPackThrustH ?? 0;
     }
     // Clear any bodies we pre-created for projectiles (we didn't).
     for (const ps of state.projectiles) {

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -116,6 +116,10 @@ export interface SerializedSim {
     alive: boolean;
     activeWeapon: string;
     ammoLeft: number;
+    jetPackActive?: boolean;
+    jetPackFuel?: number;
+    jetPackThrustV?: boolean;
+    jetPackThrustH?: -1 | 0 | 1;
   }>;
   projectiles: Array<{
     id: string;
@@ -223,6 +227,23 @@ export class Simulation {
     worm.setFacing(facing);
   }
 
+  applyJetPackToggle(wormId: string): void {
+    this.worms.get(wormId)?.toggleJetPack();
+  }
+
+  applyJetPackThrust(wormId: string, active: boolean): void {
+    this.worms.get(wormId)?.setJetPackThrust(active);
+  }
+
+  applyJetPackHorizontal(wormId: string, dir: -1 | 0 | 1): void {
+    this.worms.get(wormId)?.setJetPackHorizontal(dir);
+  }
+
+  /** Reset utility state when a new turn starts for the given worm. */
+  resetUtilitiesForTurnStart(wormId: string): void {
+    this.worms.get(wormId)?.resetUtilitiesForTurnStart();
+  }
+
   applySelectWeapon(wormId: string, weaponId: string): void {
     const worm = this.worms.get(wormId);
     if (!worm) return;
@@ -303,6 +324,7 @@ export class Simulation {
     //    advance implicitly stops the previous walker.
     if (activeWormId) {
       this.worms.get(activeWormId)?.applyWalking();
+      this.worms.get(activeWormId)?.applyJetPackForce(dtMs);
     }
 
     // 1. Step world. planck does fixed-step internally via the passed
@@ -406,6 +428,10 @@ export class Simulation {
           alive: w.alive,
           activeWeapon: w.activeWeapon,
           ammoLeft: w.ammoLeft,
+          jetPackActive: w.toRenderState().jetPackActive,
+          jetPackFuel: w.toRenderState().jetPackFuel,
+          jetPackThrustV: false,
+          jetPackThrustH: 0 as -1 | 0 | 1,
         };
       }),
       projectiles: this.projectiles.map((p) => ({
@@ -442,6 +468,9 @@ export class Simulation {
       worm.alive = ws.alive;
       worm.activeWeapon = ws.activeWeapon;
       worm.ammoLeft = ws.ammoLeft;
+      // Reset jetpack to safe defaults on restore (mid-flight hibernation is
+      // an acceptable edge case; the alternative is serializing thrust state).
+      worm.resetUtilitiesForTurnStart();
     }
     // Clear any bodies we pre-created for projectiles (we didn't).
     for (const ps of state.projectiles) {

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -176,6 +176,47 @@ describe("Simulation - movement", () => {
     // well under half a meter (compare to >1m sustained travel above).
     expect(afterInactive - afterActive).toBeLessThan(0.5);
   });
+
+  it("jetpack: toggle on, sustained thrust lifts worm, fuel drains, auto-deactivates", () => {
+    // Settle worm onto floor.
+    for (let i = 0; i < 30; i++) sim.tick(50, "Red-1");
+    const yBefore = requireWorm(sim, "Red-1").body.getPosition().y;
+
+    // Toggle jetpack on and apply upward thrust.
+    sim.applyJetPackToggle("Red-1");
+    sim.applyJetPackThrust("Red-1", true);
+
+    // 30 ticks at 50ms = 1.5s of thrust - should lift the worm noticeably.
+    for (let i = 0; i < 30; i++) sim.tick(50, "Red-1");
+    const yAfter = requireWorm(sim, "Red-1").body.getPosition().y;
+    // In planck (y-down), moving up means y decreases.
+    expect(yAfter).toBeLessThan(yBefore - 0.3);
+
+    // Check fuel drained. Drain for more ticks until auto-deactivate.
+    for (let i = 0; i < 80; i++) sim.tick(50, "Red-1");
+    const state = requireWorm(sim, "Red-1").toRenderState();
+    expect(state.jetPackActive).toBe(false);
+  });
+
+  it("jetpack: turn advance resets fuel to 100", () => {
+    // Settle.
+    for (let i = 0; i < 20; i++) sim.tick(50, "Red-1");
+
+    // Burn some fuel.
+    sim.applyJetPackToggle("Red-1");
+    sim.applyJetPackThrust("Red-1", true);
+    for (let i = 0; i < 20; i++) sim.tick(50, "Red-1");
+
+    const midState = requireWorm(sim, "Red-1").toRenderState();
+    expect(midState.jetPackFuel).toBeLessThan(100);
+
+    // Simulate turn change: reset utilities for Red-1.
+    sim.resetUtilitiesForTurnStart("Red-1");
+
+    const resetState = requireWorm(sim, "Red-1").toRenderState();
+    expect(resetState.jetPackFuel).toBe(100);
+    expect(resetState.jetPackActive).toBe(false);
+  });
 });
 
 describe("Simulation - fire / cut / damage", () => {


### PR DESCRIPTION
## Summary

**WS1 — Nickname persistence (closes #77).** Pre-fill the lobby nickname field from localStorage (`worms.nickname.v1`); save after a validated create or join. Trim + length 1-16 match existing validation. Storage failures swallowed gracefully (private-browsing safe).

**WS2 — Jetpack in networked mode (refs #65, partial).** Ports client-local jetpack to server-authoritative, matching the walk netcode pattern. Three new inbound messages (`input_jetpack_toggle`, `input_jetpack_thrust`, `input_jetpack_horizontal`). Server Worm gains state + `applyJetPackForce` called per tick on the active worm. Room detects turn changes and resets utility state on the incoming worm. UI refactor: TouchControls gets per-utility enable flags, UtilityDPad mounts in both modes. Rope stays inert in networked mode; Phase 2 will wire it (tracked separately as the rope-on-mobile follow-up).

## Bug Check

Ran inline after merge. Three Critical findings, all resolved in commit `1402f1e`:
- **C1** jetpack force constants aligned with `src/tuning.ts` (server was 18/10 vs client 15/8 → desync)
- **C2** turn-change hook widened: `prevWormId` now captured at the top of the alarm cycle so `endTurnByPlayer` and `onTeamForfeit` advances also trigger `resetUtilitiesForTurnStart`
- **C3** hibernation now round-trips jetpack state via `serialize`/`restore` instead of silently resetting

Medium/Low (deferred as follow-up tracking):
- Nickname: client saves un-normalized text (server strips control chars on submit); cosmetic next-session pre-fill only
- `JetPack.getFuel()` comment accurate since `fuelCapacity=100`

## Test plan

- [ ] Enter a nickname, create or join a room, reload the page → nickname pre-fills
- [ ] Networked mode: tap J button → worm lifts, fuel drops; d-pad up sustains thrust; left/right steers
- [ ] Fuel drains to zero → jetpack auto-deactivates
- [ ] Turn advances → fuel resets to 100 for the incoming worm
- [ ] End-turn button during active jetpack → utilities reset for next worm
- [ ] Offline mode unchanged (sanity check)

Closes #77