### PR TITLE
fix: use npx wrangler in deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "biome format --write .",
     "test": "vitest",
     "test:run": "vitest run",
-    "deploy": "npm run build && cd worker && wrangler deploy"
+    "deploy": "npm run build && cd worker && npx wrangler deploy"
   },
   "dependencies": {
     "phaser": "3.90.0",


### PR DESCRIPTION
wrangler isn't on PATH after cd worker; use npx wrangler to pick up the local devDep.