### PR TITLE
Classic Worms Feel: wind + water + fall damage + retreat window (closes #83)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -184,6 +184,10 @@ export interface SimState {
   activeWormId: string;
   /** ms-epoch time at which the active turn ends (client ticks down locally). */
   turnEndsAt: number;
+  /** Wind strength -1..1, negative = leftward. Applied as horizontal force on projectiles. */
+  wind: number;
+  /** Y coordinate (pixels) below which worms drown. Number.MAX_SAFE_INTEGER = no water. */
+  waterLevelPx: number;
 }
 
 /**

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -13,6 +13,7 @@ import { NetworkedSimAdapter } from "../sim/NetworkedSimAdapter";
 import { OfflineSimAdapter } from "../sim/OfflineSimAdapter";
 import type { RenderableWorm, SimAdapter, SimEvent } from "../sim/SimAdapter";
 import { TerrainRenderer } from "../terrain/TerrainRenderer";
+import { WaterRenderer } from "../terrain/WaterRenderer";
 import { tuning } from "../tuning";
 import { AimHUD } from "../ui/AimHUD";
 import { ReconnectingOverlay } from "../ui/ReconnectingOverlay";
@@ -21,6 +22,7 @@ import { TouchControls } from "../ui/TouchControls";
 import { TurnHUD } from "../ui/TurnHUD";
 import { UtilityDPad } from "../ui/UtilityDPad";
 import { WeaponDrawer } from "../ui/WeaponDrawer";
+import { WindHUD } from "../ui/WindHUD";
 import { allWeapons, defaultAmmoForMatch } from "../weapons/registry";
 import type { Team } from "../worm/Team";
 import type { Worm } from "../worm/Worm";
@@ -59,6 +61,10 @@ export class GameScene extends Phaser.Scene {
   private wormSprites: Map<string, WormSprite> = new Map();
   /** Fallback graphics for server-spawned projectiles (networked mode). */
   private projectileGraphics: Map<string, Phaser.GameObjects.Graphics> = new Map();
+
+  // ---- Wind + water HUD / rendering ----
+  private windHUD: WindHUD | null = null;
+  private waterRenderer: WaterRenderer | null = null;
 
   // ---- Scene-level UI (same for both modes) ----
   private debugGfx!: Phaser.GameObjects.Graphics;
@@ -250,6 +256,10 @@ export class GameScene extends Phaser.Scene {
       this.spectatorHUD?.destroy();
       this.utilityDPad?.destroy();
       this.utilityDPad = null;
+      this.windHUD?.destroy();
+      this.windHUD = null;
+      this.waterRenderer?.destroy();
+      this.waterRenderer = null;
       this.reconnectingOverlay?.destroy();
       this.reconnectingOverlay = null;
       this.disconnectTick?.remove(false);
@@ -349,6 +359,17 @@ export class GameScene extends Phaser.Scene {
       this.wireNetworkedScene();
     }
 
+    // Wind HUD and water renderer (both modes).
+    const sceneWidthPx = this.serverWidthPx ?? this.scale.width;
+    const sceneHeightPx = this.serverHeightPx ?? this.scale.height;
+    this.windHUD = new WindHUD({ scene: this, sim: this.sim });
+    this.waterRenderer = new WaterRenderer({
+      scene: this,
+      sim: this.sim,
+      widthPx: sceneWidthPx,
+      heightPx: sceneHeightPx,
+    });
+
     this.debugGfx = this.add.graphics();
     this.debugGfx.setDepth(10);
     this.hud = this.add
@@ -380,6 +401,8 @@ export class GameScene extends Phaser.Scene {
     this.turnHUD.update(this.sim.getTurnSecondsRemaining());
     this.weaponDrawer.update();
     this.aimHUD.update();
+    this.windHUD?.update();
+    this.waterRenderer?.update();
     this.refreshUtilityDPad();
     const selectedId = this.getSelectedWeaponId();
     const weapon = allWeapons().find((w) => w.id === selectedId);

--- a/src/sim/NetworkedSimAdapter.test.ts
+++ b/src/sim/NetworkedSimAdapter.test.ts
@@ -153,6 +153,8 @@ function makeSimState(overrides: Partial<SimStateMessage> = {}): SimStateMessage
     activeTeamId: "red",
     activeWormId: "red-1",
     turnEndsAt: Date.now() + 30000,
+    wind: 0,
+    waterLevelPx: Number.MAX_SAFE_INTEGER,
     ...overrides,
   };
 }

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -191,6 +191,14 @@ export class NetworkedSimAdapter implements SimAdapter {
     return Math.max(0, Math.ceil((endsAt - Date.now()) / 1000));
   }
 
