### PR TITLE
fix: wire setFacing over the wire in networked mode

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -296,6 +296,7 @@ export type ClientMsg =
   | { type: "input_backflip"; seq: number }
   | { type: "input_aim_angle"; angleRad: number; seq: number }
   | { type: "input_aim_power"; power: number; seq: number }
+  | { type: "input_facing"; dir: -1 | 1; seq: number }
   | { type: "input_select_weapon"; weaponId: string; seq: number }
   | { type: "input_fire"; seq: number }
   | { type: "input_end_turn"; seq: number }

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -225,10 +225,12 @@ export class NetworkedSimAdapter implements SimAdapter {
     this.maybeFlushAim();
   }
 
-  setFacing(_dir: -1 | 1): void {
-    // Facing is derived from the server sim (from the last walk dir applied
-    // server-side). Client does not own facing authoritatively in networked
-    // mode. Intentional no-op.
+  setFacing(dir: -1 | 1): void {
+    // Send an explicit facing input so drag-to-aim can flip the worm to face
+    // the slingshot direction. Without this the server would keep the facing
+    // set by the last walk input, causing the fire direction to ignore the
+    // drag side.
+    this.send({ type: "input_facing", dir, seq: this.nextSeq() });
   }
 
   selectWeapon(id: string): void {

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -77,6 +77,7 @@ type PendingInput =
   | { kind: "backflip"; sessionId: string }
   | { kind: "aim_angle"; sessionId: string; angleRad: number }
   | { kind: "aim_power"; sessionId: string; power: number }
+  | { kind: "facing"; sessionId: string; dir: -1 | 1 }
   | { kind: "select_weapon"; sessionId: string; weaponId: string }
   | { kind: "fire"; sessionId: string }
   | { kind: "jetpack_toggle"; sessionId: string }
@@ -426,6 +427,7 @@ export class Room implements DurableObject {
       case "input_backflip":
       case "input_aim_angle":
       case "input_aim_power":
+      case "input_facing":
       case "input_select_weapon":
       case "input_fire":
       case "input_end_turn":
@@ -842,6 +844,16 @@ export class Room implements DurableObject {
         });
         return;
       }
+      case "input_facing": {
+        const dir = raw.dir;
+        if (dir !== -1 && dir !== 1) return;
+        this.pendingInputs.push({
+          kind: "facing",
+          sessionId: senderSessionId,
+          dir,
+        });
+        return;
+      }
       case "input_select_weapon": {
         const weaponId = raw.weaponId;
         if (typeof weaponId !== "string") return;
@@ -910,6 +922,9 @@ export class Room implements DurableObject {
           break;
         case "aim_power":
           this.sim.applyAimPower(activeWormId, input.power);
+          break;
+        case "facing":
+          this.sim.applyFacing(activeWormId, input.dir);
           break;
         case "select_weapon":
           this.sim.applySelectWeapon(activeWormId, input.weaponId);


### PR DESCRIPTION
Slingshot aim was broken in networked mode because `NetworkedSimAdapter.setFacing` was a no-op. Server kept the facing from the last walk, so fire direction was same-direction-as-pull whenever the last walk didn't happen to align with the slingshot flip direction. Presented as red-only one game, blue-only the next.

Adds `input_facing` message + wires it through the Room drain path and the existing Simulation.applyFacing method.