### PR TITLE
fix: input gate past turn timer + dpad hit-test when hidden

### DIFF
--- a/src/ui/UtilityDPad.ts
+++ b/src/ui/UtilityDPad.ts
@@ -78,15 +78,31 @@ export class UtilityDPad {
 
     for (const b of [this.leftBtn, this.rightBtn, this.upBtn, this.downBtn]) {
       b.setAlpha(tuning.touch.buttonIdleAlpha);
+      // Start non-interactive since the container is hidden; show() re-enables.
+      b.disableInteractive();
     }
   }
 
   show(): void {
     this.container.setVisible(true);
+    // Re-enable hit-testing on each button; setInteractive() is a no-op
+    // if already interactive so this is safe to call repeatedly.
+    for (const b of [this.leftBtn, this.rightBtn, this.upBtn, this.downBtn]) {
+      b.setInteractive({
+        hitArea: new Phaser.Geom.Circle(0, 0, tuning.touch.buttonRadiusPx),
+        hitAreaCallback: Phaser.Geom.Circle.Contains,
+      });
+    }
   }
 
   hide(): void {
     this.container.setVisible(false);
+    // Disable hit-testing on each button. Phaser's setVisible(false) does
+    // NOT disable interactivity, so without this the invisible d-pad would
+    // swallow taps meant for the weapon drawer / HUD underneath.
+    for (const b of [this.leftBtn, this.rightBtn, this.upBtn, this.downBtn]) {
+      b.disableInteractive();
+    }
     // Release any held directions when hiding so the utility doesn't think
     // the user is still pressing.
     if (this.leftHeld || this.rightHeld) {

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -951,6 +951,11 @@ export class Room implements DurableObject {
     const lobby = this.lobby;
     const inputs = this.pendingInputs;
     this.pendingInputs = [];
+    // If the turn timer has expired OR we're in the game-over / paused
+    // state, drop all action inputs for this tick. The active worm should
+    // stop responding once the clock hits 0 instead of accepting moves
+    // during the settle-grace window.
+    const inputsLocked = !this.arbiter?.areInputsAccepted();
     for (const input of inputs) {
       const player = lobby.players[input.sessionId];
       if (!player) continue;
@@ -959,6 +964,7 @@ export class Room implements DurableObject {
       if (player.ownerOfTeamId !== lobby.currentTeamId) continue;
       const activeWormId = lobby.currentWormId;
       if (!activeWormId) continue;
+      if (inputsLocked) continue;
       switch (input.kind) {
         case "walk":
           this.sim.applyWalkInput(activeWormId, input.dir);

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -195,9 +195,20 @@ export class TurnArbiter {
    * ignored so the player can't sneak another fire after the timer hits 0).
    */
   canFire(): boolean {
+    if (!this.areInputsAccepted()) return false;
+    if (this.hasFiredThisTurn) return false;
+    return true;
+  }
+
+  /**
+   * Broader gate used by the Room for any action input (walk, jump, aim,
+   * fire, jetpack). Once the turn timer hits 0 we lock the active worm's
+   * inputs so only physics continues during settle grace. Also rejects
+   * during game-over and disconnect pause.
+   */
+  areInputsAccepted(): boolean {
     if (this.gameOver) return false;
     if (this.pausedRemainingMs !== null) return false;
-    if (this.hasFiredThisTurn) return false;
     if (Date.now() > this.room.state.turnEndsAt) return false;
     return true;
   }


### PR DESCRIPTION
Two playtest bugs:

- **#1 (delay after timer 0)**: Walk/jump/aim/fire/jetpack inputs now drop once `Date.now() > turnEndsAt` via a new `areInputsAccepted()` gate on the arbiter, drained at the input drain step in Room.
- **#3 (weapons not clickable)**: UtilityDPad's hidden buttons were still intercepting taps because Phaser's `setVisible(false)` doesn't disable hit-testing. Explicitly `disableInteractive()` on hide and re-enable on show; also start non-interactive at construction.

Still investigating #2 (rematch Start button) and #6 (fire animation fails) — ship these first, gather more data.