### PR TITLE
feat: rematch via Back-to-lobby button

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -297,6 +297,7 @@ export type ClientMsg =
   | { type: "input_aim_angle"; angleRad: number; seq: number }
   | { type: "input_aim_power"; power: number; seq: number }
   | { type: "input_facing"; dir: -1 | 1; seq: number }
+  | { type: "input_return_to_lobby"; seq: number }
   | { type: "input_select_weapon"; weaponId: string; seq: number }
   | { type: "input_fire"; seq: number }
   | { type: "input_end_turn"; seq: number }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -122,6 +122,7 @@ export class GameScene extends Phaser.Scene {
   private currentRoomCode = "";
   private disconnectTick: Phaser.Time.TimerEvent | null = null;
   private roomUnsubs: Array<() => void> = [];
+  private returnToLobbyObjects: Phaser.GameObjects.GameObject[] = [];
 
   // ---- Offline-mode WeaponManager map (built per-team) ----
   // Networked mode: ammo + select state arrive via sim_state.worms[].ammoLeft.
@@ -547,6 +548,60 @@ export class GameScene extends Phaser.Scene {
     this.spectatorHUD?.hide();
     const winner = this.sim.teams.find((t) => t.id === winnerTeamId) ?? null;
     this.turnHUD?.showGameOver(winner?.name ?? null);
+    if (this.isNetworked) this.showReturnToLobbyControl();
+  }
+
+  /**
+   * After game_over in networked mode, show a "Back to lobby" affordance:
+   * the host sees a clickable button that sends input_return_to_lobby;
+   * non-host players see a waiting line. Phase transition back to LobbyScene
+   * is driven by the server's state broadcast (handled elsewhere).
+   */
+  private showReturnToLobbyControl(): void {
+    if (!this.room) return;
+    const mySid = this.mySessionId;
+    const me = mySid ? this.room.state?.players?.[mySid] : undefined;
+    const iAmHost = !!me?.isHost;
+    const cx = this.scale.width / 2;
+    const cy = this.scale.height / 2 + 60;
+
+    if (!iAmHost) {
+      const waitText = this.add
+        .text(cx, cy, "Waiting for host to return to lobby...", {
+          fontSize: "16px",
+          color: "#ffffff",
+          fontFamily: "system-ui, sans-serif",
+          stroke: "#000000",
+          strokeThickness: 2,
+        })
+        .setOrigin(0.5)
+        .setDepth(200)
+        .setScrollFactor(0);
+      this.returnToLobbyObjects.push(waitText);
+      return;
+    }
+
+    const gfx = this.add.graphics().setDepth(200).setScrollFactor(0);
+    gfx.fillStyle(0x2266cc, 1);
+    gfx.fillRoundedRect(cx - 110, cy - 22, 220, 44, 8);
+    gfx.lineStyle(2, 0x88aaff, 1);
+    gfx.strokeRoundedRect(cx - 110, cy - 22, 220, 44, 8);
+    const btnText = this.add
+      .text(cx, cy, "Back to lobby", {
+        fontSize: "18px",
+        color: "#ffffff",
+        fontFamily: "system-ui, sans-serif",
+        stroke: "#000000",
+        strokeThickness: 2,
+      })
+      .setOrigin(0.5)
+      .setDepth(201)
+      .setScrollFactor(0);
+    const hit = this.add.zone(cx, cy, 220, 44).setOrigin(0.5).setScrollFactor(0).setInteractive();
+    hit.on("pointerdown", () => {
+      this.room?.send({ type: "input_return_to_lobby", seq: 0 });
+    });
+    this.returnToLobbyObjects.push(gfx, btnText, hit);
   }
 
   private handleTurnChanged(teamId: string, _wormId: string): void {
@@ -700,6 +755,17 @@ export class GameScene extends Phaser.Scene {
       this.room.onClose((code) => {
         if (code === 1000) return;
         void this.startReconnectionLoop();
+      }),
+    );
+
+    // Phase change: if the server flips back to "lobby" (after host presses
+    // Back to lobby from the game-over overlay), return to LobbyScene with
+    // the existing room handle so players re-ready in place.
+    this.roomUnsubs.push(
+      this.room.onStateChange((state) => {
+        if (state.phase === "lobby" && this.scene.key === "GameScene") {
+          this.scene.start("LobbyScene", { netClient: this.netClient, room: this.room });
+        }
       }),
     );
 

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -422,6 +422,9 @@ export class Room implements DurableObject {
       case "start_game":
         await this.onStartGame(ws, player, msg);
         break;
+      case "input_return_to_lobby":
+        await this.onReturnToLobby(ws, player);
+        break;
       case "input_walk":
       case "input_jump":
       case "input_backflip":
@@ -647,6 +650,55 @@ export class Room implements DurableObject {
       return;
     }
     lobby.selectedMapId = mapId;
+    this.broadcastState();
+  }
+
+  /**
+   * Host-only: after game_over, tear down the sim/arbiter and flip phase back
+   * to "lobby" so everyone lands on the ready-up screen. Clients see the
+   * phase change and transition their scene; non-host players auto-unready
+   * so a new game requires explicit re-confirmation.
+   */
+  private async onReturnToLobby(ws: WebSocket, player: LobbyPlayer): Promise<void> {
+    const lobby = this.ensureLobby();
+    if (!player.isHost) {
+      this.sendError(ws, "not_host", "Only the host may return to the lobby.");
+      return;
+    }
+    // Only meaningful from a playing / ended state; ignore if already in lobby.
+    if (lobby.phase === "lobby") return;
+
+    // Tear down game state.
+    if (this.sim) {
+      try {
+        this.sim.destroy();
+      } catch {
+        // ignore
+      }
+      this.sim = null;
+    }
+    this.arbiter = null;
+    this.simBootstrap = null;
+    this.rosters = [];
+    await this.state.storage.delete("simState");
+    await this.state.storage.delete("simBootstrap");
+    await this.state.storage.delete("arbiterState");
+    await this.state.storage.delete("rosters");
+
+    // Flip the lobby back to pre-start state. Keep players + nicknames +
+    // colors + selectedMapId (host's last choice). Un-ready every non-host
+    // so the next start_game requires explicit re-confirmation from each.
+    lobby.phase = "lobby";
+    lobby.currentTeamId = "";
+    lobby.currentWormId = "";
+    lobby.turnSeq = 0;
+    lobby.turnEndsAt = 0;
+    lobby.teamOrder = [];
+    for (const p of Object.values(lobby.players)) {
+      p.ownerOfTeamId = "";
+      if (!p.isHost) p.ready = false;
+    }
+    await this.persistLobby();
     this.broadcastState();
   }
 


### PR DESCRIPTION
Closes the 'must refresh after a win' bug from the last playtest.

- New `input_return_to_lobby` client message (host-only).
- Server resets sim/arbiter/rosters/simBootstrap, flips phase to 'lobby', un-readies non-host players, broadcasts.
- Client: game-over screen gets a 'Back to lobby' button for host, 'Waiting for host...' for non-host.
- Phase-change listener in GameScene returns to LobbyScene with the existing room handle so players re-ready in place.