### PR TITLE
fix: apply depth-stratum paint in offline mode

### DIFF
--- a/src/terrain/Terrain.ts
+++ b/src/terrain/Terrain.ts
@@ -3,6 +3,7 @@ import { Box } from "planck";
 import type { Body } from "planck";
 import type { PhysicsSystem } from "../physics/PhysicsSystem";
 import { toMeters } from "../physics/scale";
+import { applyStratumPaint } from "./stratumPaint";
 import { TERRAIN_ROW_HEIGHT, scanMaskForBoxes } from "./terrainAlgorithm";
 
 interface TerrainBodyMeta {
@@ -61,6 +62,11 @@ export class Terrain {
     if (!ctx) throw new Error("Terrain: could not get 2D context");
     this.ctx = ctx;
     this.ctx.drawImage(init.sourceMask, 0, 0);
+
+    // Depth-stratum paint: grass/dirt/stone over the mask alpha. Matches
+    // the networked TerrainRenderer so offline + networked look identical
+    // regardless of whether the generator painted its own RGB.
+    applyStratumPaint(this.ctx, this.widthPx, this.heightPx);
 
     // Register canvas with Phaser TextureManager
     const canvasTexture = this.scene.textures.addCanvas(this.textureKey, this.buffer);

--- a/src/terrain/TerrainRenderer.ts
+++ b/src/terrain/TerrainRenderer.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Scene } from "phaser";
+import { applyStratumPaint } from "./stratumPaint";
 
 export interface TerrainRendererInit {
   scene: Scene;
@@ -48,44 +49,7 @@ export class TerrainRenderer {
     this.ctx = ctx;
     this.ctx.drawImage(init.sourceMask, 0, 0);
 
-    // Stratum paint: scan each column top-down for the first solid pixel
-    // (the surface), then paint each pixel's RGB by depth-from-surface.
-    // Grass for the first 6px, dirt for the next 54px, stone below. Alpha
-    // is preserved from the mask so destruction (destination-out) still
-    // works correctly.
-    const img = this.ctx.getImageData(0, 0, this.widthPx, this.heightPx);
-    const data = img.data;
-    for (let x = 0; x < this.widthPx; x++) {
-      let surfaceY = -1;
-      for (let y = 0; y < this.heightPx; y++) {
-        const i = (y * this.widthPx + x) * 4;
-        if (data[i + 3] === 0) continue;
-        if (surfaceY === -1) surfaceY = y;
-        const depth = y - surfaceY;
-        let r: number;
-        let g: number;
-        let b: number;
-        if (depth < 6) {
-          r = 58;
-          g = 122;
-          b = 60;
-        } // grass
-        else if (depth < 60) {
-          r = 122;
-          g = 74;
-          b = 44;
-        } // dirt
-        else {
-          r = 90;
-          g = 90;
-          b = 90;
-        } // stone
-        data[i] = r;
-        data[i + 1] = g;
-        data[i + 2] = b;
-      }
-    }
-    this.ctx.putImageData(img, 0, 0);
+    applyStratumPaint(this.ctx, this.widthPx, this.heightPx);
 
     const canvasTexture = init.scene.textures.addCanvas(this.textureKey, this.buffer);
     if (!canvasTexture) {

--- a/src/terrain/stratumPaint.ts
+++ b/src/terrain/stratumPaint.ts
@@ -1,0 +1,62 @@
+/**
+ * Depth-stratum paint pass.
+ *
+ * Scans each column of a terrain mask top-down for the first opaque
+ * pixel (the surface), then paints each opaque pixel's RGB by its
+ * depth from that surface: grass (0-5px), dirt (6-59px), stone (60+px).
+ * Alpha is preserved, so destruction (destination-out) keeps working.
+ *
+ * Shared between the offline `Terrain` and networked `TerrainRenderer`
+ * so both code paths produce the same Terraria-style look regardless
+ * of whether the source mask came from a local generator or the server.
+ */
+
+const GRASS_R = 58;
+const GRASS_G = 122;
+const GRASS_B = 60;
+const DIRT_R = 122;
+const DIRT_G = 74;
+const DIRT_B = 44;
+const STONE_R = 90;
+const STONE_G = 90;
+const STONE_B = 90;
+const GRASS_DEPTH_PX = 6;
+const DIRT_DEPTH_PX = 60;
+
+export function applyStratumPaint(
+  ctx: CanvasRenderingContext2D,
+  widthPx: number,
+  heightPx: number,
+): void {
+  const img = ctx.getImageData(0, 0, widthPx, heightPx);
+  const data = img.data;
+  for (let x = 0; x < widthPx; x++) {
+    let surfaceY = -1;
+    for (let y = 0; y < heightPx; y++) {
+      const i = (y * widthPx + x) * 4;
+      if (data[i + 3] === 0) continue;
+      if (surfaceY === -1) surfaceY = y;
+      const depth = y - surfaceY;
+      let r: number;
+      let g: number;
+      let b: number;
+      if (depth < GRASS_DEPTH_PX) {
+        r = GRASS_R;
+        g = GRASS_G;
+        b = GRASS_B;
+      } else if (depth < DIRT_DEPTH_PX) {
+        r = DIRT_R;
+        g = DIRT_G;
+        b = DIRT_B;
+      } else {
+        r = STONE_R;
+        g = STONE_G;
+        b = STONE_B;
+      }
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}


### PR DESCRIPTION
## Summary

M6 Phase 1 introduced the grass/dirt/stone depth-stratum paint pass, but only in the networked \`TerrainRenderer\`. The offline \`Terrain\` class was missed, so \`?offline=1&map=terraworld\` rendered pure-white terrain, and legacy offline maps showed whatever color the generator painted (e.g. \`#4a6a3c\` for bridges). Offline mode diverged visually from networked mode.

## Fix

Extract the stratum paint into \`src/terrain/stratumPaint.ts\`. Both \`Terrain\` (offline) and \`TerrainRenderer\` (networked) call the same helper right after copying the source mask into their internal buffer. Offline now matches networked exactly regardless of what the map generator painted.

## How this got caught

Ran a browser visual-QA sweep after the PR #99 camera-follow fix. Canvas pixel sampling at (640, 400) came back pure white in offline \`terraworld\`; bridges came back \`#4a6a3c\`. Both were supposed to be stratum-colored.

## Test plan

- [ ] \`?offline=1&map=terraworld\`: terrain shows grass/dirt/stone bands
- [ ] \`?offline=1&map=bridges\`: terrain also shows stratum colors (generator \`fillStyle\` overridden)
- [ ] Networked room: unchanged from before (same helper, same result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)