### PR TITLE
M6 Phase 1: scrolling 2560x1024 world + depth-stratum terrain (#96)

### DIFF
--- a/shared/maskPack.test.ts
+++ b/shared/maskPack.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { packMask, packedMaskByteLength, unpackMask } from "./maskPack";
+
+describe("maskPack", () => {
+  it("round-trips small arrays", () => {
+    const input = new Uint8Array([1, 0, 1, 1, 0, 0, 1, 0, 1, 0]);
+    const packed = packMask(input);
+    const out = unpackMask(packed, input.length);
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+
+  it("packedMaskByteLength rounds up", () => {
+    expect(packedMaskByteLength(0)).toBe(0);
+    expect(packedMaskByteLength(1)).toBe(1);
+    expect(packedMaskByteLength(8)).toBe(1);
+    expect(packedMaskByteLength(9)).toBe(2);
+    expect(packedMaskByteLength(2560 * 1024)).toBe(327680);
+  });
+
+  it("round-trips a 2560x1024 mask with random pattern", () => {
+    const size = 2560 * 1024;
+    const input = new Uint8Array(size);
+    for (let i = 0; i < size; i++) input[i] = (i * 31) & 1;
+    const packed = packMask(input);
+    const out = unpackMask(packed, size);
+    expect(out.length).toBe(size);
+    // Sample check: verify every 1000th pixel matches rather than all 2.6M
+    // assertions (which would time out the test runner).
+    let mismatch = -1;
+    for (let i = 0; i < size; i++) {
+      if (out[i] !== input[i]) {
+        mismatch = i;
+        break;
+      }
+    }
+    expect(mismatch).toBe(-1);
+  }, 30000);
+});

--- a/shared/maskPack.ts
+++ b/shared/maskPack.ts
@@ -1,0 +1,25 @@
+/**
+ * 1-bit-per-pixel mask packing for the host-provides-mask wire protocol.
+ *
+ * Alpha source -> packed bytes where bit i (LSB-first) of byte i>>3 is 1
+ * if the source pixel i is solid. Length check: ceil(pixelCount / 8).
+ */
+export function packMask(alphaBytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(Math.ceil(alphaBytes.length / 8));
+  for (let i = 0; i < alphaBytes.length; i++) {
+    if (alphaBytes[i]) out[i >> 3] |= 1 << (i & 7);
+  }
+  return out;
+}
+
+export function unpackMask(packed: Uint8Array, pixelCount: number): Uint8Array {
+  const out = new Uint8Array(pixelCount);
+  for (let i = 0; i < pixelCount; i++) {
+    if (packed[i >> 3] & (1 << (i & 7))) out[i] = 1;
+  }
+  return out;
+}
+
+export function packedMaskByteLength(pixelCount: number): number {
+  return Math.ceil(pixelCount / 8);
+}

--- a/shared/worldConfig.ts
+++ b/shared/worldConfig.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonical world dimensions shared across client + server + worker.
+ * Changing these requires a deploy; the wire mask length validation
+ * derives from these via packedMaskByteLength().
+ */
+export const WORLD_WIDTH_PX = 2560;
+export const WORLD_HEIGHT_PX = 1024;

--- a/src/maps/generators.test.ts
+++ b/src/maps/generators.test.ts
@@ -9,6 +9,7 @@ import { hillsGenerator } from "./generators/hills";
 import { islandGenerator } from "./generators/island";
 import { plateauGenerator } from "./generators/plateau";
 import { spireGenerator } from "./generators/spire";
+import { terraworldGenerator } from "./generators/terraworld";
 
 const W = 1280;
 const H = 720;
@@ -308,6 +309,50 @@ describe("plateauGenerator", () => {
       // Check 3px above to clear any anti-aliased edge fringe; should be clean air.
       const clearAboveAlpha = yPx >= 3 ? (imgData.data[((yPx - 3) * W + xPx) * 4 + 3] ?? 0) : 255;
       expect(clearAboveAlpha).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Terraworld generator (2560x1024 - the Phase 1 world size)
+// ---------------------------------------------------------------------------
+const TW = 2560;
+const TH = 1024;
+
+function renderTerraworldPixels(seed: number): Uint8ClampedArray {
+  const canvas = createCanvas(TW, TH);
+  const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+  terraworldGenerator(ctx, TW, TH, { seed });
+  return canvas.getContext("2d").getImageData(0, 0, TW, TH).data;
+}
+
+describe("terraworldGenerator", () => {
+  it("terraworld generator is deterministic given a seed (2560x1024)", () => {
+    const a = renderTerraworldPixels(42);
+    const b = renderTerraworldPixels(42);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("terraworld has solid ratio between 20% and 60%", () => {
+    const data = renderTerraworldPixels(42);
+    const solid = countSolidPixels(data);
+    const ratio = solid / (TW * TH);
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThan(0.6);
+  });
+
+  it("terraworld yields 4 valid spawn points on solid surface", () => {
+    const canvas = createCanvas(TW, TH);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    terraworldGenerator(ctx, TW, TH, { seed: 1 });
+    const imgData = canvas.getContext("2d").getImageData(0, 0, TW, TH);
+    const spawnPoints = findSpawnPoints(imgData.data, TW, TH, 4);
+    expect(spawnPoints.length).toBe(4);
+    const ids = new Set(spawnPoints.map((s) => `${s.xPx},${s.yPx}`));
+    expect(ids.size).toBe(4);
+    for (const { xPx, yPx } of spawnPoints) {
+      const selfAlpha = imgData.data[(yPx * TW + xPx) * 4 + 3] ?? 0;
+      expect(selfAlpha).toBeGreaterThan(0);
     }
   });
 });

--- a/src/maps/generators/bridges.ts
+++ b/src/maps/generators/bridges.ts
@@ -1,44 +1,48 @@
 import type { MapGenerator } from "../types";
 import { xorshift } from "../xorshift";
 
-export const bridgesGenerator: MapGenerator = (ctx, _width, height, opts) => {
+export const bridgesGenerator: MapGenerator = (ctx, width, height, opts) => {
   const rng = xorshift(opts.seed);
   ctx.fillStyle = "#4a6a3c";
 
-  // Left plateau: x=0..400, y=500..720
-  // With seeded surface bumps at 50px intervals (±5px)
+  // Proportional landmark positions (designed for 1280x720 baseline).
+  const leftEdge = Math.floor(width * 0.3125); // ~400 at 1280
+  const rightEdge = Math.floor(width * 0.6875); // ~880 at 1280
+  const plateauY = Math.floor(height * 0.694); // ~500 at 720
+  const bridgeY = Math.floor(height * 0.681); // ~490 at 720
+
+  // Left plateau: x=0..leftEdge, y=plateauY..height
   ctx.beginPath();
   ctx.moveTo(0, height);
-  ctx.lineTo(0, 500);
-  for (let x = 0; x <= 400; x += 50) {
+  ctx.lineTo(0, plateauY);
+  for (let x = 0; x <= leftEdge; x += 50) {
     const bump = rng() * 10 - 5;
-    ctx.lineTo(x, 500 + bump);
+    ctx.lineTo(x, plateauY + bump);
   }
-  ctx.lineTo(400, 500);
-  ctx.lineTo(400, height);
+  ctx.lineTo(leftEdge, plateauY);
+  ctx.lineTo(leftEdge, height);
   ctx.closePath();
   ctx.fill();
 
-  // Right plateau: x=880..1280, y=500..720
-  // With seeded surface bumps at 50px intervals (±5px)
+  // Right plateau: x=rightEdge..width, y=plateauY..height
   ctx.beginPath();
-  ctx.moveTo(880, height);
-  ctx.lineTo(880, 500);
-  for (let x = 880; x <= 1280; x += 50) {
+  ctx.moveTo(rightEdge, height);
+  ctx.lineTo(rightEdge, plateauY);
+  for (let x = rightEdge; x <= width; x += 50) {
     const bump = rng() * 10 - 5;
-    ctx.lineTo(x, 500 + bump);
+    ctx.lineTo(x, plateauY + bump);
   }
-  ctx.lineTo(1280, 500);
-  ctx.lineTo(1280, height);
+  ctx.lineTo(width, plateauY);
+  ctx.lineTo(width, height);
   ctx.closePath();
   ctx.fill();
 
-  // Central bridge: x=400..880, y=490..530 (40px thick, 480px long)
-  ctx.fillRect(400, 490, 480, 40);
+  // Central bridge (40px thick)
+  ctx.fillRect(leftEdge, bridgeY, rightEdge - leftEdge, 40);
 
-  // Left step (cover on inner edge of left plateau): x=340..400, y=440..500
-  ctx.fillRect(340, 440, 60, 60);
+  // Left step
+  ctx.fillRect(leftEdge - 60, plateauY - 60, 60, 60);
 
-  // Right step (cover on inner edge of right plateau): x=880..940, y=440..500
-  ctx.fillRect(880, 440, 60, 60);
+  // Right step
+  ctx.fillRect(rightEdge, plateauY - 60, 60, 60);
 };

--- a/src/maps/generators/canyon.ts
+++ b/src/maps/generators/canyon.ts
@@ -1,37 +1,40 @@
 import type { MapGenerator } from "../types";
 import { xorshift } from "../xorshift";
 
-export const canyonGenerator: MapGenerator = (ctx, _width, height, opts) => {
+export const canyonGenerator: MapGenerator = (ctx, width, height, opts) => {
   const rng = xorshift(opts.seed);
   ctx.fillStyle = "#6a5a3c";
 
-  // Left cliff: x=0..500, y=300..720
-  // With seeded variation on cliff top (±10px bumps at 40px intervals)
+  // Proportional landmark positions (designed for 1280x720 baseline).
+  const leftEdge = Math.floor(width * 0.3906); // ~500 at 1280
+  const rightEdge = Math.floor(width * 0.6094); // ~780 at 1280
+  const cliffY = Math.floor(height * 0.417); // ~300 at 720
+
+  // Left cliff
   ctx.beginPath();
   ctx.moveTo(0, height);
-  ctx.lineTo(0, 300);
-  for (let x = 0; x <= 500; x += 40) {
+  ctx.lineTo(0, cliffY);
+  for (let x = 0; x <= leftEdge; x += 40) {
     const bump = rng() * 20 - 10;
-    ctx.lineTo(x, 300 + bump);
+    ctx.lineTo(x, cliffY + bump);
   }
-  ctx.lineTo(500, 300);
-  ctx.lineTo(500, height);
+  ctx.lineTo(leftEdge, cliffY);
+  ctx.lineTo(leftEdge, height);
   ctx.closePath();
   ctx.fill();
 
-  // Right cliff: x=780..1280, y=300..720
-  // With seeded variation on cliff top (±10px bumps at 40px intervals)
+  // Right cliff
   ctx.beginPath();
-  ctx.moveTo(780, height);
-  ctx.lineTo(780, 300);
-  for (let x = 780; x <= 1280; x += 40) {
+  ctx.moveTo(rightEdge, height);
+  ctx.lineTo(rightEdge, cliffY);
+  for (let x = rightEdge; x <= width; x += 40) {
     const bump = rng() * 20 - 10;
-    ctx.lineTo(x, 300 + bump);
+    ctx.lineTo(x, cliffY + bump);
   }
-  ctx.lineTo(1280, 300);
-  ctx.lineTo(1280, height);
+  ctx.lineTo(width, cliffY);
+  ctx.lineTo(width, height);
   ctx.closePath();
   ctx.fill();
 
-  // Canyon gap x=500..780 is entirely air - no geometry drawn there
+  // Canyon gap between leftEdge..rightEdge is entirely air - no geometry drawn there
 };

--- a/src/maps/generators/plateau.ts
+++ b/src/maps/generators/plateau.ts
@@ -1,45 +1,56 @@
 import type { MapGenerator } from "../types";
 import { xorshift } from "../xorshift";
 
-export const plateauGenerator: MapGenerator = (ctx, _width, _height, opts) => {
+export const plateauGenerator: MapGenerator = (ctx, width, height, opts) => {
   const rng = xorshift(opts.seed);
   ctx.fillStyle = "#5a4a2c";
 
-  // Left low ground: x=0..320, y=530..720
-  ctx.fillRect(0, 530, 320, 190);
+  // Proportional positions (designed for 1280x720 baseline).
+  const lowY = Math.round(height * 0.7361); // 530 at 720
+  const plateauY = Math.floor(height * 0.417); // ~300 at 720
+  const leftEdge = Math.floor(width * 0.25); // ~320 at 1280
+  const rightEdge = Math.floor(width * 0.75); // ~960 at 1280
 
-  // Right low ground: x=960..1280, y=530..720
-  ctx.fillRect(960, 530, 320, 190);
+  // Left low ground
+  ctx.fillRect(0, lowY, leftEdge, height - lowY);
 
-  // Central plateau: x=320..960, y=300..720
-  ctx.fillRect(320, 300, 640, 420);
+  // Right low ground
+  ctx.fillRect(rightEdge, lowY, width - rightEdge, height - lowY);
 
-  // Left ramp polygon (sloped): (260, 530) -> (320, 300) -> (320, 530) close
+  // Central plateau
+  ctx.fillRect(leftEdge, plateauY, rightEdge - leftEdge, height - plateauY);
+
+  // Left ramp polygon
+  const leftRampBase = Math.round(width * 0.203125); // 260 at 1280
   ctx.beginPath();
-  ctx.moveTo(260, 530);
-  ctx.lineTo(320, 300);
-  ctx.lineTo(320, 530);
+  ctx.moveTo(leftRampBase, lowY);
+  ctx.lineTo(leftEdge, plateauY);
+  ctx.lineTo(leftEdge, lowY);
   ctx.closePath();
   ctx.fill();
 
-  // Right ramp polygon (sloped): (1020, 530) -> (960, 300) -> (960, 530) close
+  // Right ramp polygon
+  const rightRampBase = Math.round(width * 0.796875); // 1020 at 1280
   ctx.beginPath();
-  ctx.moveTo(1020, 530);
-  ctx.lineTo(960, 300);
-  ctx.lineTo(960, 530);
+  ctx.moveTo(rightRampBase, lowY);
+  ctx.lineTo(rightEdge, plateauY);
+  ctx.lineTo(rightEdge, lowY);
   ctx.closePath();
   ctx.fill();
 
-  // Plateau top peaks: 3 peaks centered at x=420, x=640, x=860
-  // Each 60px wide, height seeded between 40 and 80px, pointing up from y=300
-  const peakCenters = [420, 640, 860];
+  // Plateau top peaks at proportional positions (420, 640, 860 at width=1280).
+  const peakCenters = [
+    Math.round(width * 0.328125),
+    Math.round(width * 0.5),
+    Math.round(width * 0.671875),
+  ];
   for (const cx of peakCenters) {
     const peakHeight = 40 + Math.floor(rng() * 41); // 40..80
-    const peakTop = 300 - peakHeight;
+    const peakTop = plateauY - peakHeight;
     ctx.beginPath();
-    ctx.moveTo(cx - 30, 300);
+    ctx.moveTo(cx - 30, plateauY);
     ctx.lineTo(cx, peakTop);
-    ctx.lineTo(cx + 30, 300);
+    ctx.lineTo(cx + 30, plateauY);
     ctx.closePath();
     ctx.fill();
   }

--- a/src/maps/generators/spire.ts
+++ b/src/maps/generators/spire.ts
@@ -1,17 +1,24 @@
 import type { MapGenerator } from "../types";
 
-export const spireGenerator: MapGenerator = (ctx, _width, _height, _opts) => {
+export const spireGenerator: MapGenerator = (ctx, width, height, _opts) => {
   ctx.fillStyle = "#3c5a6a";
 
-  // Floor: x=0..1280, y=660..720 (60px thick)
-  ctx.fillRect(0, 660, 1280, 60);
+  // Proportional positions (designed for 1280x720 baseline).
+  const floorThick = 60;
+  const floorY = height - floorThick;
+  const spireLeft = Math.floor(width * 0.398); // ~510 at 1280
+  const spireRight = Math.floor(width * 0.602); // ~770 at 1280
+  const spireTop = Math.floor(height * 0.167); // ~120 at 720
 
-  // Central spire: x=510..770, y=120..660
-  ctx.fillRect(510, 120, 260, 540);
+  // Floor: full width
+  ctx.fillRect(0, floorY, width, floorThick);
 
-  // Left ledge on spire: x=470..510, y=290..310 (juts left)
-  ctx.fillRect(470, 290, 40, 20);
+  // Central spire
+  ctx.fillRect(spireLeft, spireTop, spireRight - spireLeft, floorY - spireTop);
 
-  // Right ledge on spire: x=770..810, y=440..460 (juts right)
-  ctx.fillRect(770, 440, 40, 20);
+  // Left ledge on spire (juts left)
+  ctx.fillRect(spireLeft - 40, Math.floor(height * 0.403), 40, 20);
+
+  // Right ledge on spire (juts right)
+  ctx.fillRect(spireRight, Math.floor(height * 0.611), 40, 20);
 };

--- a/src/maps/generators/terraworld.ts
+++ b/src/maps/generators/terraworld.ts
@@ -1,0 +1,33 @@
+import type { MapGenerator } from "../types";
+import { xorshift } from "../xorshift";
+
+/**
+ * Phase 1 procgen generator: heightmap surface noise, solid below.
+ * RGB is painted by TerrainRenderer's stratum pass; this generator only
+ * produces the alpha mask (solid/air geometry).
+ */
+export const terraworldGenerator: MapGenerator = (ctx, width, height, opts) => {
+  const rng = xorshift(opts.seed);
+  const sampleStride = 32;
+  const baseY = height * 0.55;
+  const ampY = height * 0.12;
+  const sampleCount = Math.ceil(width / sampleStride) + 1;
+  const samples: number[] = [];
+  for (let i = 0; i < sampleCount; i++) {
+    samples.push(baseY + (rng() * 2 - 1) * ampY);
+  }
+
+  // Any opaque fill works; stratum painter overwrites RGB.
+  ctx.fillStyle = "#ffffff";
+  for (let x = 0; x < width; x++) {
+    const col = x / sampleStride;
+    const i = Math.floor(col);
+    const t = col - i;
+    const s0 = samples[i] ?? baseY;
+    const s1 = samples[i + 1] ?? baseY;
+    const surfaceY = Math.floor(s0 * (1 - t) + s1 * t);
+    if (surfaceY < height) {
+      ctx.fillRect(x, surfaceY, 1, height - surfaceY);
+    }
+  }
+};

--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -6,6 +6,7 @@ import { hillsGenerator } from "./generators/hills";
 import { islandGenerator } from "./generators/island";
 import { plateauGenerator } from "./generators/plateau";
 import { spireGenerator } from "./generators/spire";
+import { terraworldGenerator } from "./generators/terraworld";
 import type { MapConfig, MapGenerator } from "./types";
 
 type RegistryEntry = { config: MapConfig; generator: MapGenerator };
@@ -97,6 +98,16 @@ export const MAPS: Record<string, RegistryEntry> = {
       generator: { id: "plateau", seed: 0 },
     },
     generator: plateauGenerator,
+  },
+  terraworld: {
+    config: {
+      id: "terraworld",
+      name: "Terraworld",
+      description: "Procedural heightmap surface with grass, dirt, and stone strata.",
+      maxWorms: 4,
+      generator: { id: "terraworld", seed: 0 },
+    },
+    generator: terraworldGenerator,
   },
 };
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,4 +1,5 @@
 import * as Phaser from "phaser";
+import { unpackMask } from "../../shared/maskPack";
 import { mountTuningPanel, registerMapCycleFn } from "../debug/tuningPanel";
 import { InputController } from "../input/InputController";
 import { type GestureInput, createGestureTracker } from "../input/touchGestures";
@@ -374,6 +375,11 @@ export class GameScene extends Phaser.Scene {
       heightPx: sceneHeightPx,
     });
 
+    // Camera: constrain scroll to the world bounds so the camera never shows
+    // blank space outside the terrain. The camera will follow the active worm
+    // once handleTurnChanged fires.
+    this.cameras.main.setBounds(0, 0, sceneWidthPx, sceneHeightPx);
+
     this.debugGfx = this.add.graphics();
     this.debugGfx.setDepth(10);
     this.hud = this.add
@@ -621,6 +627,10 @@ export class GameScene extends Phaser.Scene {
     if (this.offlineSim) {
       const activeWorm = this.offlineSim.wormsInternal.find((w) => w.name === _wormId);
       if (activeWorm) this.inputController?.setActiveWorm(activeWorm);
+      // Follow the offline worm's physics body renderer.
+      if (activeWorm) {
+        this.cameras.main.startFollow(activeWorm.graphicsObject, true, 0.08, 0.08);
+      }
     } else if (this.networkedSim) {
       // Wrap the render view in a facade so InputController has something
       // to read xPx / facing / aimAngle from. The facade's mutator methods
@@ -629,6 +639,12 @@ export class GameScene extends Phaser.Scene {
       this.inputController?.setActiveWorm(
         view ? adaptRenderableToWormFacade(view, () => this.sim.isJetPacking(), this.sim) : null,
       );
+      // Follow the networked worm sprite's graphics object.
+      const sprite = this.wormSprites.get(_wormId);
+      const followTarget = sprite?.graphics ?? null;
+      if (followTarget) {
+        this.cameras.main.startFollow(followTarget, true, 0.08, 0.08);
+      }
     }
   }
 
@@ -1090,9 +1106,13 @@ function adaptRenderableToWormFacade(
 }
 
 /**
- * Decode the server's base64 Uint8Array mask into an HTMLCanvasElement
- * painted with the usual terrain color, ready for Terrain / TerrainRenderer
- * to consume as its `sourceMask`. 1 byte per pixel: solid (1) or air (0).
+ * Decode the server's base64 1-bit-packed mask into an HTMLCanvasElement
+ * with alpha set (solid) or cleared (air). RGB is left as opaque white here;
+ * TerrainRenderer's stratum painter overwrites the RGB in a post-pass.
+ *
+ * Wire format (as of Phase 1): 1-bit-per-pixel packed (LSB-first), base64.
+ * So the decoded Uint8Array is packed bytes; unpackMask expands to one byte
+ * per pixel for canvas painting.
  */
 function decodeServerMaskToCanvas(
   base64: string,
@@ -1100,8 +1120,12 @@ function decodeServerMaskToCanvas(
   heightPx: number,
 ): HTMLCanvasElement {
   const raw = atob(base64);
-  const bytes = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+  const packed = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) packed[i] = raw.charCodeAt(i);
+
+  // Expand packed bits back to one-byte-per-pixel.
+  const pixelCount = widthPx * heightPx;
+  const bytes = unpackMask(packed, pixelCount);
 
   const canvas = document.createElement("canvas");
   canvas.width = widthPx;
@@ -1109,15 +1133,15 @@ function decodeServerMaskToCanvas(
   const ctx = canvas.getContext("2d");
   if (!ctx) throw new Error("decodeServerMaskToCanvas: no 2d context");
 
-  // Paint solid pixels using the default terrain green. Row-major byte
-  // layout matches the server's buildFlatMask / host's mask extraction.
+  // Paint solid pixels opaque (RGB will be overwritten by stratum pass).
+  // Air pixels stay transparent so destruction (destination-out) works.
   const img = ctx.createImageData(widthPx, heightPx);
-  for (let i = 0; i < bytes.length; i++) {
+  for (let i = 0; i < pixelCount; i++) {
     const j = i * 4;
     if (bytes[i]) {
-      img.data[j] = 0x5a;
-      img.data[j + 1] = 0x7a;
-      img.data[j + 2] = 0x3c;
+      img.data[j] = 0xff;
+      img.data[j + 1] = 0xff;
+      img.data[j + 2] = 0xff;
       img.data[j + 3] = 0xff;
     }
     // else: leave transparent (air).

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,5 +1,6 @@
 import * as Phaser from "phaser";
 import { unpackMask } from "../../shared/maskPack";
+import { WORLD_HEIGHT_PX, WORLD_WIDTH_PX } from "../../shared/worldConfig";
 import { mountTuningPanel, registerMapCycleFn } from "../debug/tuningPanel";
 import { InputController } from "../input/InputController";
 import { type GestureInput, createGestureTracker } from "../input/touchGestures";
@@ -185,20 +186,23 @@ export class GameScene extends Phaser.Scene {
     // ------------------------------------------------------------------
     // Pick the adapter. Everything sim-related flows through it.
     // ------------------------------------------------------------------
+    // World dimensions: networked games get them from game_started; offline
+    // and fallback paths use the canonical WORLD_*_PX constants so the
+    // scrolling world (2560x1024) still applies. Never use this.scale.width
+    // as a fallback - that's the logical viewport (1280x720 for Scale.FIT),
+    // not the world.
+    const worldW = this.serverWidthPx ?? WORLD_WIDTH_PX;
+    const worldH = this.serverHeightPx ?? WORLD_HEIGHT_PX;
     if (this.isNetworked && this.room) {
       // Networked path: the server is authoritative for geometry. Paint
       // the received mask into a canvas for the visual terrain.
       const maskCanvas = this.serverMask
-        ? decodeServerMaskToCanvas(
-            this.serverMask,
-            this.serverWidthPx ?? this.scale.width,
-            this.serverHeightPx ?? this.scale.height,
-          )
-        : loadMap(this.mapId, this.scale.width, this.scale.height, this.seedOverride).mask;
+        ? decodeServerMaskToCanvas(this.serverMask, worldW, worldH)
+        : loadMap(this.mapId, worldW, worldH, this.seedOverride).mask;
       this.terrainRenderer = new TerrainRenderer({
         scene: this,
-        widthPx: this.serverWidthPx ?? this.scale.width,
-        heightPx: this.serverHeightPx ?? this.scale.height,
+        widthPx: worldW,
+        heightPx: worldH,
         sourceMask: maskCanvas,
       });
       this.networkedSim = new NetworkedSimAdapter({
@@ -208,12 +212,12 @@ export class GameScene extends Phaser.Scene {
       this.sim = this.networkedSim;
     } else {
       // Offline path: adapter owns everything physics-touching.
-      const loaded = loadMap(this.mapId, this.scale.width, this.scale.height, this.seedOverride);
+      const loaded = loadMap(this.mapId, worldW, worldH, this.seedOverride);
       this.offlineSim = new OfflineSimAdapter({
         scene: this,
         loaded,
-        widthPx: this.scale.width,
-        heightPx: this.scale.height,
+        widthPx: worldW,
+        heightPx: worldH,
         teams: teamsForAdapter,
       });
       this.sim = this.offlineSim;
@@ -364,9 +368,10 @@ export class GameScene extends Phaser.Scene {
       this.wireNetworkedScene();
     }
 
-    // Wind HUD and water renderer (both modes).
-    const sceneWidthPx = this.serverWidthPx ?? this.scale.width;
-    const sceneHeightPx = this.serverHeightPx ?? this.scale.height;
+    // Wind HUD and water renderer (both modes). Use the canonical world
+    // dims - not this.scale.width, which is the viewport, not the world.
+    const sceneWidthPx = this.serverWidthPx ?? WORLD_WIDTH_PX;
+    const sceneHeightPx = this.serverHeightPx ?? WORLD_HEIGHT_PX;
     this.windHUD = new WindHUD({ scene: this, sim: this.sim });
     this.waterRenderer = new WaterRenderer({
       scene: this,

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -1,4 +1,5 @@
 import * as Phaser from "phaser";
+import { packMask } from "../../shared/maskPack";
 import { loadMap } from "../maps/loadMap";
 import { allIds, getById } from "../maps/registry";
 import type { NetClient } from "../net/client";
@@ -822,9 +823,21 @@ export class LobbyScene extends Phaser.Scene {
     // Workers runtime. Host generates the mask + spawn points locally and
     // ships them in start_game; server uses for physics + forwards them
     // in game_started so every client renders pixel-identical terrain.
+
+    const loadingText = this.add
+      .text(CANVAS_W / 2, this.scale.height / 2, "Generating world...", {
+        fontSize: "32px",
+        color: "#ffffff",
+        fontFamily: "system-ui, sans-serif",
+        stroke: "#000000",
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5)
+      .setDepth(1000);
+
     try {
-      const WORLD_W = 1280;
-      const WORLD_H = 720;
+      const WORLD_W = 2560;
+      const WORLD_H = 1024;
       const loaded = loadMap(mapId, WORLD_W, WORLD_H);
       const ctx = loaded.mask.getContext("2d");
       if (!ctx) throw new Error("mask canvas has no 2d context");
@@ -832,12 +845,15 @@ export class LobbyScene extends Phaser.Scene {
       const bytes = new Uint8Array(WORLD_W * WORLD_H);
       // Alpha > 0 means solid terrain.
       for (let i = 0; i < bytes.length; i++) bytes[i] = img.data[i * 4 + 3] > 0 ? 1 : 0;
-      const mask = bytesToBase64(bytes);
+      const packed = packMask(bytes);
+      const mask = bytesToBase64(packed);
       const spawnPoints = loaded.spawnPoints.map((s) => ({ xPx: s.xPx, yPx: s.yPx }));
       room.send({ type: "start_game", mask, spawnPoints });
     } catch (err) {
       console.warn("[start_game] host could not generate mask, sending without:", err);
       room.send({ type: "start_game" });
+    } finally {
+      loadingText.destroy();
     }
   }
 

--- a/src/terrain/TerrainRenderer.ts
+++ b/src/terrain/TerrainRenderer.ts
@@ -48,6 +48,45 @@ export class TerrainRenderer {
     this.ctx = ctx;
     this.ctx.drawImage(init.sourceMask, 0, 0);
 
+    // Stratum paint: scan each column top-down for the first solid pixel
+    // (the surface), then paint each pixel's RGB by depth-from-surface.
+    // Grass for the first 6px, dirt for the next 54px, stone below. Alpha
+    // is preserved from the mask so destruction (destination-out) still
+    // works correctly.
+    const img = this.ctx.getImageData(0, 0, this.widthPx, this.heightPx);
+    const data = img.data;
+    for (let x = 0; x < this.widthPx; x++) {
+      let surfaceY = -1;
+      for (let y = 0; y < this.heightPx; y++) {
+        const i = (y * this.widthPx + x) * 4;
+        if (data[i + 3] === 0) continue;
+        if (surfaceY === -1) surfaceY = y;
+        const depth = y - surfaceY;
+        let r: number;
+        let g: number;
+        let b: number;
+        if (depth < 6) {
+          r = 58;
+          g = 122;
+          b = 60;
+        } // grass
+        else if (depth < 60) {
+          r = 122;
+          g = 74;
+          b = 44;
+        } // dirt
+        else {
+          r = 90;
+          g = 90;
+          b = 90;
+        } // stone
+        data[i] = r;
+        data[i + 1] = g;
+        data[i + 2] = b;
+      }
+    }
+    this.ctx.putImageData(img, 0, 0);
+
     const canvasTexture = init.scene.textures.addCanvas(this.textureKey, this.buffer);
     if (!canvasTexture) {
       throw new Error(`TerrainRenderer: addCanvas failed for key "${this.textureKey}"`);

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -139,7 +139,7 @@ export const tuning: Tuning = {
     longPressMs: 400,
   },
   maps: {
-    defaultId: "hills", // registry lookup; falls back to firstId() if invalid
+    defaultId: "terraworld", // registry lookup; falls back to firstId() if invalid
   },
   wind: { forceNewtonsPerUnit: 2 },
 };

--- a/src/worm/Worm.ts
+++ b/src/worm/Worm.ts
@@ -126,6 +126,11 @@ export class Worm {
     this.drawWorm(init.spawnXPx, init.spawnYPx);
   }
 
+  /** Expose the graphics object for camera follow targets. */
+  get graphicsObject(): Phaser.GameObjects.Graphics {
+    return this.graphics;
+  }
+
   // ------ Movement ------
 
   walk(direction: -1 | 0 | 1): void {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "shared/**/*.test.ts"],
   },
 });

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -20,6 +20,11 @@
  */
 
 import {
+  packMask as packMaskBytes,
+  packedMaskByteLength,
+  unpackMask,
+} from "../../shared/maskPack.js";
+import {
   ALLOWED_COLORS,
   type LobbyPlayer,
   type LobbyState,
@@ -49,6 +54,7 @@ const MAP_WHITELIST = [
   "spire",
   "canyon",
   "plateau",
+  "terraworld",
 ] as const;
 const MIN_PLAYERS_TO_START = 2;
 const MAX_CLIENTS = 8;
@@ -57,8 +63,8 @@ const SIM_TICK_MS = 50;
 const EMPTY_ROOM_GRACE_MS = 5 * 60 * 1000;
 
 /** Canonical physics world size. Clients use PX_PER_M=30 to render. */
-const WORLD_WIDTH_PX = 1280;
-const WORLD_HEIGHT_PX = 720;
+const WORLD_WIDTH_PX = 2560;
+const WORLD_HEIGHT_PX = 1024;
 
 const TEAM_PALETTE: Array<{ id: string; name: string; color: string; prefix: string }> = [
   { id: "red", name: "Team Red", color: "#ff4444", prefix: "Red" },
@@ -219,7 +225,14 @@ export class Room implements DurableObject {
       this.simBootstrap = stored;
     }
     const bootstrap = this.simBootstrap;
-    const mask = base64ToBytes(bootstrap.maskBase64);
+    // maskBase64 stores the 1-bit-packed form (for wire transport efficiency).
+    // Unpack to a full 1-byte-per-pixel mask before handing to Simulation.
+    const packedBytes = base64ToBytes(bootstrap.maskBase64);
+    const pixelCount = bootstrap.widthPx * bootstrap.heightPx;
+    const mask =
+      packedBytes.length === pixelCount
+        ? packedBytes // legacy: old bootstrap stored unpacked form directly
+        : unpackMask(packedBytes, pixelCount);
     this.sim = new Simulation({
       widthPx: bootstrap.widthPx,
       heightPx: bootstrap.heightPx,
@@ -768,21 +781,28 @@ export class Room implements DurableObject {
     const hostMask = typeof startMsg.mask === "string" ? startMsg.mask : null;
     const hostSpawns = Array.isArray(startMsg.spawnPoints) ? startMsg.spawnPoints : null;
     let mask: Uint8Array;
+    let packedMaskBase64: string;
     let mapSpawns: Array<{ xPx: number; yPx: number }>;
     if (hostMask && hostSpawns && hostSpawns.length > 0) {
       try {
-        mask = base64ToBytes(hostMask);
-        if (mask.length !== WORLD_WIDTH_PX * WORLD_HEIGHT_PX) {
-          throw new Error(`mask length ${mask.length} != ${WORLD_WIDTH_PX * WORLD_HEIGHT_PX}`);
+        const packed = base64ToBytes(hostMask);
+        const expectedPackedLen = packedMaskByteLength(WORLD_WIDTH_PX * WORLD_HEIGHT_PX);
+        if (packed.length !== expectedPackedLen) {
+          throw new Error(`packed mask length ${packed.length} != ${expectedPackedLen}`);
         }
+        mask = unpackMask(packed, WORLD_WIDTH_PX * WORLD_HEIGHT_PX);
+        // Preserve the original packed base64 so game_started forwards the packed form.
+        packedMaskBase64 = hostMask;
         mapSpawns = hostSpawns;
       } catch (err) {
         console.warn("[start_game] bad mask from host, using flat fallback:", err);
         mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+        packedMaskBase64 = bytesToBase64(packMaskBytes(mask));
         mapSpawns = [];
       }
     } else {
       mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+      packedMaskBase64 = bytesToBase64(packMaskBytes(mask));
       mapSpawns = [];
     }
 
@@ -807,7 +827,8 @@ export class Room implements DurableObject {
     this.simBootstrap = {
       widthPx: WORLD_WIDTH_PX,
       heightPx: WORLD_HEIGHT_PX,
-      maskBase64: bytesToBase64(mask),
+      // Store the packed base64 so game_started forwards the packed wire form to clients.
+      maskBase64: packedMaskBase64,
       teams: simTeams,
       seed,
       mapId: lobby.selectedMapId,


### PR DESCRIPTION
## Summary

First phase of the Worms-in-Terraria-world pivot ([ADR-003](docs/decisions/003-terraria-world-pivot.md)). Gameplay loop is untouched; this PR is purely world + visual changes.

- **World size**: 1280x720 -> 2560x1024. Canonical dims live in `shared/worldConfig.ts`.
- **Scrolling camera**: follows the active worm on turn change (0.08 lerp). Viewport stays 1280x720 (Phaser Scale.FIT); camera shows a 1280x720 window into the wider world.
- **Tile-stratum terrain rendering**: TerrainRenderer paints RGB by depth-from-surface: grass (0-5px), dirt (6-59px), stone (60px+). No RNG — deterministic across host + clients. Alpha mask still drives physics exactly as before, so destruction stays Worms-style per-pixel craters.
- **New `terraworld` generator**: heightmap surface via seeded noise, becomes the default map (`tuning.maps.defaultId = "terraworld"`).
- **Wire protocol**: mask packed 1-bit-per-pixel. 2560x1024 packed = ~437KB base64, well under Cloudflare's 1MB WebSocket cap. New `shared/maskPack.ts` with `packMask` / `unpackMask` + tests.
- **Legacy arena generators** (bridges/canyon/spire/plateau) parameterize width/height so they render without clipping at any world size.
- **"Generating world..." overlay** in the lobby so the ~200-400ms mobile gen delay isn't a silent hang.

## What does NOT change

- Turn arbiter, teams, 9 weapons, planck physics, per-pixel destruction, netcode, mobile touch, wind/water/fall-damage/retreat, reconnection, PWA. All identical.

## Bug Check

3 parallel hunters, 2 confirmed findings fixed in the integration branch:
- **[H1]** Offline mode fell back to viewport dims for world bounds; now uses `WORLD_*_PX` from `shared/worldConfig.ts`. Offline games get the scrolling world too.
- **[L1/L2]** spire + canyon ratio precision loss fixed (exact ratios preserve byte-identical 1280x720 reference geometry).

Non-bugs triaged (not fixed): overlay finally-block race (Phaser auto-destroys on scene shutdown), missing all-zeros/all-ones test cases (coverage gap not correctness), theoretical DO storage limit concern (empirically fine).

## Test plan

- [ ] Create a room, start a new game — world loads with heightmap terrain, not geometric arenas
- [ ] Camera scrolls to follow the active worm across the 2560px-wide world
- [ ] Fire a bazooka; camera tracks the projectile (best-effort; follows worm, not projectile)
- [ ] Explosion craters look correct (grass/dirt/stone strata visible at crater edges)
- [ ] Open `?offline=1` — same scrolling world behavior
- [ ] Pick a legacy arena from the map picker (bridges/canyon/spire/plateau); renders parameterized at the new world size without clipping
- [ ] Reload a game in progress — reconnect still works, terrain re-renders from server's packed mask

Closes #96