### PR TITLE
fix: aim HUD follows camera scroll

### DIFF
--- a/src/ui/AimHUD.ts
+++ b/src/ui/AimHUD.ts
@@ -27,7 +27,9 @@ export class AimHUD {
     this.isInputAllowed = init.isInputAllowed;
 
     this.gfx = init.scene.add.graphics();
-    this.gfx.setDepth(20).setScrollFactor(0);
+    // No setScrollFactor(0): drawing uses world coords (worm.xPx/yPx),
+    // so the HUD must scroll with the camera like the worm does.
+    this.gfx.setDepth(20);
   }
 
   /** Call each frame from GameScene.update. Clears and redraws. */


### PR DESCRIPTION
## Summary

AimHUD had \`setScrollFactor(0)\` (viewport-locked) but drew the arrow + power bar at \`worm.xPx\` / \`worm.yPx\` which are world coords. In the 1280x720 single-screen world they coincided. In the 2560x1024 scrolling world they don't: the HUD renders at \`(wx, wy)\` in the viewport while the worm renders at \`(wx - scrollX, wy - scrollY)\`. Result was an arrow floating well below the active worm (Scott's screenshot: ~125px vertical offset, matching the camera scrollY).

Same class of bug as the M6 Phase 1 camera-follow regression.

## Fix

Drop \`setScrollFactor(0)\`. The drawing already uses world coords, so the Graphics should scroll with the camera like the worm it tracks.

## Test plan

- [ ] Active worm near screen edge: aim arrow originates from the worm
- [ ] After walking (camera scrolls): HUD stays attached to the worm
- [ ] Power bar renders just under the worm, not 100+px below

🤖 Generated with [Claude Code](https://claude.com/claude-code)