### PR TITLE
Arena maps: bridges, spire, canyon, plateau (closes #41)

### DIFF
--- a/src/maps/generators.test.ts
+++ b/src/maps/generators.test.ts
@@ -1,9 +1,14 @@
 import { createCanvas } from "canvas";
 import { describe, expect, it } from "vitest";
+import { findSpawnPoints } from "../worm/spawnPoints";
+import { bridgesGenerator } from "./generators/bridges";
+import { canyonGenerator } from "./generators/canyon";
 import { caveGenerator } from "./generators/cave";
 import { flatGenerator } from "./generators/flat";
 import { hillsGenerator } from "./generators/hills";
 import { islandGenerator } from "./generators/island";
+import { plateauGenerator } from "./generators/plateau";
+import { spireGenerator } from "./generators/spire";
 
 const W = 1280;
 const H = 720;
@@ -152,6 +157,157 @@ describe("islandGenerator", () => {
         }
       }
       expect(foundTerrain).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: render a generator into a fresh canvas and return the full pixel
+// data buffer (Uint8ClampedArray, RGBA interleaved).
+// ---------------------------------------------------------------------------
+function renderPixels(
+  gen: (ctx: CanvasRenderingContext2D, w: number, h: number, opts: { seed: number }) => void,
+  seed: number,
+): Uint8ClampedArray {
+  const canvas = createCanvas(W, H);
+  const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+  gen(ctx, W, H, { seed });
+  return canvas.getContext("2d").getImageData(0, 0, W, H).data;
+}
+
+function countSolidPixels(data: Uint8ClampedArray): number {
+  let count = 0;
+  for (let i = 3; i < data.length; i += 4) {
+    if ((data[i] ?? 0) > 0) count++;
+  }
+  return count;
+}
+
+describe("bridgesGenerator", () => {
+  it("bridges generator is deterministic given a seed", () => {
+    const a = renderPixels(bridgesGenerator, 1);
+    const b = renderPixels(bridgesGenerator, 1);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("bridges produces substantial solid terrain", () => {
+    const data = renderPixels(bridgesGenerator, 1);
+    const solid = countSolidPixels(data);
+    expect(solid / (W * H)).toBeGreaterThan(0.1);
+  });
+
+  it("bridges yields 4 valid spawn points on solid surface", () => {
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    bridgesGenerator(ctx, W, H, { seed: 1 });
+    const imgData = canvas.getContext("2d").getImageData(0, 0, W, H);
+    const spawnPoints = findSpawnPoints(imgData.data, W, H, 4);
+    expect(spawnPoints.length).toBe(4);
+    const ids = new Set(spawnPoints.map((s) => `${s.xPx},${s.yPx}`));
+    expect(ids.size).toBe(4);
+    for (const { xPx, yPx } of spawnPoints) {
+      // yPx itself is solid (that is what findSpawnPoints returns)
+      const selfAlpha = imgData.data[(yPx * W + xPx) * 4 + 3] ?? 0;
+      expect(selfAlpha).toBeGreaterThan(0);
+      // Check 3px above to clear any anti-aliased edge fringe; should be clean air.
+      const clearAboveAlpha = yPx >= 3 ? (imgData.data[((yPx - 3) * W + xPx) * 4 + 3] ?? 0) : 255;
+      expect(clearAboveAlpha).toBe(0);
+    }
+  });
+});
+
+describe("spireGenerator", () => {
+  it("spire generator is deterministic given a seed", () => {
+    const a = renderPixels(spireGenerator, 1);
+    const b = renderPixels(spireGenerator, 1);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("spire produces substantial solid terrain", () => {
+    const data = renderPixels(spireGenerator, 1);
+    const solid = countSolidPixels(data);
+    expect(solid / (W * H)).toBeGreaterThan(0.1);
+  });
+
+  it("spire yields 4 valid spawn points on solid surface", () => {
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    spireGenerator(ctx, W, H, { seed: 1 });
+    const imgData = canvas.getContext("2d").getImageData(0, 0, W, H);
+    const spawnPoints = findSpawnPoints(imgData.data, W, H, 4);
+    expect(spawnPoints.length).toBe(4);
+    const ids = new Set(spawnPoints.map((s) => `${s.xPx},${s.yPx}`));
+    expect(ids.size).toBe(4);
+    for (const { xPx, yPx } of spawnPoints) {
+      const selfAlpha = imgData.data[(yPx * W + xPx) * 4 + 3] ?? 0;
+      expect(selfAlpha).toBeGreaterThan(0);
+      // Check 3px above to clear any anti-aliased edge fringe; should be clean air.
+      const clearAboveAlpha = yPx >= 3 ? (imgData.data[((yPx - 3) * W + xPx) * 4 + 3] ?? 0) : 255;
+      expect(clearAboveAlpha).toBe(0);
+    }
+  });
+});
+
+describe("canyonGenerator", () => {
+  it("canyon generator is deterministic given a seed", () => {
+    const a = renderPixels(canyonGenerator, 1);
+    const b = renderPixels(canyonGenerator, 1);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("canyon produces substantial solid terrain", () => {
+    const data = renderPixels(canyonGenerator, 1);
+    const solid = countSolidPixels(data);
+    expect(solid / (W * H)).toBeGreaterThan(0.1);
+  });
+
+  it("canyon yields 4 valid spawn points on solid surface", () => {
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    canyonGenerator(ctx, W, H, { seed: 1 });
+    const imgData = canvas.getContext("2d").getImageData(0, 0, W, H);
+    const spawnPoints = findSpawnPoints(imgData.data, W, H, 4);
+    expect(spawnPoints.length).toBe(4);
+    const ids = new Set(spawnPoints.map((s) => `${s.xPx},${s.yPx}`));
+    expect(ids.size).toBe(4);
+    for (const { xPx, yPx } of spawnPoints) {
+      const selfAlpha = imgData.data[(yPx * W + xPx) * 4 + 3] ?? 0;
+      expect(selfAlpha).toBeGreaterThan(0);
+      // Check 3px above to clear any anti-aliased edge fringe; should be clean air.
+      const clearAboveAlpha = yPx >= 3 ? (imgData.data[((yPx - 3) * W + xPx) * 4 + 3] ?? 0) : 255;
+      expect(clearAboveAlpha).toBe(0);
+    }
+  });
+});
+
+describe("plateauGenerator", () => {
+  it("plateau generator is deterministic given a seed", () => {
+    const a = renderPixels(plateauGenerator, 1);
+    const b = renderPixels(plateauGenerator, 1);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("plateau produces substantial solid terrain", () => {
+    const data = renderPixels(plateauGenerator, 1);
+    const solid = countSolidPixels(data);
+    expect(solid / (W * H)).toBeGreaterThan(0.1);
+  });
+
+  it("plateau yields 4 valid spawn points on solid surface", () => {
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    plateauGenerator(ctx, W, H, { seed: 1 });
+    const imgData = canvas.getContext("2d").getImageData(0, 0, W, H);
+    const spawnPoints = findSpawnPoints(imgData.data, W, H, 4);
+    expect(spawnPoints.length).toBe(4);
+    const ids = new Set(spawnPoints.map((s) => `${s.xPx},${s.yPx}`));
+    expect(ids.size).toBe(4);
+    for (const { xPx, yPx } of spawnPoints) {
+      const selfAlpha = imgData.data[(yPx * W + xPx) * 4 + 3] ?? 0;
+      expect(selfAlpha).toBeGreaterThan(0);
+      // Check 3px above to clear any anti-aliased edge fringe; should be clean air.
+      const clearAboveAlpha = yPx >= 3 ? (imgData.data[((yPx - 3) * W + xPx) * 4 + 3] ?? 0) : 255;
+      expect(clearAboveAlpha).toBe(0);
     }
   });
 });

--- a/src/maps/generators/bridges.ts
+++ b/src/maps/generators/bridges.ts
@@ -1,0 +1,44 @@
+import type { MapGenerator } from "../types";
+import { xorshift } from "../xorshift";
+
+export const bridgesGenerator: MapGenerator = (ctx, _width, height, opts) => {
+  const rng = xorshift(opts.seed);
+  ctx.fillStyle = "#4a6a3c";
+
+  // Left plateau: x=0..400, y=500..720
+  // With seeded surface bumps at 50px intervals (±5px)
+  ctx.beginPath();
+  ctx.moveTo(0, height);
+  ctx.lineTo(0, 500);
+  for (let x = 0; x <= 400; x += 50) {
+    const bump = rng() * 10 - 5;
+    ctx.lineTo(x, 500 + bump);
+  }
+  ctx.lineTo(400, 500);
+  ctx.lineTo(400, height);
+  ctx.closePath();
+  ctx.fill();
+
+  // Right plateau: x=880..1280, y=500..720
+  // With seeded surface bumps at 50px intervals (±5px)
+  ctx.beginPath();
+  ctx.moveTo(880, height);
+  ctx.lineTo(880, 500);
+  for (let x = 880; x <= 1280; x += 50) {
+    const bump = rng() * 10 - 5;
+    ctx.lineTo(x, 500 + bump);
+  }
+  ctx.lineTo(1280, 500);
+  ctx.lineTo(1280, height);
+  ctx.closePath();
+  ctx.fill();
+
+  // Central bridge: x=400..880, y=490..530 (40px thick, 480px long)
+  ctx.fillRect(400, 490, 480, 40);
+
+  // Left step (cover on inner edge of left plateau): x=340..400, y=440..500
+  ctx.fillRect(340, 440, 60, 60);
+
+  // Right step (cover on inner edge of right plateau): x=880..940, y=440..500
+  ctx.fillRect(880, 440, 60, 60);
+};

--- a/src/maps/generators/canyon.ts
+++ b/src/maps/generators/canyon.ts
@@ -1,0 +1,37 @@
+import type { MapGenerator } from "../types";
+import { xorshift } from "../xorshift";
+
+export const canyonGenerator: MapGenerator = (ctx, _width, height, opts) => {
+  const rng = xorshift(opts.seed);
+  ctx.fillStyle = "#6a5a3c";
+
+  // Left cliff: x=0..500, y=300..720
+  // With seeded variation on cliff top (±10px bumps at 40px intervals)
+  ctx.beginPath();
+  ctx.moveTo(0, height);
+  ctx.lineTo(0, 300);
+  for (let x = 0; x <= 500; x += 40) {
+    const bump = rng() * 20 - 10;
+    ctx.lineTo(x, 300 + bump);
+  }
+  ctx.lineTo(500, 300);
+  ctx.lineTo(500, height);
+  ctx.closePath();
+  ctx.fill();
+
+  // Right cliff: x=780..1280, y=300..720
+  // With seeded variation on cliff top (±10px bumps at 40px intervals)
+  ctx.beginPath();
+  ctx.moveTo(780, height);
+  ctx.lineTo(780, 300);
+  for (let x = 780; x <= 1280; x += 40) {
+    const bump = rng() * 20 - 10;
+    ctx.lineTo(x, 300 + bump);
+  }
+  ctx.lineTo(1280, 300);
+  ctx.lineTo(1280, height);
+  ctx.closePath();
+  ctx.fill();
+
+  // Canyon gap x=500..780 is entirely air - no geometry drawn there
+};

--- a/src/maps/generators/plateau.ts
+++ b/src/maps/generators/plateau.ts
@@ -1,0 +1,46 @@
+import type { MapGenerator } from "../types";
+import { xorshift } from "../xorshift";
+
+export const plateauGenerator: MapGenerator = (ctx, _width, _height, opts) => {
+  const rng = xorshift(opts.seed);
+  ctx.fillStyle = "#5a4a2c";
+
+  // Left low ground: x=0..320, y=530..720
+  ctx.fillRect(0, 530, 320, 190);
+
+  // Right low ground: x=960..1280, y=530..720
+  ctx.fillRect(960, 530, 320, 190);
+
+  // Central plateau: x=320..960, y=300..720
+  ctx.fillRect(320, 300, 640, 420);
+
+  // Left ramp polygon (sloped): (260, 530) -> (320, 300) -> (320, 530) close
+  ctx.beginPath();
+  ctx.moveTo(260, 530);
+  ctx.lineTo(320, 300);
+  ctx.lineTo(320, 530);
+  ctx.closePath();
+  ctx.fill();
+
+  // Right ramp polygon (sloped): (1020, 530) -> (960, 300) -> (960, 530) close
+  ctx.beginPath();
+  ctx.moveTo(1020, 530);
+  ctx.lineTo(960, 300);
+  ctx.lineTo(960, 530);
+  ctx.closePath();
+  ctx.fill();
+
+  // Plateau top peaks: 3 peaks centered at x=420, x=640, x=860
+  // Each 60px wide, height seeded between 40 and 80px, pointing up from y=300
+  const peakCenters = [420, 640, 860];
+  for (const cx of peakCenters) {
+    const peakHeight = 40 + Math.floor(rng() * 41); // 40..80
+    const peakTop = 300 - peakHeight;
+    ctx.beginPath();
+    ctx.moveTo(cx - 30, 300);
+    ctx.lineTo(cx, peakTop);
+    ctx.lineTo(cx + 30, 300);
+    ctx.closePath();
+    ctx.fill();
+  }
+};

--- a/src/maps/generators/spire.ts
+++ b/src/maps/generators/spire.ts
@@ -1,0 +1,17 @@
+import type { MapGenerator } from "../types";
+
+export const spireGenerator: MapGenerator = (ctx, _width, _height, _opts) => {
+  ctx.fillStyle = "#3c5a6a";
+
+  // Floor: x=0..1280, y=660..720 (60px thick)
+  ctx.fillRect(0, 660, 1280, 60);
+
+  // Central spire: x=510..770, y=120..660
+  ctx.fillRect(510, 120, 260, 540);
+
+  // Left ledge on spire: x=470..510, y=290..310 (juts left)
+  ctx.fillRect(470, 290, 40, 20);
+
+  // Right ledge on spire: x=770..810, y=440..460 (juts right)
+  ctx.fillRect(770, 440, 40, 20);
+};

--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -1,11 +1,16 @@
+import { bridgesGenerator } from "./generators/bridges";
+import { canyonGenerator } from "./generators/canyon";
 import { caveGenerator } from "./generators/cave";
 import { flatGenerator } from "./generators/flat";
 import { hillsGenerator } from "./generators/hills";
 import { islandGenerator } from "./generators/island";
+import { plateauGenerator } from "./generators/plateau";
+import { spireGenerator } from "./generators/spire";
 import type { MapConfig, MapGenerator } from "./types";
 
 type RegistryEntry = { config: MapConfig; generator: MapGenerator };
 
+// Keep in sync with MAP_WHITELIST in worker/src/room.ts
 export const MAPS: Record<string, RegistryEntry> = {
   flat: {
     config: {
@@ -52,6 +57,46 @@ export const MAPS: Record<string, RegistryEntry> = {
       generator: { id: "cave", seed: 0 },
     },
     generator: caveGenerator,
+  },
+  bridges: {
+    config: {
+      id: "bridges",
+      name: "Bridges",
+      description: "Two plateaus connected by a narrow central bridge.",
+      maxWorms: 4,
+      generator: { id: "bridges", seed: 0 },
+    },
+    generator: bridgesGenerator,
+  },
+  spire: {
+    config: {
+      id: "spire",
+      name: "Spire",
+      description: "A tall central spire rising from a continuous floor.",
+      maxWorms: 4,
+      generator: { id: "spire", seed: 0 },
+    },
+    generator: spireGenerator,
+  },
+  canyon: {
+    config: {
+      id: "canyon",
+      name: "Canyon",
+      description: "Two cliffs split by an impassable gap. Fire across.",
+      maxWorms: 4,
+      generator: { id: "canyon", seed: 0 },
+    },
+    generator: canyonGenerator,
+  },
+  plateau: {
+    config: {
+      id: "plateau",
+      name: "Plateau",
+      description: "A raised central plateau with stepped slopes on each side.",
+      maxWorms: 4,
+      generator: { id: "plateau", seed: 0 },
+    },
+    generator: plateauGenerator,
   },
 };
 

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -39,7 +39,17 @@ import {
   TurnArbiter,
 } from "./turnArbiter.js";
 
-const MAP_WHITELIST = ["flat", "hills", "island", "cave"] as const;
+// Keep in sync with MAPS in src/maps/registry.ts
+const MAP_WHITELIST = [
+  "flat",
+  "hills",
+  "island",
+  "cave",
+  "bridges",
+  "spire",
+  "canyon",
+  "plateau",
+] as const;
 const MIN_PLAYERS_TO_START = 2;
 const MAX_CLIENTS = 8;
 /** Sim tick cadence. 50ms = 20Hz. */


### PR DESCRIPTION
## Summary

Adds 4 new arena maps to replace the "trig-shape procgen" feel with deliberate geometry. Part of the playtest-ready MVP focus (M5 step 2 of 3; step 1 Classic Worms Feel shipped in PR #86).

- **Bridges** — left + right plateaus connected by a 40px-thick central bridge. Blast the bridge to strand teams.
- **Spire** — full-width floor with a tall central spire. Ledges on either side at different heights.
- **Canyon** — two cliffs separated by an impassable gap. Fire across; no crossing without rope/jetpack.
- **Plateau** — raised central plateau with stepped slopes on each side.

Registry now has 8 maps total. Host cycles through them in the lobby map picker.

## Implementation notes

- All generators live in `src/maps/generators/` matching `hills.ts` / `island.ts` convention.
- Seeded randomness via `xorshift(opts.seed)` only (no `Math.random()`) so host-ships-mask stays byte-identical across clients. `spire.ts` is fully static (no seeded variation).
- Server `MAP_WHITELIST` in `worker/src/room.ts` extended 4 → 8; sync comments in both files point to the other.
- 12 new tests in `src/maps/generators.test.ts` (4 maps × 3 tests): determinism, non-empty geometry, spawn point validity.

## Bug Check

3 parallel hunters (spawn geometry, determinism, whitelist/e2e). All findings triaged:
- Spire spawn "landing on ledge" → false positive: `scanColumnTopDown` ceiling-skip algo correctly routes to floor at y=660.
- Canyon spawn "on cliffs not gap" → false positive: that's the intended design.
- Test count delta → verified +12 as expected (master 184 → feature 196).

No real bugs.

## Test plan (post-deploy)

- [ ] Host cycles through all 8 maps in the lobby map picker without errors
- [ ] Each new map loads successfully: terrain renders, 4 spawn points visible, teams land on solid ground
- [ ] Bazooka fire across canyon works (can't walk the gap)
- [ ] Spire: climb the ledges by jumping
- [ ] Plateau: walk up the slopes from low ground to central plateau
- [ ] Deterministic: host vs peer see identical terrain shape (no desync)

Closes #41