### PR TITLE
fix(input): walk direction relative to worm

### DIFF
--- a/src/input/touchGestures.test.ts
+++ b/src/input/touchGestures.test.ts
@@ -39,6 +39,20 @@ describe("touchGestures state machine", () => {
     expect(up).toEqual([{ kind: "walk_release" }]);
   });
 
+  it("walk direction is relative to the worm, not the screen midline", () => {
+    const t = createGestureTracker();
+    // Worm on the far right; tap on the far left of the screen - still left
+    // of the worm, so this should walk left.
+    const leftOfRightWorm = t.processDown(mkInput({ downXPx: 100, wormXPx: 1000, nowMs: 1000 }));
+    expect(leftOfRightWorm).toEqual([{ kind: "walk", dir: -1 }]);
+    t.processUp(1100);
+
+    // Worm on the far left; tap on the right side - right of the worm even
+    // though still left of the screen midline at x=640.
+    const rightOfLeftWorm = t.processDown(mkInput({ downXPx: 500, wormXPx: 200, nowMs: 3000 }));
+    expect(rightOfLeftWorm).toEqual([{ kind: "walk", dir: 1 }]);
+  });
+
   it("tap on worm enters aim mode (no walk)", () => {
     const t = createGestureTracker();
     // downXPx within 40px of worm (640, 400)

--- a/src/input/touchGestures.ts
+++ b/src/input/touchGestures.ts
@@ -102,7 +102,11 @@ export function createGestureTracker(): {
       }
 
       // Off-worm, my turn, no utility -> WALK mode.
-      const side: -1 | 1 = input.downXPx < input.screenWidth / 2 ? -1 : 1;
+      // Walk direction is relative to the active worm's position: tap left of
+      // the worm walks left, tap right walks right. This reads as intuitive
+      // no matter where the worm is on the map (if the worm is far-right and
+      // you tap the left side of the screen, you meant "walk left toward me").
+      const side: -1 | 1 = input.downXPx < input.wormXPx ? -1 : 1;
       walkSide = side;
       mode = "walk";
 


### PR DESCRIPTION
Walk side now compares tap against worm.xPx instead of screenWidth/2 so movement reads as intuitive regardless of where the worm is on the map. New test covers both extremes (worm far-right + tap far-left, worm far-left + tap right-of-worm).