### PR TITLE
fix: rematch freeze + weapon drawer + aim power

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -242,6 +242,10 @@ export class GameScene extends Phaser.Scene {
     // on SHUTDOWN to tear down adapter + unsubs.
     // ------------------------------------------------------------------
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      // Tear down room listeners FIRST so a throw in any of the downstream
+      // destroys can't leave an active onStateChange listener that keeps
+      // firing (and attempting scene.start) after we've moved on.
+      this.tearDownRoomListeners();
       try {
         this.sim.destroy();
       } catch {
@@ -267,7 +271,6 @@ export class GameScene extends Phaser.Scene {
       this.disconnectTick = null;
       this.terrainRenderer?.destroy();
       this.terrainRenderer = null;
-      this.tearDownRoomListeners();
     });
 
     // ------------------------------------------------------------------
@@ -716,13 +719,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private getSelectedWeaponId(): string {
-    if (this.offlineSim) {
-      const team = this.offlineSim.turns.getActiveTeam();
-      return this.offlineSim.getWeaponManager(team)?.getSelected().id ?? "";
-    }
-    // Networked mode: until sim_state carries activeWeapon (W1), default to
-    // the first registry entry so the drawer draws a selection.
-    return allWeapons()[0]?.id ?? "";
+    return this.sim.getActiveWeaponId() || allWeapons()[0]?.id || "";
   }
 
   private getActiveTeamColor(): number {
@@ -761,13 +758,20 @@ export class GameScene extends Phaser.Scene {
     // Phase change: if the server flips back to "lobby" (after host presses
     // Back to lobby from the game-over overlay), return to LobbyScene with
     // the existing room handle so players re-ready in place.
-    this.roomUnsubs.push(
-      this.room.onStateChange((state) => {
-        if (state.phase === "lobby" && this.scene.key === "GameScene") {
-          this.scene.start("LobbyScene", { netClient: this.netClient, room: this.room });
-        }
-      }),
-    );
+    //
+    // CRITICAL: self-unsubscribe after the first lobby-phase hit. Without
+    // this, every subsequent state change (e.g. the non-host readying up
+    // in the rematch lobby) retriggers scene.start("LobbyScene") because
+    // the transition is async and state keeps flowing. That produced a
+    // freeze on rematch-ready.
+    let phaseSub: (() => void) | null = null;
+    phaseSub = this.room.onStateChange((state) => {
+      if (state.phase !== "lobby") return;
+      phaseSub?.();
+      phaseSub = null;
+      this.scene.start("LobbyScene", { netClient: this.netClient, room: this.room });
+    });
+    this.roomUnsubs.push(() => phaseSub?.());
 
     this.disconnectTick = this.time.addEvent({
       delay: 250,

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -185,6 +185,13 @@ export class NetworkedSimAdapter implements SimAdapter {
     return this.currFrame?.state.activeTeamId ?? this.lastActiveTeamId;
   }
 
+  getActiveWeaponId(): string {
+    const activeId = this.getActiveWormId();
+    if (!activeId) return "";
+    const worm = this.currFrame?.state.worms.find((w) => w.id === activeId);
+    return worm?.activeWeapon ?? "";
+  }
+
   getTurnSecondsRemaining(): number {
     const endsAt = this.currFrame?.state.turnEndsAt ?? this.lastTurnEndsAt;
     if (endsAt <= 0) return 0;

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -222,6 +222,11 @@ export class OfflineSimAdapter implements SimAdapter {
     return this.turnManager.getActiveTeam()?.id ?? "";
   }
 
+  getActiveWeaponId(): string {
+    const team = this.turnManager.getActiveTeam();
+    return this.getWeaponManager(team)?.getSelected().id ?? "";
+  }
+
   getTurnSecondsRemaining(): number {
     return this.turnManager.getTurnSecondsRemaining();
   }

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -65,6 +65,8 @@ export interface SimAdapter {
 
   getActiveWormId(): string;
   getActiveTeamId(): string;
+  /** Weapon id currently selected by the active worm, empty if none. */
+  getActiveWeaponId(): string;
   /** Seconds remaining on the active turn. Server-authoritative when networked. */
   getTurnSecondsRemaining(): number;
   /** Wind strength -1..1; negative = leftward. Zero in offline mode. */

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -90,7 +90,7 @@ export const tuning: Tuning = {
   water: { suddenDeathTurn: 15, risePxPerTurn: 50 },
   weapons: {
     testCutRadiusPx: 40,
-    dragMaxLengthPx: 200,
+    dragMaxLengthPx: 140,
     dragDeadZonePx: 8,
     powerStepPerPress: 0.05,
     ammo: { bazooka: -1, shotgun: -1, handgrenade: -1 },


### PR DESCRIPTION
Three playtest bugs:

- **#1/#3 rematch freeze**: GameScene's phase-change listener fired on every state change after scene transition, retriggering scene.start on an already-active LobbyScene. Self-unsubscribe on first hit. Also moved tearDownRoomListeners to run first in SHUTDOWN so a downstream throw can't leave orphan listeners.
- **#2 weapon drawer stuck on bazooka**: `getSelectedWeaponId` had a stale stub that returned `allWeapons()[0]` in networked mode. Added `SimAdapter.getActiveWeaponId()`; networked reads from worm render state, offline delegates to WeaponManager.
- **#4 aim power scale**: `dragMaxLengthPx` 200 -> 140 so max power is reached with a shorter pull.

Shotgun-no-animation tracked as a separate hitscan-VFX gap — deferred since not blocking.