### PR TITLE
fix: one-shot fire gate + UI position collisions

### DIFF
--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -53,17 +53,20 @@ export class TouchControls {
 
     const { getActiveWorm } = init;
     const radius = tuning.touch.buttonRadiusPx;
-    const sw = this.scene.scale.width;
+    // End-turn button occupies the top-right 80px square (TurnHUD). Stack rope
+    // + jet along the LEFT edge so neither their tap areas nor the End button's
+    // hit area overlap.
+    const leftX = 60;
 
     if (ropeEnabled) {
-      // --- Rope button (top-right, inboard) ---
+      // --- Rope button (top-left) ---
       const ropeBtn = this._makeButton({
         fillColor: 0x2266cc,
         strokeColor: 0x88aaff,
         label: "R",
         radius,
       });
-      ropeBtn.setPosition(sw - 60 - (radius * 2 + 10), 60);
+      ropeBtn.setPosition(leftX, 60);
       this.ropeBtn = ropeBtn;
       this.container.add(ropeBtn);
 
@@ -81,14 +84,16 @@ export class TouchControls {
     }
 
     if (jetPackEnabled) {
-      // --- JetPack button (top-right corner) ---
+      // --- JetPack button (top-left, right of rope) ---
       const jetBtn = this._makeButton({
         fillColor: 0xcc6600,
         strokeColor: 0xff9933,
         label: "J",
         radius,
       });
-      jetBtn.setPosition(sw - 60, 60);
+      // Offset by rope's footprint (+10px gap) even if rope is disabled, so
+      // the jet button sits at the same absolute position in both modes.
+      jetBtn.setPosition(leftX + radius * 2 + 10, 60);
       this.jetBtn = jetBtn;
       this.container.add(jetBtn);
 

--- a/src/ui/WindHUD.ts
+++ b/src/ui/WindHUD.ts
@@ -23,7 +23,9 @@ export class WindHUD {
   constructor(init: WindHUDInit) {
     this.sim = init.sim;
     const sw = init.scene.scale.width;
-    this.container = init.scene.add.container(sw / 2, 90);
+    // y=140 sits below the SpectatorHUD banner (at y=90) so the two don't
+    // overlap when a spectator is watching and wind is non-zero.
+    this.container = init.scene.add.container(sw / 2, 140);
     this.container.setDepth(100);
     this.container.setScrollFactor(0);
     this.arrow = init.scene.add.graphics();

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -930,8 +930,11 @@ export class Room implements DurableObject {
           this.sim.applySelectWeapon(activeWormId, input.weaponId);
           break;
         case "fire":
+          // Reject if arbiter says no: already fired, paused, past timer, or
+          // game over. Prevents double-fire within a turn and post-timer sneaks.
+          if (!this.arbiter?.canFire()) break;
           this.sim.applyFire(activeWormId);
-          this.arbiter?.onFireCommitted();
+          this.arbiter.onFireCommitted();
           break;
         case "jetpack_toggle":
           this.sim.applyJetPackToggle(activeWormId);

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -79,6 +79,7 @@ export class TurnArbiter {
   private turnDurationMs = 0;
   private pausedRemainingMs: number | null = null;
   private pendingAdvance = false;
+  private hasFiredThisTurn = false;
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
@@ -176,12 +177,27 @@ export class TurnArbiter {
     // Never touch turnEndsAt while paused; the sentinel is MAX_SAFE_INTEGER
     // and pausedRemainingMs is the source of truth.
     if (this.pausedRemainingMs !== null) return;
+    this.hasFiredThisTurn = true;
     const RETREAT_WINDOW_MS = 5_000; // mirrors tuning.retreat.windowMs
     const retreatEnd = Date.now() + RETREAT_WINDOW_MS;
     // Only shorten - never extend.
     if (retreatEnd < this.room.state.turnEndsAt) {
       this.room.state.turnEndsAt = retreatEnd;
     }
+  }
+
+  /**
+   * Gate for the Room's fire input drain. Rejects if the game is over, the
+   * turn is paused, the active worm already fired this turn (one-shot per
+   * turn), or the turn timer has elapsed (past settle-grace inputs are
+   * ignored so the player can't sneak another fire after the timer hits 0).
+   */
+  canFire(): boolean {
+    if (this.gameOver) return false;
+    if (this.pausedRemainingMs !== null) return false;
+    if (this.hasFiredThisTurn) return false;
+    if (Date.now() > this.room.state.turnEndsAt) return false;
+    return true;
   }
 
   /**
@@ -259,6 +275,7 @@ export class TurnArbiter {
   // ---- private ----
 
   private fireTurnStart(): void {
+    this.hasFiredThisTurn = false;
     this.room.onTurnStart?.();
   }
 


### PR DESCRIPTION
Four bugs from the last playtest:

- **#3** can fire twice per turn -> new canFire() gate in TurnArbiter, set on onFireCommitted, reset on turn start. Room.drainInputs checks it before applying.
- **#5** can still shoot after timer hits 0 -> canFire also rejects when `Date.now() > turnEndsAt`.
- **#2** J button covered by End button -> rope + jet moved from top-right to top-left.
- **#4** WindHUD overlaps 'waiting for player' banner -> WindHUD moved from y=90 to y=140.

Rematch screen (#1) coming as a separate PR.