+  getWind(): number {
+    return this.currFrame?.state.wind ?? 0;
+  }
+
+  getWaterLevelPx(): number {
+    return this.currFrame?.state.waterLevelPx ?? Number.MAX_SAFE_INTEGER;
+  }
+
   walk(dir: -1 | 0 | 1): void {
     // Transition-only send: walk() is called every frame by InputController
     // while a key is held; the server only needs press/release edges.

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -226,6 +226,14 @@ export class OfflineSimAdapter implements SimAdapter {
     return this.turnManager.getTurnSecondsRemaining();
   }
 
+  getWind(): number {
+    return 0;
+  }
+
+  getWaterLevelPx(): number {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
   walk(dir: -1 | 0 | 1): void {
     if (!this.inputAllowed) return;
     this.turnManager.getActiveWorm()?.walk(dir);

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -67,6 +67,10 @@ export interface SimAdapter {
   getActiveTeamId(): string;
   /** Seconds remaining on the active turn. Server-authoritative when networked. */
   getTurnSecondsRemaining(): number;
+  /** Wind strength -1..1; negative = leftward. Zero in offline mode. */
+  getWind(): number;
+  /** Water level in pixels. Number.MAX_SAFE_INTEGER means no water. */
+  getWaterLevelPx(): number;
 
   // ---- Input accepters (caller is whoever holds the local input device) ----
   walk(dir: -1 | 0 | 1): void;

--- a/src/terrain/WaterRenderer.ts
+++ b/src/terrain/WaterRenderer.ts
@@ -1,0 +1,50 @@
+/**
+ * WaterRenderer - draws a rising water layer below terrain.
+ *
+ * Renders a semi-transparent blue fill from `waterLevelPx` down to the
+ * bottom of the world. Depth -5 places it below terrain sprites (typically
+ * depth 0) but above the sky backdrop.
+ *
+ * When waterLevelPx === Number.MAX_SAFE_INTEGER (the sentinel meaning "no
+ * water") nothing is drawn. The graphics object is cleared each update so
+ * the level can change smoothly turn-over-turn.
+ */
+import type * as Phaser from "phaser";
+import type { SimAdapter } from "../sim/SimAdapter";
+
+export interface WaterRendererInit {
+  scene: Phaser.Scene;
+  sim: SimAdapter;
+  widthPx: number;
+  heightPx: number;
+}
+
+export class WaterRenderer {
+  private readonly gfx: Phaser.GameObjects.Graphics;
+  private readonly sim: SimAdapter;
+  private readonly widthPx: number;
+  private readonly heightPx: number;
+  private lastLevelPx = Number.MAX_SAFE_INTEGER;
+
+  constructor(init: WaterRendererInit) {
+    this.sim = init.sim;
+    this.widthPx = init.widthPx;
+    this.heightPx = init.heightPx;
+    this.gfx = init.scene.add.graphics();
+    this.gfx.setDepth(-5); // below terrain sprite (which is typically 0)
+  }
+
+  update(): void {
+    const lvl = this.sim.getWaterLevelPx();
+    if (lvl === this.lastLevelPx) return;
+    this.lastLevelPx = lvl;
+    this.gfx.clear();
+    if (lvl >= Number.MAX_SAFE_INTEGER) return;
+    this.gfx.fillStyle(0x1155aa, 0.55);
+    this.gfx.fillRect(0, lvl, this.widthPx, this.heightPx - lvl);
+  }
+
+  destroy(): void {
+    this.gfx.destroy();
+  }
+}

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -1,5 +1,12 @@
 interface Tuning {
   world: { gravityY: number };
+  retreat: {
+    windowMs: number;
+  };
+  water: {
+    suddenDeathTurn: number;
+    risePxPerTurn: number;
+  };
   weapons: {
     testCutRadiusPx: number;
     dragMaxLengthPx: number;
@@ -72,10 +79,15 @@ interface Tuning {
     /** Default map id used on first load. Must be a valid registry key. */
     defaultId: string;
   };
+  wind: {
+    forceNewtonsPerUnit: number;
+  };
 }
 
 export const tuning: Tuning = {
   world: { gravityY: 10 },
+  retreat: { windowMs: 5000 },
+  water: { suddenDeathTurn: 15, risePxPerTurn: 50 },
   weapons: {
     testCutRadiusPx: 40,
     dragMaxLengthPx: 200,
@@ -129,4 +141,5 @@ export const tuning: Tuning = {
   maps: {
     defaultId: "hills", // registry lookup; falls back to firstId() if invalid
   },
+  wind: { forceNewtonsPerUnit: 2 },
 };

--- a/src/ui/WindHUD.ts
+++ b/src/ui/WindHUD.ts
@@ -1,0 +1,75 @@
+/**
+ * WindHUD - top-center widget showing current wind direction and magnitude.
+ *
+ * Rendered as a horizontal arrow (direction + length proportional to |wind|)
+ * with a text label below it. Sits at depth 100 so it renders above terrain
+ * and worm sprites. Scroll-factor 0 keeps it fixed to the screen.
+ */
+import type * as Phaser from "phaser";
+import type { SimAdapter } from "../sim/SimAdapter";
+
+export interface WindHUDInit {
+  scene: Phaser.Scene;
+  sim: SimAdapter;
+}
+
+export class WindHUD {
+  private readonly container: Phaser.GameObjects.Container;
+  private readonly arrow: Phaser.GameObjects.Graphics;
+  private readonly label: Phaser.GameObjects.Text;
+  private readonly sim: SimAdapter;
+  private lastWind = 0;
+
+  constructor(init: WindHUDInit) {
+    this.sim = init.sim;
+    const sw = init.scene.scale.width;
+    this.container = init.scene.add.container(sw / 2, 90);
+    this.container.setDepth(100);
+    this.container.setScrollFactor(0);
+    this.arrow = init.scene.add.graphics();
+    this.label = init.scene.add
+      .text(0, 20, "WIND 0.0", {
+        fontSize: "14px",
+        color: "#ffffff",
+        fontFamily: "system-ui, sans-serif",
+        stroke: "#000000",
+        strokeThickness: 2,
+      })
+      .setOrigin(0.5);
+    this.container.add([this.arrow, this.label]);
+    this.redraw(0);
+  }
+
+  update(): void {
+    const w = this.sim.getWind();
+    if (w !== this.lastWind) {
+      this.lastWind = w;
+      this.redraw(w);
+    }
+  }
+
+  destroy(): void {
+    this.container.destroy();
+  }
+
+  private redraw(wind: number): void {
+    this.arrow.clear();
+    this.label.setText(`WIND ${wind.toFixed(1)}`);
+    if (wind === 0) return;
+    const len = 40 * Math.abs(wind);
+    const dir = wind > 0 ? 1 : -1;
+    this.arrow.lineStyle(3, 0x88ccff, 1);
+    this.arrow.beginPath();
+    this.arrow.moveTo(-dir * 5, 0);
+    this.arrow.lineTo(dir * len, 0);
+    this.arrow.strokePath();
+    // Arrowhead
+    this.arrow.fillStyle(0x88ccff, 1);
+    this.arrow.beginPath();
+    this.arrow.moveTo(dir * len, 0);
+    this.arrow.lineTo(dir * (len - 8), -5);
+    this.arrow.lineTo(dir * (len - 8), 5);
+    this.arrow.closePath();
+    this.arrow.fillPath();
+  }
+}

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -25,6 +25,11 @@ export const DEFAULT_WORM_DENSITY = 1.0;
 export const DEFAULT_WORM_LINEAR_DAMPING = 0.1;
 export const DEFAULT_WALK_SPEED_MPS = 2.5;
 
+// Fall damage tuning - mirrors src/tuning.ts worm.fallDamageThresholdImpulse
+// and worm.fallDamageCapHp so server and client agree on the formula.
+const FALL_DAMAGE_THRESHOLD = 8;
+const FALL_DAMAGE_CAP_HP = 25;
+
 export interface WormInit {
   id: string;
   teamId: string;
@@ -86,6 +91,7 @@ export class Worm {
   private readonly footSensor: Fixture;
   private readonly walkSpeedMps: number;
   private walkingDir: -1 | 0 | 1 = 0;
+  private pendingFallImpulse = 0;
   // Jetpack fields are public so serialize/restore can round-trip them
   // without a separate API surface. Writes from outside are rare and
   // happen only on hibernation restore.
@@ -279,6 +285,7 @@ export class Worm {
     this.health = 0;
     this.alive = false;
     this.walkingDir = 0;
+    this.pendingFallImpulse = 0;
     this.jetPackActive = false;
     this.jetPackThrustV = false;
     this.jetPackThrustH = 0;
@@ -301,6 +308,38 @@ export class Worm {
   canJump(): boolean {
     const vel = this.body.getLinearVelocity();
     return this.footContactCount > 0 && Math.abs(vel.y) < 0.5;
+  }
+
+  /**
+   * Accumulate a contact impulse on this worm for this tick. Uses MAX not SUM
+   * so a worm resting on a slope (continuous small impulses from gravity) doesn't
+   * accrue phantom fall damage across ticks.
+   */
+  accumulateFallImpulse(impulse: number): void {
+    if (!this.alive) return;
+    if (!Number.isFinite(impulse) || impulse <= 0) return;
+    if (impulse > this.pendingFallImpulse) {
+      this.pendingFallImpulse = impulse;
+    }
+  }
+
+  /**
+   * Compute + apply any pending fall damage. Returns amount dealt (0 if below
+   * threshold or already dead). Called once per sim tick after world.step.
+   */
+  applyPendingFallDamage(): number {
+    const pending = this.pendingFallImpulse;
+    this.pendingFallImpulse = 0;
+    if (!this.alive || pending <= 0) return 0;
+    const density = DEFAULT_WORM_DENSITY;
+    const threshold = FALL_DAMAGE_THRESHOLD;
+    const maxDmg = FALL_DAMAGE_CAP_HP;
+    if (pending < threshold * density) return 0;
+    const excess = pending - threshold * density;
+    const scaled = excess * (maxDmg / (threshold * density));
+    const dmg = Math.min(maxDmg, Math.max(0, Math.round(scaled)));
+    if (dmg <= 0) return 0;
+    return this.takeDamage(dmg);
   }
 
   // ---- Serialisation ----

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -522,7 +522,10 @@ export class Room implements DurableObject {
       // activeWormId, turnEndsAt are merged in from the lobby at the
       // broadcast site below.
       let simTickEvents: SimEvent[] = [];
-      let simTickState: Pick<SimState, "tick" | "worms" | "projectiles"> | null = null;
+      let simTickState: Pick<
+        SimState,
+        "tick" | "worms" | "projectiles" | "wind" | "waterLevelPx"
+      > | null = null;
       if (lobby.phase === "playing" && this.sim) {
         this.drainInputs();
         const result = this.sim.tick(SIM_TICK_MS, lobby.currentWormId || null);
@@ -1044,7 +1047,28 @@ export class Room implements DurableObject {
       getAliveCountsProvider(): AliveCountsProvider | null {
         return self.sim;
       },
+      onTurnStart(): void {
+        self.onTurnStart();
+      },
     };
+  }
+
+  private onTurnStart(): void {
+    if (!this.sim || !this.lobby) return;
+    const turnSeq = this.lobby.turnSeq;
+
+    // Wind: random per turn, rounded to 0.1 precision.
+    const w = Math.round((Math.random() * 2 - 1) * 10) / 10;
+    this.sim.setWind(w);
+
+    // Sudden-death water: after turnSeq >= threshold, rise linearly.
+    const SUDDEN_DEATH_TURN = 15; // Mirror of tuning.water.suddenDeathTurn.
+    const RISE_PX_PER_TURN = 50; // Mirror of tuning.water.risePxPerTurn.
+    if (turnSeq >= SUDDEN_DEATH_TURN) {
+      const turnsIntoSuddenDeath = turnSeq - SUDDEN_DEATH_TURN;
+      const waterY = WORLD_HEIGHT_PX - turnsIntoSuddenDeath * RISE_PX_PER_TURN;
+      this.sim.setWaterLevel(Math.max(0, waterY));
+    }
   }
 
   private handleFinalLeave(sessionId: string): void {

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -372,12 +372,13 @@ export class Simulation {
       if (!worm.alive) continue;
       const dmg = worm.applyPendingFallDamage();
       if (dmg > 0) {
+        const pos = worm.body.getPosition();
         this.events.push({
           type: "damage_event",
           wormId: worm.id,
           amount: dmg,
           fromProjectileId: null,
-          impact: { x: 0, y: 0 },
+          impact: { x: toPixels(pos.x), y: toPixels(pos.y) },
         });
         if (!worm.alive && !this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -21,14 +21,19 @@
  * and drains them right before calling tick().
  */
 
-import type { Contact } from "planck";
+import type { Contact, ContactImpulse } from "planck";
 import {
   Projectile,
   type ProjectileRenderState,
   type ProjectileUserData,
 } from "../entities/projectile.js";
 import { Terrain } from "../entities/terrain.js";
-import { Worm, type WormFootUserData, type WormRenderState } from "../entities/worm.js";
+import {
+  Worm,
+  type WormFootUserData,
+  type WormRenderState,
+  type WormUserData,
+} from "../entities/worm.js";
 import { toPixels } from "../physics/scale.js";
 import { createPhysicsWorld } from "../physics/world.js";
 import type { PlanckWorld } from "../physics/world.js";
@@ -149,6 +154,7 @@ export class Simulation {
   private events: SimEvent[] = [];
   /** Worms already marked dead this tick; dedupes worm_died events. */
   private readonly diedThisTick = new Set<string>();
+  private onPostSolve: ((contact: Contact, impulse: ContactImpulse) => void) | null = null;
 
   constructor(init: SimulationInit) {
     this.widthPx = init.widthPx;
@@ -178,6 +184,8 @@ export class Simulation {
     }
 
     this.world.on("begin-contact", this.onBeginContact);
+    this.onPostSolve = this.handlePostSolve.bind(this);
+    this.world.on("post-solve", this.onPostSolve);
   }
 
   /** Destroy listeners + free planck resources. */
@@ -186,6 +194,14 @@ export class Simulation {
       this.world.off("begin-contact", this.onBeginContact);
     } catch {
       // planck contract: off() may no-op after world is GC'd
+    }
+    if (this.onPostSolve) {
+      try {
+        this.world.off("post-solve", this.onPostSolve);
+      } catch {
+        // planck contract: off() may no-op after world is GC'd
+      }
+      this.onPostSolve = null;
     }
   }
 
@@ -330,6 +346,27 @@ export class Simulation {
     // 1. Step world. planck does fixed-step internally via the passed
     //    timestep; 50ms is a single step at 20Hz.
     this.world.step(dtMs / 1000, 8, 3);
+
+    // 1a. Fall damage: post-solve listeners have accumulated per-contact
+    //     impulses during world.step. Apply them now, before detonation
+    //     processing so we don't double-emit worm_died.
+    for (const worm of this.worms.values()) {
+      if (!worm.alive) continue;
+      const dmg = worm.applyPendingFallDamage();
+      if (dmg > 0) {
+        this.events.push({
+          type: "damage_event",
+          wormId: worm.id,
+          amount: dmg,
+          fromProjectileId: null,
+          impact: { x: 0, y: 0 },
+        });
+        if (!worm.alive && !this.diedThisTick.has(worm.id)) {
+          this.diedThisTick.add(worm.id);
+          this.events.push({ type: "worm_died", wormId: worm.id });
+        }
+      }
+    }
 
     // 2. Process pending contact detonations.
     for (const proj of this.pendingDetonate) {
@@ -593,6 +630,36 @@ export class Simulation {
       }
     }
   };
+
+  private handlePostSolve(contact: Contact, impulse: ContactImpulse): void {
+    const normalImpulse = impulse.normalImpulses[0] ?? 0;
+    if (normalImpulse <= 0) return;
+    const fA = contact.getFixtureA();
+    const fB = contact.getFixtureB();
+    // WormUserData is set on the body (this.body.setUserData) not the fixture.
+    // ProjectileUserData is also set on the body.
+    const bodyUdA = fA.getBody().getUserData() as
+      | WormUserData
+      | WormFootUserData
+      | { kind?: string }
+      | null;
+    const bodyUdB = fB.getBody().getUserData() as
+      | WormUserData
+      | WormFootUserData
+      | { kind?: string }
+      | null;
+    // Skip contacts involving projectiles (handled via detonation).
+    if (bodyUdA?.kind === "projectile" || bodyUdB?.kind === "projectile") return;
+    // Accumulate fall impulse on worm bodies. kind === "worm" is the main body
+    // userData set in the Worm constructor. The foot sensor fixture shares the
+    // same body so kind will also be "worm" - that's fine since we want the
+    // body-level tracking. Sensors don't participate in physics resolution so
+    // post-solve won't fire for them anyway.
+    if (bodyUdA?.kind === "worm")
+      (bodyUdA as WormUserData).worm.accumulateFallImpulse(normalImpulse);
+    if (bodyUdB?.kind === "worm")
+      (bodyUdB as WormUserData).worm.accumulateFallImpulse(normalImpulse);
+  }
 
   private snapshotWormPositions(): Map<string, { x: number; y: number }> {
     const out = new Map<string, { x: number; y: number }>();

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -29,7 +29,7 @@ import {
 } from "../entities/projectile.js";
 import { Terrain } from "../entities/terrain.js";
 import { Worm, type WormFootUserData, type WormRenderState } from "../entities/worm.js";
-import { toPixels } from "../physics/scale.js";
+import { toMeters, toPixels } from "../physics/scale.js";
 import { createPhysicsWorld } from "../physics/world.js";
 import type { PlanckWorld } from "../physics/world.js";
 import { type ExplodeResult, explode } from "../weapons/explode.js";
@@ -81,6 +81,8 @@ export interface SimState {
   tick: number;
   worms: WormRenderState[];
   projectiles: ProjectileRenderState[];
+  wind: number;
+  waterLevelPx: number;
 }
 
 export interface SimTeamInit {
@@ -132,6 +134,8 @@ export interface SerializedSim {
     fuseRemainingMs: number | null;
   }>;
   terrainCutSeq: number;
+  wind: number;
+  waterLevelPx: number;
 }
 
 export class Simulation {
@@ -149,6 +153,10 @@ export class Simulation {
   private events: SimEvent[] = [];
   /** Worms already marked dead this tick; dedupes worm_died events. */
   private readonly diedThisTick = new Set<string>();
+  /** Wind strength -1..1. Applied as horizontal force on in-flight projectiles each tick. */
+  private wind = 0;
+  /** Water level in pixels. Number.MAX_SAFE_INTEGER = no water (sentinel). */
+  private waterLevelPx = Number.MAX_SAFE_INTEGER;
 
   constructor(init: SimulationInit) {
     this.widthPx = init.widthPx;
@@ -187,6 +195,16 @@ export class Simulation {
     } catch {
       // planck contract: off() may no-op after world is GC'd
     }
+  }
+
+  // ---- Wind + water controls ----
+
+  setWind(w: number): void {
+    this.wind = Math.max(-1, Math.min(1, w));
+  }
+
+  setWaterLevel(yPx: number): void {
+    this.waterLevelPx = Math.max(0, yPx);
   }
 
   // ---- Input application (called after validating active player) ----
@@ -341,6 +359,16 @@ export class Simulation {
     for (const proj of this.projectiles) {
       if (proj.detonated) continue;
       proj.tick(dtMs);
+      // Wind: apply horizontal force per tick to in-flight projectiles.
+      // WIND_FORCE is Newtons per unit wind; tunable in src/tuning.ts.
+      if (this.wind !== 0) {
+        const WIND_FORCE = 2; // Mirror of tuning.wind.forceNewtonsPerUnit.
+        proj.body.applyForce(
+          { x: this.wind * WIND_FORCE, y: 0 },
+          proj.body.getWorldCenter(),
+          true, // wake
+        );
+      }
       if (proj.shouldDetonate()) {
         this.detonateProjectile(proj, "fuse");
       }
@@ -375,15 +403,42 @@ export class Simulation {
       }
     }
 
-    // 6. Drain terrain cut log. Currently every cut is authored via
+    // 6. Water drown: rising water level kills worms below the surface.
+    //    Shares diedThisTick with the off-map floor so a worm at the
+    //    corner doesn't double-emit worm_died.
+    if (this.waterLevelPx !== Number.MAX_SAFE_INTEGER) {
+      const waterY = toMeters(this.waterLevelPx);
+      for (const worm of this.worms.values()) {
+        if (!worm.alive) continue;
+        const pos = worm.body.getPosition();
+        if (pos.y > waterY) {
+          worm.kill();
+          if (!this.diedThisTick.has(worm.id)) {
+            this.diedThisTick.add(worm.id);
+            this.events.push({ type: "worm_died", wormId: worm.id });
+            this.events.push({
+              type: "damage_event",
+              wormId: worm.id,
+              amount: 999,
+              fromProjectileId: null,
+              impact: { x: toPixels(pos.x), y: toPixels(pos.y) },
+            });
+          }
+        }
+      }
+    }
+
+    // 7. Drain terrain cut log. Currently every cut is authored via
     //    explode() which also emits its own terrain_cut SimEvent, so
     //    the log entries are redundant. Drain to keep the log from
     //    growing unbounded.
     this.terrain.consumeCutLog();
 
     // stateChanged: always true when playing (worms + projectiles
-    // move). Cheap heuristic: events non-empty OR any worm moved.
-    const stateChanged = this.events.length > 0 || this.wormsMoved(beforeWormPositions);
+    // move). Cheap heuristic: events non-empty OR any worm moved OR
+    // projectiles in flight (they drift under gravity + wind each tick).
+    const stateChanged =
+      this.events.length > 0 || this.wormsMoved(beforeWormPositions) || this.projectiles.length > 0;
 
     this.tickCount += 1;
     const emittedEvents = this.events;
@@ -402,7 +457,13 @@ export class Simulation {
     for (const w of this.worms.values()) worms.push(w.toRenderState());
     const projectiles: ProjectileRenderState[] = [];
     for (const p of this.projectiles) projectiles.push(p.toRenderState());
-    return { tick: this.tickCount, worms, projectiles };
+    return {
+      tick: this.tickCount,
+      worms,
+      projectiles,
+      wind: this.wind,
+      waterLevelPx: this.waterLevelPx,
+    };
   }
 
   serialize(): SerializedSim {
@@ -445,6 +506,8 @@ export class Simulation {
         fuseRemainingMs: p.fuseRemainingMs,
       })),
       terrainCutSeq: 0,
+      wind: this.wind,
+      waterLevelPx: this.waterLevelPx,
     };
   }
 
@@ -475,6 +538,8 @@ export class Simulation {
       worm.jetPackThrustV = ws.jetPackThrustV ?? false;
       worm.jetPackThrustH = ws.jetPackThrustH ?? 0;
     }
+    this.wind = state.wind ?? 0;
+    this.waterLevelPx = state.waterLevelPx ?? Number.MAX_SAFE_INTEGER;
     // Clear any bodies we pre-created for projectiles (we didn't).
     for (const ps of state.projectiles) {
       const weapon = getById(ps.weaponId);

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -158,12 +158,27 @@ export class TurnArbiter {
 
   /**
    * Called by the Room immediately after a fire input is processed.
-   * Advances the turn on the next alarm tick (the projectile needs
-   * to land + settle first). For now this is a no-op - the settle
-   * grace check in onTick will handle it.
+   * Shortens turnEndsAt to +5s so players can reposition (retreat window)
+   * before the full 45s turn timer expires.
+   *
+   * Guarded against the paused state (pausedRemainingMs !== null): a fire
+   * during owner-disconnect grace must not stomp the MAX_SAFE_INTEGER
+   * sentinel - pausedRemainingMs is the source of truth during pause.
+   *
+   * Only shortens, never extends: if somehow turnEndsAt is already closer
+   * than 5s (e.g. rapid fire at end of turn), we leave it alone.
    */
   onFireCommitted(): void {
-    // Placeholder; v1 relies on the settle grace timeout.
+    if (this.gameOver) return;
+    // Never touch turnEndsAt while paused; the sentinel is MAX_SAFE_INTEGER
+    // and pausedRemainingMs is the source of truth.
+    if (this.pausedRemainingMs !== null) return;
+    const RETREAT_WINDOW_MS = 5_000; // mirrors tuning.retreat.windowMs
+    const retreatEnd = Date.now() + RETREAT_WINDOW_MS;
+    // Only shorten - never extend.
+    if (retreatEnd < this.room.state.turnEndsAt) {
+      this.room.state.turnEndsAt = retreatEnd;
+    }
   }
 
   /**

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -67,8 +67,6 @@ export interface ArbiterPersistedState {
   pausedRemainingMs: number | null;
   /** teamId -> next worm cursor index. */
   teamWormCursor: Record<string, number>;
-  /** True once sudden-death water has been triggered. */
-  suddenDeathStarted: boolean;
 }
 
 export class TurnArbiter {
@@ -81,7 +79,6 @@ export class TurnArbiter {
   private turnDurationMs = 0;
   private pausedRemainingMs: number | null = null;
   private pendingAdvance = false;
-  private suddenDeathStarted = false;
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
@@ -94,7 +91,6 @@ export class TurnArbiter {
       gameOver: this.gameOver,
       pausedRemainingMs: this.pausedRemainingMs,
       teamWormCursor: Object.fromEntries(this.teamWormCursor),
-      suddenDeathStarted: this.suddenDeathStarted,
     };
   }
 
@@ -110,7 +106,6 @@ export class TurnArbiter {
     arbiter.gameOver = state.gameOver;
     arbiter.pausedRemainingMs = state.pausedRemainingMs;
     arbiter.teamWormCursor = new Map(Object.entries(state.teamWormCursor));
-    arbiter.suddenDeathStarted = state.suddenDeathStarted ?? false;
     return arbiter;
   }
 

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -43,6 +43,8 @@ export interface ArbiterRoomAdapter {
   getPlayerDisconnected(sessionId: string): boolean;
   /** Source of authoritative alive counts. Set when the Simulation is ready. */
   getAliveCountsProvider(): AliveCountsProvider | null;
+  /** Called when a new turn starts (first turn via start(), subsequent via advanceTurn()). */
+  onTurnStart?: () => void;
 }
 
 /** One roster entry per team. Populated at start_game, immutable after. */
@@ -65,6 +67,8 @@ export interface ArbiterPersistedState {
   pausedRemainingMs: number | null;
   /** teamId -> next worm cursor index. */
   teamWormCursor: Record<string, number>;
+  /** True once sudden-death water has been triggered. */
+  suddenDeathStarted: boolean;
 }
 
 export class TurnArbiter {
@@ -77,6 +81,7 @@ export class TurnArbiter {
   private turnDurationMs = 0;
   private pausedRemainingMs: number | null = null;
   private pendingAdvance = false;
+  private suddenDeathStarted = false;
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
@@ -89,6 +94,7 @@ export class TurnArbiter {
       gameOver: this.gameOver,
       pausedRemainingMs: this.pausedRemainingMs,
       teamWormCursor: Object.fromEntries(this.teamWormCursor),
+      suddenDeathStarted: this.suddenDeathStarted,
     };
   }
 
@@ -104,6 +110,7 @@ export class TurnArbiter {
     arbiter.gameOver = state.gameOver;
     arbiter.pausedRemainingMs = state.pausedRemainingMs;
     arbiter.teamWormCursor = new Map(Object.entries(state.teamWormCursor));
+    arbiter.suddenDeathStarted = state.suddenDeathStarted ?? false;
     return arbiter;
   }
 
@@ -127,6 +134,7 @@ export class TurnArbiter {
     this.room.state.currentWormId = this.pickNextWormInTeam(firstTeamId);
     this.room.state.turnSeq = 1;
     this.room.state.turnEndsAt = Date.now() + turnDurationMs;
+    this.fireTurnStart();
   }
 
   /**
@@ -240,6 +248,10 @@ export class TurnArbiter {
 
   // ---- private ----
 
+  private fireTurnStart(): void {
+    this.room.onTurnStart?.();
+  }
+
   private teamAliveCount(teamId: string): number {
     if (this.forfeitedTeams.has(teamId)) return 0;
     const provider = this.room.getAliveCountsProvider();
@@ -292,6 +304,7 @@ export class TurnArbiter {
     this.room.state.turnSeq += 1;
     this.room.state.turnEndsAt = Date.now() + this.turnDurationMs;
     this.pausedRemainingMs = null;
+    this.fireTurnStart();
   }
 
   private pickNextWormInTeam(teamId: string): string {

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -368,6 +368,61 @@ describe("Simulation - fire / cut / damage", () => {
   });
 });
 
+describe("Simulation - wind and water", () => {
+  it("wind pushes a projectile horizontally", () => {
+    const sim = makeSim(twoTeams());
+    // Settle worms.
+    for (let i = 0; i < 20; i++) sim.tick(50);
+
+    // Fire a bazooka aimed sharply upward so it stays in flight long enough
+    // for wind to accumulate horizontal drift. Aim nearly straight up.
+    sim.applyAimAngle("Red-1", -Math.PI / 2 + 0.1); // nearly straight up
+    sim.applyAimPower("Red-1", 0.5);
+    sim.applySelectWeapon("Red-1", "bazooka");
+    sim.applyFire("Red-1");
+
+    // Record x position of the projectile right after spawn.
+    const stateAfterFire = sim.toSimState();
+    const projAfterFire = stateAfterFire.projectiles[0];
+    expect(projAfterFire).toBeDefined();
+    const startX = projAfterFire?.x ?? 0;
+
+    // Apply strong rightward wind and tick 30 frames.
+    sim.setWind(1);
+    for (let i = 0; i < 30; i++) sim.tick(50);
+
+    const stateAfterWind = sim.toSimState();
+    // wind should be reflected in toSimState().
+    expect(stateAfterWind.wind).toBe(1);
+
+    // If projectile is still in flight, it should have drifted right (x increased).
+    const projAfterWind = stateAfterWind.projectiles.find(
+      (p: { id: string }) => p.id === projAfterFire?.id,
+    );
+    if (projAfterWind) {
+      expect((projAfterWind as { x: number }).x).toBeGreaterThan(startX);
+    }
+  });
+
+  it("water drowns a worm below the water level", () => {
+    const sim = makeSim(twoTeams());
+    // Settle.
+    for (let i = 0; i < 20; i++) sim.tick(50);
+
+    // Worms spawn at FLOOR_Y - 40px (FLOOR_Y = 612, so ~572px y coordinate).
+    // Setting waterLevelPx to 200 places the water surface at y=200.
+    // Since worms are at y~572 > 200, they are below the water surface.
+    sim.setWaterLevel(200);
+    const result = sim.tick(50);
+
+    const drowned = result.events.find(
+      (e: { type: string; wormId?: string }) => e.type === "worm_died" && e.wormId === "Red-1",
+    );
+    expect(drowned).toBeDefined();
+    expect(requireWorm(sim, "Red-1").alive).toBe(false);
+  });
+});
+
 describe("Simulation - serialize/restore", () => {
   it("serialize + restore reproduces worm positions + health", () => {
     const sim1 = makeSim(twoTeams());
@@ -392,6 +447,24 @@ describe("Simulation - serialize/restore", () => {
       expect(w2?.y).toBeCloseTo(w.y, 3);
       expect(w2?.hp).toBe(w.hp);
     }
+  });
+
+  it("serialize + restore preserves wind and waterLevelPx", () => {
+    const sim1 = makeSim(twoTeams());
+    for (let i = 0; i < 5; i++) sim1.tick(50);
+
+    sim1.setWind(0.7);
+    sim1.setWaterLevel(500);
+
+    const serialized = sim1.serialize();
+    expect(serialized.wind).toBe(0.7);
+    expect(serialized.waterLevelPx).toBe(500);
+
+    const sim2 = makeSim(twoTeams());
+    sim2.restore(serialized);
+    const state = sim2.toSimState();
+    expect(state.wind).toBe(0.7);
+    expect(state.waterLevelPx).toBe(500);
   });
 });
 

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -217,6 +217,34 @@ describe("Simulation - movement", () => {
     expect(resetState.jetPackFuel).toBe(100);
     expect(resetState.jetPackActive).toBe(false);
   });
+
+  it("fall damage: worm takes damage on hard landing", () => {
+    // Let the worm settle, then teleport it well above the floor and release.
+    // Physics: threshold impulse = 8 * density (8 * 1.0 = 8).
+    // Worm mass ≈ pi * (0.4m)^2 * 1.0 ≈ 0.50 kg.
+    // Need v > 8 / 0.50 ≈ 16 m/s on impact -> h > v^2/(2g) = 256/20 = 12.8m.
+    // Use 20m drop to ensure we clear the threshold with margin.
+    for (let i = 0; i < 20; i++) sim.tick(50);
+    const worm = requireWorm(sim, "Red-1");
+    const hpBefore = worm.health;
+    const pos = worm.body.getPosition();
+    worm.body.setPosition({ x: pos.x, y: pos.y - 20 }); // 20m above current position
+    worm.body.setLinearVelocity({ x: 0, y: 0 });
+    // Tick until it lands + fall damage applies (20m at g=10 takes ~2s, 40 ticks + buffer).
+    for (let i = 0; i < 80; i++) sim.tick(50, "Red-1");
+    const hpAfter = requireWorm(sim, "Red-1").health;
+    expect(hpAfter).toBeLessThan(hpBefore);
+  });
+
+  it("fall damage: resting worm takes no damage", () => {
+    // Settle + tick for a while - contact impulse from gravity each tick
+    // should NOT accumulate into phantom damage.
+    for (let i = 0; i < 20; i++) sim.tick(50);
+    const hpBefore = requireWorm(sim, "Red-1").health;
+    for (let i = 0; i < 100; i++) sim.tick(50, "Red-1");
+    const hpAfter = requireWorm(sim, "Red-1").health;
+    expect(hpAfter).toBe(hpBefore);
+  });
 });
 
 describe("Simulation - fire / cut / damage", () => {

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -236,4 +236,55 @@ describe("TurnArbiter", () => {
     arbiter.onTeamForfeit("red");
     expect(arbiter.isGameOver()).toBe(true);
   });
+
+  it("onFireCommitted shortens turnEndsAt to +5s", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    const before = room.state.turnEndsAt;
+    // turnEndsAt starts at now + 45s; +5s retreat window should shorten it.
+    arbiter.onFireCommitted();
+    const after = room.state.turnEndsAt;
+    expect(after).toBeLessThan(before); // shortened
+    expect(after - Date.now()).toBeLessThanOrEqual(5000 + 50); // within 5s window (+tolerance)
+  });
+
+  it("onFireCommitted is a no-op when paused", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    // Pause via owner disconnect; turnEndsAt becomes MAX_SAFE_INTEGER.
+    arbiter.onOwnerDisconnected("alice");
+    expect(room.state.turnEndsAt).toBe(Number.MAX_SAFE_INTEGER);
+
+    // onFireCommitted must not stomp the sentinel.
+    arbiter.onFireCommitted();
+    expect(room.state.turnEndsAt).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("onFireCommitted does not extend an already-short turnEndsAt", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    // Manually set turnEndsAt to 1s from now (already short).
+    room.state.turnEndsAt = Date.now() + 1_000;
+    const shortened = room.state.turnEndsAt;
+
+    arbiter.onFireCommitted();
+    // Should NOT have extended it - 1s < 5s so retreat window would extend it,
+    // but the guard prevents extension.
+    expect(room.state.turnEndsAt).toBe(shortened);
+  });
 });

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -41,6 +41,7 @@ class StubRoom implements ArbiterRoomAdapter {
   connected = new Set<string>();
   disconnectedPlayers = new Set<string>();
   provider = new StubAliveCountsProvider();
+  turnStartCount = 0;
 
   broadcast(type: string, payload: unknown): void {
     this.broadcasts.push({ type, payload });
@@ -53,6 +54,9 @@ class StubRoom implements ArbiterRoomAdapter {
   }
   getAliveCountsProvider(): AliveCountsProvider | null {
     return this.provider;
+  }
+  onTurnStart(): void {
+    this.turnStartCount += 1;
   }
 }
 
@@ -235,5 +239,23 @@ describe("TurnArbiter", () => {
     expect(arbiter.isGameOver()).toBe(false);
     arbiter.onTeamForfeit("red");
     expect(arbiter.isGameOver()).toBe(true);
+  });
+
+  it("onTurnStart fires once on start() and once per advanceTurn()", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+    // start() fires onTurnStart once.
+    expect(room.turnStartCount).toBe(1);
+
+    // Force timer elapsed, trigger advance.
+    room.state.turnEndsAt = Date.now() - 10_000;
+    arbiter.onTick(50);
+    // advanceTurn() fires onTurnStart again.
+    expect(room.turnStartCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Part of the playtest-ready MVP focus. Bundles three environmental mechanics so the nine-weapon core finally reads as Worms, not a prototype.

### WS1 — Wind + Water (closes #19, #20)
- **Wind**: per-turn random -1..1, applied as horizontal force on in-flight projectiles each sim tick. `WindHUD` renders a directional arrow + magnitude bar top-center below the turn timer.
- **Water**: sudden-death trigger at turn 15, water level rises 50px per turn. Worm below the line dies instantly and emits a `damage_event` (at the worm's position) so the client can render a splash VFX. `WaterRenderer` draws a semi-transparent blue fill below terrain.
- `SimState` gains required `wind: number` and `waterLevelPx: number`. Sentinel for "no water" is `Number.MAX_SAFE_INTEGER` (JSON-safe, unlike `Infinity`).
- Both fields persist across DO hibernation with `?? 0` / `?? MAX_SAFE_INTEGER` defaults.
- `TurnArbiter` gains an `onTurnStart` callback fired from both `start()` and `advanceTurn()` so Room can pick wind + escalate water.
- Offline mode returns wind=0, no water — documented.
- `stateChanged` heuristic extended to broadcast when projectiles exist so wind-drift arcs render correctly.

### WS2 — Fall damage + retreat window (closes #21)
- Server `Worm` ports `fallDamageFromImpulse` from the client. Post-solve contact listener on the physics world accumulates normal impulses per tick using MAX (not SUM — avoids phantom damage from resting contact). Tick applies pending damage and emits `damage_event`/`worm_died`. UserData read from the body (not the fixture) — project convention.
- `TurnArbiter.onFireCommitted` shortens `turnEndsAt` to +5s retreat window, guarded against pause (pausedRemainingMs !== null) and only ever shortening.

## Bug Check

Ran inline. Two Medium findings, resolved in commit \`5302e99\`:

- **M1** fall-damage `damage_event` impact coord was \`{x:0,y:0}\`; now uses worm pixel position so the client splash renders at the correct place.
- **M2** removed \`suddenDeathStarted\` dead state — set/persisted/restored but never consulted.

False positives triaged: \`turnSeq\` at fireTurnStart correctly represents the current active turn (not off-by-one). Other checks clean.

Tunable constants live in \`src/tuning.ts\` per project convention.

## Test plan

- [ ] Fire a bazooka in a strong wind; arc bends visibly
- [ ] Fire in 0 wind; arc is symmetric
- [ ] Play ≥15 turns and watch water begin rising from the floor
- [ ] Fall off a cliff — HP drops; land gently — HP unchanged
- [ ] Fire a weapon → turn timer shortens to ~5s (retreat window)
- [ ] Disconnect during fire — timer stays paused (retreat doesn't stomp the pause sentinel)

Closes #19
Closes #20
Closes #21
Closes #83