### PR TITLE
fix: camera follows worm (M6 Phase 1 regression)

### DIFF
--- a/src/worm/Worm.ts
+++ b/src/worm/Worm.ts
@@ -294,26 +294,30 @@ export class Worm {
     const r = tuning.worm.radiusPx;
     const color = this.team.color;
 
+    // Position the Graphics transform at the worm's world pos so
+    // camera.startFollow(graphics) tracks the worm. Shapes are drawn
+    // origin-relative below.
+    this.graphics.setPosition(xPx, yPx);
     this.graphics.clear();
 
     if (this.isActivePlayer) {
       this.graphics.lineStyle(3, 0xffff00, 1);
-      this.graphics.strokeCircle(xPx, yPx, r + 4);
+      this.graphics.strokeCircle(0, 0, r + 4);
     }
 
     this.graphics.fillStyle(color, 1);
-    this.graphics.fillCircle(xPx, yPx, r);
+    this.graphics.fillCircle(0, 0, r);
 
     this.graphics.lineStyle(1.5, 0xffffff, 0.6);
-    this.graphics.strokeCircle(xPx, yPx, r);
+    this.graphics.strokeCircle(0, 0, r);
 
     if (this.isActivePlayer) {
       const aimLen = r * 2.2;
-      const ax = xPx + Math.cos(this.aimAngle) * this.facing * aimLen;
-      const ay = yPx + Math.sin(this.aimAngle) * aimLen;
+      const ax = Math.cos(this.aimAngle) * this.facing * aimLen;
+      const ay = Math.sin(this.aimAngle) * aimLen;
       this.graphics.lineStyle(2, 0xffffff, 0.8);
       this.graphics.beginPath();
-      this.graphics.moveTo(xPx, yPx);
+      this.graphics.moveTo(0, 0);
       this.graphics.lineTo(ax, ay);
       this.graphics.strokePath();
     }

--- a/src/worm/WormSprite.ts
+++ b/src/worm/WormSprite.ts
@@ -62,6 +62,10 @@ export class WormSprite {
     const r = tuning.worm.radiusPx;
     const color = snapshot.team.color;
 
+    // Position the Graphics transform at the worm's world pos so
+    // camera.startFollow(graphics) tracks the worm. Shapes are drawn
+    // origin-relative below.
+    this.graphics.setPosition(snapshot.xPx, snapshot.yPx);
     this.graphics.clear();
 
     if (!snapshot.isAlive) {
@@ -74,21 +78,21 @@ export class WormSprite {
 
     if (this.isActive && snapshot.isAlive) {
       this.graphics.lineStyle(3, 0xffff00, 1);
-      this.graphics.strokeCircle(snapshot.xPx, snapshot.yPx, r + 4);
+      this.graphics.strokeCircle(0, 0, r + 4);
     }
 
     this.graphics.fillStyle(color, 1);
-    this.graphics.fillCircle(snapshot.xPx, snapshot.yPx, r);
+    this.graphics.fillCircle(0, 0, r);
     this.graphics.lineStyle(1.5, 0xffffff, 0.6);
-    this.graphics.strokeCircle(snapshot.xPx, snapshot.yPx, r);
+    this.graphics.strokeCircle(0, 0, r);
 
     if (this.isActive && snapshot.isAlive) {
       const aimLen = r * 2.2;
-      const ax = snapshot.xPx + Math.cos(snapshot.aimAngle) * snapshot.facing * aimLen;
-      const ay = snapshot.yPx + Math.sin(snapshot.aimAngle) * aimLen;
+      const ax = Math.cos(snapshot.aimAngle) * snapshot.facing * aimLen;
+      const ay = Math.sin(snapshot.aimAngle) * aimLen;
       this.graphics.lineStyle(2, 0xffffff, 0.8);
       this.graphics.beginPath();
-      this.graphics.moveTo(snapshot.xPx, snapshot.yPx);
+      this.graphics.moveTo(0, 0);
       this.graphics.lineTo(ax, ay);
       this.graphics.strokePath();
     }


### PR DESCRIPTION
## Summary

After M6 Phase 1 shipped the 2560x1024 scrolling world, the camera never actually scrolled. Symptom was "only a small sliver of terrain at the bottom" and worms that flew off the viewport looked lost even when they were still inside the world bounds.

**Root cause**: `Worm.graphics` and `WormSprite.graphics` drew their circles at absolute world coords (`fillCircle(xPx, yPx, r)`) while the GameObject's own transform stayed at `(0, 0)`. `camera.startFollow(graphics)` reads the transform, so the camera was "following" `(0, 0)` and clamped to the top-left of the world. With a 720-tall viewport over a 1024-tall world, the terrain surface (~y=563) only showed a ~157px sliver along the top.

**Fix**: set the Graphics transform to the worm's world position each frame and draw shapes origin-relative. Minimal change in both the offline `Worm.drawWorm` and the networked `WormSprite.render` paths. Camera follow now works.

**Side effect**: the perceived "win mechanic lost when worm leaves area" was a consequence of the same bug. Server-side off-map kill already reads the 2560x1024 bounds correctly (`worker/src/sim/simulation.ts:430-442`); the user just couldn't see the worm leave because the camera didn't move. With the fix, camera follows the active worm, and falling past the world edge triggers death as expected.

## Test plan

- [ ] Load a match: scrolls smoothly with the active worm
- [ ] Full terrain is visible (not a thin strip at top)
- [ ] Blow a worm off the right side of the world: it dies, win-check fires
- [ ] `?offline=1` and networked both behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)