### PR TITLE
docs: Worms-in-Terraria-world direction (ADR-003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Project-specific instructions for Claude sessions working in this repo. Override
 
 ## Mission
 
-Browser-based multiplayer Worms-style artillery game. Friends visit `mccarrison.me/worms`, one hosts a room with a 4-letter code, others join. The shell is done; the current phase is taking the nine-weapon core from "prototype that works" to "playtest-ready product that reads as a finished game". Content expansion (more weapons, modes, rope netcode) waits until that polish lands.
+Browser-based multiplayer turn-based artillery combat in procedurally generated Terraria-style worlds. Friends visit `mccarrison.me/worms`, one hosts a room with a 4-letter code, others join. Classic Worms gameplay (teams, 9 weapons, wind/water/fall-damage, 45s turns, retreat window) set inside a scrolling tile-based world with caves + biomes. See [ADR-003](docs/decisions/003-terraria-world-pivot.md).
 
 ## Target platforms (first-class)
 
@@ -23,14 +23,16 @@ Browser-based multiplayer Worms-style artillery game. Friends visit `mccarrison.
 
 ## Status
 
-**Phase**: Playtest-ready MVP (M5). Shell complete through Epic 13 (Cloudflare deploy) + Epic 45 (server-auth sim) + Epic 32 (mobile touch) + jetpack netcode. Shipped and live at mccarrison.me/worms.
+**Phase**: M6 Worms-in-Terraria-world. Shell + playtest polish (M1-M5) complete. Classic Worms mechanics live (wind/water/fall-damage/retreat), 8 geometric arena maps shipped as fallback, mobile touch + PWA + reconnect all working. Live at mccarrison.me/worms.
 
 **Next, in order:**
-1. **Classic Worms Feel** epic — bundle of #19 wind + #20 water + #21 fall damage/retreat. Pure code, biggest feel-upgrade per hour.
-2. **Real arena maps** (#41). Replace procgen trig shapes with hand-built pixel-mask arenas.
-3. **Sprites + audio** (#11 + #12). Asset-sourcing epic; inventory filed separately. Can run in parallel with code work.
+1. **Phase 1**: world size + scrolling camera + tile-atlas loader + single-biome tile-texture fill + basic heightmap surface gen.
+2. **Phase 2**: cave carving + decoration stamps + 3-4 biome presets + parallax backdrop.
+3. **Phase 3**: polish (biome ambient, weather, lighting).
 
-**Deferred until MVP lands**: weapon expansion (#16/#17/#39), rope netcode (#82), game modes (#24), team customization (#23), backflip on mobile (#75).
+See [ADR-003](docs/decisions/003-terraria-world-pivot.md) for the rationale and scope boundaries of the world pivot.
+
+**Deferred until M6 lands**: weapon expansion (#16/#17/#39), rope netcode (#82), game modes (#24), team customization (#23), backflip on mobile (#75), jetpack radial (#91).
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for full state and [docs/decisions/](docs/decisions/) for architecture decision records.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,19 +4,28 @@ Source of truth: [GitHub issues](https://github.com/scottmccarrison/worms/issues
 
 > **Framework pivot 2026-04-20**: stack is now Phaser 3 + planck + Colyseus + Aseprite. See [ADR-001](decisions/001-framework-pivot.md). Epic descriptions below reflect the new approach; issue bodies were updated with pivot notes.
 
-## Playtest-ready MVP focus (2026-04-22)
+## Worms-in-Terraria-world direction (2026-04-22)
 
-The core shell is playable end-to-end (rooms, reconnect, server-auth sim, 9 weapons, touch controls, PWA, jetpack). Next phase stops adding breadth and deepens the existing feature set so the game reads as a polished product, not a prototype. Once that's done, weapon/mode expansion drops in without friction.
+Playtest feedback on the 1280x720 geometric-arena MVP was "maps are small and boring." After exploring options (see [ADR-003](decisions/003-terraria-world-pivot.md)), the new direction is:
 
-**Three epics to reach playtest-ready MVP, in order:**
+**Keep the turn-based Worms gameplay loop exactly as-is. Drop it inside a procedurally generated Terraria-style side-scrolling world.** The world is the new visual + gen layer; the game that happens inside it (teams, 9 weapons, wind/water/fall damage, 45s turns, retreat window) is unchanged.
 
-1. **Classic Worms Feel** (bundle of #19 wind + #20 water + #21 fall damage/retreat). Pure code, biggest gameplay-feel delta, ships as one integration PR.
-2. **Real arena maps** (#41, with #22 as a stretch). Replace procgen trig shapes with 3-5 hand-built pixel-mask arenas. No art dependency.
-3. **Sprites + audio** (#11 + #12). Asset-sourcing epic (OpenGameArt / Freesound / commission gaps). Concrete inventory will be filed alongside so sourcing is parallelizable.
+The pixel-mask physics model is actually _better_ suited to this than to full Terraria (pixel-perfect crater destruction still works; tile rendering is purely a visual composite over the alpha mask).
 
-Deferred until after MVP lands: weapon expansion (#16/#17/#39), rope in networked mode (#82), game modes (#24), replay/bots (#25), team customization (#23), backflip on mobile (#75).
+**Phased delivery:**
 
-Rationale: 15 more weapons on geometric shapes over trig-shape terrain is still a prototype. One tuned wind + rising water + real arenas + real sprites turns the existing nine weapons into a complete game.
+- **Phase 1** (current epic): world size 2560x1024+ with scrolling camera, tile-atlas loader, single-biome tile-texture fill, basic heightmap surface gen. Proves the pattern; 10x visual upgrade on its own.
+- **Phase 2**: cave carving (cellular automata / noise), decoration stamps (trees, rocks, ore), 3-4 biome presets, parallax backdrop.
+- **Phase 3**: polish - biome-specific ambient (particles, tint), optional weather.
+
+**What stays the same**: turn arbiter, teams, 9 weapons, planck rigid bodies, per-pixel destruction, Cloudflare DO netcode, reconnection, mobile touch, wind/water/fall-damage/retreat. Nothing in the gameplay layer changes.
+
+**Superseded by this direction**:
+- "Real arena maps" (#41, shipped in PR #94) stays as fallback/test content; procgen replaces it for production.
+- "Sprites + audio" (#84 inventory, #11 sprites) narrows - tile art comes from Kenney / OpenGameArt CC0 packs, not commissioning. Worm + weapon + VFX sprites still needed.
+- "Procedural map generation + themes" (#22) is absorbed into this epic.
+
+**Still deferred until Phase 1+ lands**: weapon expansion (#16/#17/#39), rope in networked mode (#82), game modes (#24), replay/bots (#25), team customization (#23), backflip on mobile (#75), jetpack radial (#91).
 
 ## MVP epics
 
@@ -62,10 +71,11 @@ Rationale: 15 more weapons on geometric shapes over trig-shape terrain is still 
 - **M2 Single-player playable** (Phaser + planck): #3 → #4 → #5 → #6 → #7 — **DONE**
 - **M3 Multiplayer** (Colyseus integration, collapsed; ultimately ported to Cloudflare DOs): #8/#9/#10 + #45 — **DONE**
 - **M4 Deployed**: #13 — **DONE** (mccarrison.me/worms)
-- **M5 Playtest-ready MVP** (current phase): Classic Worms Feel (#19/#20/#21) → real arena maps (#41) → sprites + audio (#11/#12)
-- **M6 Content expansion** (post-MVP): weapons (#16/#17/#39), rope netcode (#82), game modes (#24), team customization (#23)
+- **M5 Playtest polish**: Classic Worms Feel (#19/#20/#21) + real arena maps (#41) — **DONE** (shipped in PRs #86 + #94)
+- **M6 Worms-in-Terraria-world** (current phase): Phase 1 (world + tile rendering + basic gen) → Phase 2 (caves + biomes + backdrop) → Phase 3 (polish). See [ADR-003](decisions/003-terraria-world-pivot.md).
+- **M7 Content expansion** (post-world-pivot): weapons (#16/#17/#39), rope netcode (#82), game modes (#24), team customization (#23), replay/bots (#25)
 
-Parallelization: asset sourcing (#11, #12) doesn't block code work and can run alongside M5 gameplay epics once an inventory is settled.
+Parallelization: tile-pack sourcing (#84 revised scope) doesn't block code work and can run alongside Phase 1. Worm/weapon/VFX sprite sourcing (#11 narrower scope) can run throughout M6.
 
 ## Session log
 

--- a/docs/decisions/003-terraria-world-pivot.md
+++ b/docs/decisions/003-terraria-world-pivot.md
@@ -1,0 +1,67 @@
+# ADR-003: Worms-in-Terraria-world direction
+
+## Status
+Accepted (2026-04-22).
+
+## Context
+
+The game shipped its classic-Worms mechanical core (turn arbiter, teams, 9 weapons, wind, water, fall damage, retreat window) on a single-screen 1280x720 canvas with procgen geometric terrain. Playtest feedback, summarized bluntly, was "these maps are small and boring."
+
+We considered three directions:
+
+1. **Commission hand-drawn pixel-art maps** (Armageddon-style). Unblocks "feels like a real game" but depends on an artist we don't have. Every new map is a commissioning expense.
+2. **Full Terraria-with-combat pivot.** Real-time exploration + building + combat. Different game entirely. Would delete the turn arbiter, fire gating, retreat window, all the Worms-specific scaffolding that already works.
+3. **Worms-in-Terraria-world.** Keep the turn-based Worms gameplay loop exactly as-is. Drop it inside a procedurally generated Terraria-style side-scrolling world. The world is the new visual + gen layer; the game that happens inside it is unchanged.
+
+Option 3 is the chosen direction. It's the smallest product pivot of the three (the gameplay stays identical) but the biggest visual and scale upgrade (procgen tile-based world vs flat geometric arena).
+
+The critical technical insight: our pixel-mask physics model is _better_ suited to option 3 than to option 2. Worms-style pixel-perfect crater destruction is exactly what the per-pixel alpha mask gives us. Terraria-style tile destruction would have required swapping the physics model; we don't do that. Tile rendering is purely a visual composite over the alpha mask.
+
+## Decision
+
+Pivot the world layer from "single-screen geometric arena" to "side-scrolling procedurally generated tile-based world." Gameplay layer unchanged.
+
+### What changes
+
+- **World size**: 1280x720 -> ~2560-3200 x 1024-1280. Camera follows the active worm; zoomed-out overview between turns.
+- **Terrain rendering**: flat `ctx.fillStyle` color -> tile-texture composite. The alpha channel still defines collision; the RGB is now a repeating biome tile texture (CC0 packs from Kenney et al.), not a flat color.
+- **World generation**: geometric `ctx.fillRect` + polygon paths -> layered procgen. Heightmap surface -> stratified subsurface (grass/dirt/stone/deep-stone) -> cellular-automata caves -> decoration stamps (trees, grass tufts, rocks).
+- **Biomes**: per-map tile palette + generator parameter preset (e.g. forest, desert, cavern, snow). Each biome swaps the tile set + tweaks surface/cave density; the gen engine is shared.
+- **Backdrop**: sky gradient + distant silhouette parallax layer. Scrolls with camera at reduced rate.
+- **Asset sourcing**: CC0 tile packs (Kenney Platformer Art + Platformer Tiles, etc.) instead of custom commissioning for terrain. Custom sprites still needed for worms + weapons + explosion VFX.
+
+### What does NOT change
+
+- Turn arbiter: keep. 45s turns, retreat window, pause/resume, game-over detection.
+- Teams + worms + 9 weapons + firing pipeline: keep.
+- Per-pixel alpha-mask physics: keep. Destruction is still Worms-style pixel-perfect craters (the tile texture simply stops being visible where alpha=0).
+- planck.js rigid bodies for worms and projectiles: keep.
+- Server-authoritative sim, Cloudflare DO netcode, reconnection, resume tokens: keep.
+- Wind, water, fall damage, retreat window, nickname persistence: keep.
+- `host-provides-mask` wire pattern: keep; payload grows ~3x with world area but stays under a few MB at start_game.
+
+## Consequences
+
+### Gained
+- **Visual leap**: tile-textured terrain with biome variety reads as a distinct, intentional setting rather than a prototype backdrop.
+- **Procgen = infinite map variety**: seeds produce new worlds; no artist bottleneck for map count.
+- **Scroll + scale** = more interesting combat scenarios (caves for cover, high ground, flanking). Classic Worms arena tactics benefit from larger space.
+- **Cheap asset sourcing**: Kenney and other CC0 tile sets are abundant and drop-in compatible. No commissioning required to look reasonable.
+- **Additive, not rewriting**: every existing system keeps working. Risk is bounded.
+
+### Lost / deferred
+- "Real arena maps" epic (#41, merged in PR #94) becomes a fallback/test asset. Fine to keep as-is; procgen replaces it for production maps.
+- "Sprites + audio" asset inventory (#84) narrows: map art is no longer a commissioned-art line item (tile packs cover it). Worm / weapon / VFX / UI sprites are still needed.
+- Payload: the alpha-mask wire broadcast grows from ~900KB base64 -> ~2.5MB for a 2560x1024 world. Acceptable on mobile at game start (one-shot, not per-tick).
+
+### Phased delivery
+
+- **Phase 1**: world size + scrolling camera + tile-atlas loader + single-biome tile-texture fill + basic heightmap surface gen. Proves the pattern. Already a 10x visual improvement over current geometric maps.
+- **Phase 2**: cave carving (cellular automata or noise) + decoration stamps (trees, rocks) + 3-4 biome presets + parallax backdrop.
+- **Phase 3**: polish - biome-specific ambient (particles, lighting tint), ore/crystal decorations, optional weather (rain, snow).
+
+Each phase is shippable on its own. Phase 1 alone justifies the pivot; phases 2-3 build character.
+
+## Reversal notes
+
+Unlike ADR-002 (Cloudflare Workers), this ADR is not a tech pivot - it's a content architecture pivot. Reversing it would mean going back to flat-color geometric arenas, which is easy (the existing `src/maps/generators/` files all still work). The one committed change is the wider world + scrolling camera; those are settable constants.


### PR DESCRIPTION
Documents the new direction and housekeeping.

- **ADR-003**: new doc capturing the Worms-in-Terraria-world pivot (gameplay stays, world grows + gets tile-rendered, procgen replaces geometric arenas).
- **ROADMAP.md**: M5 replaced with M6 phased plan.
- **CLAUDE.md**: Mission + Status updated.
- **Epic #96** filed for Phase 1.
- **#22** closed as superseded.
- **#84, #11** re-scoped via comments.