### PR TITLE
feat(camera): turn-transition zoom animation with adaptive net-hold

### DIFF
--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -32,6 +32,7 @@ export class InputController {
   private readonly onAimPowerChange: (power: number) => void;
   private activeWorm: Worm | null = null;
   private inputAllowed = false;
+  private transitioning = false;
   // Track last walk direction so we only fire onWalk on transitions
   // (matches the server contract: press -> send {dir:-1}, release -> send {dir:0}).
   private lastWalkDir: -1 | 0 | 1 = 0;
@@ -130,6 +131,10 @@ export class InputController {
     this.inputAllowed = allowed;
   }
 
+  setTransitioning(v: boolean): void {
+    this.transitioning = v;
+  }
+
   /**
    * Reset the local walk-direction cache to 0 (stopped). Called when
    * network ownership flips away from this client so that the NEXT time
@@ -153,7 +158,7 @@ export class InputController {
    * is the only path that drives the active worm.
    */
   isInputAllowed(): boolean {
-    return this.inputAllowed;
+    return this.inputAllowed && !this.transitioning;
   }
 
   getActiveWorm(): Worm | null {
@@ -173,7 +178,7 @@ export class InputController {
 
   /** Called from GameScene.update. Polls keys, dispatches to active worm. */
   update(dtMs: number): void {
-    if (!this.inputAllowed) return;
+    if (!this.inputAllowed || this.transitioning) return;
 
     // Enter ends turn
     if (Phaser.Input.Keyboard.JustDown(this.keyEnter)) {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -22,6 +22,7 @@ import { ReconnectingOverlay } from "../ui/ReconnectingOverlay";
 import { SpectatorHUD } from "../ui/SpectatorHUD";
 import { TouchControls } from "../ui/TouchControls";
 import { TurnHUD } from "../ui/TurnHUD";
+import { TurnTransition } from "../ui/TurnTransition";
 import { UtilityDPad } from "../ui/UtilityDPad";
 import { WeaponDrawer } from "../ui/WeaponDrawer";
 import { WindHUD } from "../ui/WindHUD";
@@ -82,6 +83,7 @@ export class GameScene extends Phaser.Scene {
    * are refreshed each frame in `update`. */
   private utilityDPad: UtilityDPad | null = null;
   private utilityDPadVisible = false;
+  private turnTransition: TurnTransition | null = null;
 
   // ---- Pointer-gesture state (primary pointer only) ----
   /** Gesture state machine shared across pointer events. Stores last-release
@@ -251,6 +253,8 @@ export class GameScene extends Phaser.Scene {
       // destroys can't leave an active onStateChange listener that keeps
       // firing (and attempting scene.start) after we've moved on.
       this.tearDownRoomListeners();
+      this.turnTransition?.destroy();
+      this.turnTransition = null;
       try {
         this.sim.destroy();
       } catch {
@@ -384,6 +388,23 @@ export class GameScene extends Phaser.Scene {
     // blank space outside the terrain. The camera will follow the active worm
     // once handleTurnChanged fires.
     this.cameras.main.setBounds(0, 0, sceneWidthPx, sceneHeightPx);
+
+    this.turnTransition = new TurnTransition({
+      scene: this,
+      sim: this.sim,
+      worldWidthPx: sceneWidthPx,
+      worldHeightPx: sceneHeightPx,
+      resolveFollowTarget: (wormId) => {
+        if (this.offlineSim) {
+          const w = this.offlineSim.wormsInternal.find((worm) => worm.name === wormId);
+          return w?.graphicsObject ?? null;
+        }
+        return this.wormSprites.get(wormId)?.graphics ?? null;
+      },
+      onTransitioningChanged: (t) => {
+        this.inputController?.setTransitioning(t);
+      },
+    });
 
     this.debugGfx = this.add.graphics();
     this.debugGfx.setDepth(10);
@@ -557,6 +578,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private handleGameOver(winnerTeamId: string | null): void {
+    this.turnTransition?.cancel();
     this.inputController?.setInputAllowed(false);
     this.turnHUD?.setEndTurnEnabled(false);
     this.spectatorHUD?.hide();
@@ -632,10 +654,6 @@ export class GameScene extends Phaser.Scene {
     if (this.offlineSim) {
       const activeWorm = this.offlineSim.wormsInternal.find((w) => w.name === _wormId);
       if (activeWorm) this.inputController?.setActiveWorm(activeWorm);
-      // Follow the offline worm's physics body renderer.
-      if (activeWorm) {
-        this.cameras.main.startFollow(activeWorm.graphicsObject, true, 0.08, 0.08);
-      }
     } else if (this.networkedSim) {
       // Wrap the render view in a facade so InputController has something
       // to read xPx / facing / aimAngle from. The facade's mutator methods
@@ -644,13 +662,9 @@ export class GameScene extends Phaser.Scene {
       this.inputController?.setActiveWorm(
         view ? adaptRenderableToWormFacade(view, () => this.sim.isJetPacking(), this.sim) : null,
       );
-      // Follow the networked worm sprite's graphics object.
-      const sprite = this.wormSprites.get(_wormId);
-      const followTarget = sprite?.graphics ?? null;
-      if (followTarget) {
-        this.cameras.main.startFollow(followTarget, true, 0.08, 0.08);
-      }
     }
+    // Delegate camera follow to TurnTransition for zoom-out/hold/zoom-in animation.
+    this.turnTransition?.begin(teamId, _wormId);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -25,6 +25,7 @@ import type {
   WormDiedMessage,
 } from "../net/types";
 import type { RoomHandle } from "../net/wsClient";
+import { tuning } from "../tuning";
 import { Team } from "../worm/Team";
 import type { RenderableProjectile, RenderableWorm, SimAdapter, SimEvent } from "./SimAdapter";
 
@@ -61,6 +62,11 @@ export class NetworkedSimAdapter implements SimAdapter {
   private readonly gameOverSubs = new Set<(winnerTeamId: string | null) => void>();
   private readonly turnChangedSubs = new Set<(teamId: string, wormId: string) => void>();
   private readonly inputAllowedSubs = new Set<(allowed: boolean) => void>();
+  private readonly stableSubs: Array<() => void> = [];
+  private framesSinceTurnChange = 0;
+  private stableFiredThisTurn = false;
+  private stableTurnTeamId: string | null = null;
+  private stableTurnWormId: string | null = null;
 
   /**
    * Two-frame interpolation buffer. `prev` is the previous sim_state;
@@ -308,6 +314,7 @@ export class NetworkedSimAdapter implements SimAdapter {
     this.gameOverSubs.clear();
     this.turnChangedSubs.clear();
     this.inputAllowedSubs.clear();
+    this.stableSubs.length = 0;
   }
 
   onEvent(cb: (ev: SimEvent) => void): () => void {
@@ -335,6 +342,14 @@ export class NetworkedSimAdapter implements SimAdapter {
     this.inputAllowedSubs.add(cb);
     return () => {
       this.inputAllowedSubs.delete(cb);
+    };
+  }
+
+  onStateStable(cb: () => void): () => void {
+    this.stableSubs.push(cb);
+    return () => {
+      const i = this.stableSubs.indexOf(cb);
+      if (i >= 0) this.stableSubs.splice(i, 1);
     };
   }
 
@@ -431,8 +446,27 @@ export class NetworkedSimAdapter implements SimAdapter {
     ) {
       this.lastActiveTeamId = state.activeTeamId;
       this.lastActiveWormId = state.activeWormId;
+      // Reset stability tracking for the new turn.
+      this.framesSinceTurnChange = 0;
+      this.stableFiredThisTurn = false;
+      this.stableTurnTeamId = state.activeTeamId;
+      this.stableTurnWormId = state.activeWormId;
       for (const sub of this.turnChangedSubs) sub(state.activeTeamId, state.activeWormId);
     }
+
+    // Stability tracking: after N consecutive frames reporting the same
+    // activeTeamId/activeWormId, consider the turn state settled.
+    this.framesSinceTurnChange += 1;
+    if (
+      !this.stableFiredThisTurn &&
+      state.activeTeamId === this.stableTurnTeamId &&
+      state.activeWormId === this.stableTurnWormId &&
+      this.framesSinceTurnChange >= tuning.camera.networkStabilityFrames
+    ) {
+      this.stableFiredThisTurn = true;
+      for (const sub of this.stableSubs) sub();
+    }
+
     this.lastTurnEndsAt = state.turnEndsAt;
   }
 

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -464,7 +464,9 @@ export class NetworkedSimAdapter implements SimAdapter {
       this.framesSinceTurnChange >= tuning.camera.networkStabilityFrames
     ) {
       this.stableFiredThisTurn = true;
-      for (const sub of this.stableSubs) sub();
+      // Iterate a copy so a subscriber that unsubs itself mid-fire
+      // doesn't cause us to skip the next entry.
+      for (const sub of [...this.stableSubs]) sub();
     }
 
     this.lastTurnEndsAt = state.turnEndsAt;

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -71,6 +71,7 @@ export class OfflineSimAdapter implements SimAdapter {
   private readonly gameOverSubs = new Set<(winnerTeamId: string | null) => void>();
   private readonly turnChangedSubs = new Set<(teamId: string, wormId: string) => void>();
   private readonly inputAllowedSubs = new Set<(allowed: boolean) => void>();
+  private readonly stableStateSubs = new Set<() => void>();
 
   // Rendering mirror: OfflineSimAdapter's Worms own their own sprites for
   // backward compat with the pre-Epic-45 flow. RenderableWorm[] is a thin
@@ -162,6 +163,10 @@ export class OfflineSimAdapter implements SimAdapter {
         this.setInputAllowed(true);
         this.getWeaponManager(team)?.resetActivation();
         for (const sub of this.turnChangedSubs) sub(team.id, worm.name);
+        // Offline sim is always immediately stable - fire stable subs on next microtask.
+        queueMicrotask(() => {
+          for (const sub of this.stableStateSubs) sub();
+        });
       },
       onTurnEnd: () => {
         this.setInputAllowed(false);
@@ -382,6 +387,7 @@ export class OfflineSimAdapter implements SimAdapter {
     this.gameOverSubs.clear();
     this.turnChangedSubs.clear();
     this.inputAllowedSubs.clear();
+    this.stableStateSubs.clear();
   }
 
   onEvent(cb: (ev: SimEvent) => void): () => void {
@@ -409,6 +415,13 @@ export class OfflineSimAdapter implements SimAdapter {
     this.inputAllowedSubs.add(cb);
     return () => {
       this.inputAllowedSubs.delete(cb);
+    };
+  }
+
+  onStateStable(cb: () => void): () => void {
+    this.stableStateSubs.add(cb);
+    return () => {
+      this.stableStateSubs.delete(cb);
     };
   }
 

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -108,6 +108,15 @@ export interface SimAdapter {
   onTurnChanged(cb: (activeTeamId: string, activeWormId: string) => void): () => void;
   /** Called when input-allowed changes (e.g. we become active, or turn-end lands). */
   onInputAllowedChanged(cb: (allowed: boolean) => void): () => void;
+  /**
+   * Fires once per turn-change when the sim's next-turn state is
+   * "committed". Offline: fires on next microtask after onTurnChanged.
+   * Networked: fires after N consecutive sim_state frames report the
+   * same active team/worm as the latest turn_changed.
+   * Used by TurnTransition to stretch the hold-at-overview phase
+   * adaptively across flaky connections.
+   */
+  onStateStable(cb: () => void): () => void;
 }
 
 /**

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -92,6 +92,13 @@ interface Tuning {
   wind: {
     forceNewtonsPerUnit: number;
   };
+  camera: {
+    turnZoomOutMs: number;
+    turnHoldMinMs: number;
+    turnHoldMaxMs: number;
+    turnZoomInMs: number;
+    networkStabilityFrames: number;
+  };
 }
 
 export const tuning: Tuning = {
@@ -165,4 +172,11 @@ export const tuning: Tuning = {
     surfaceBufferPx: 80,
   },
   wind: { forceNewtonsPerUnit: 2 },
+  camera: {
+    turnZoomOutMs: 800,
+    turnHoldMinMs: 700,
+    turnHoldMaxMs: 3000,
+    turnZoomInMs: 500,
+    networkStabilityFrames: 3,
+  },
 };

--- a/src/ui/TurnTransition.test.ts
+++ b/src/ui/TurnTransition.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TurnTransition } from "./TurnTransition";
+
+function makeMocks() {
+  const cameraCalls: Array<string> = [];
+  // Store pan callbacks so tests can trigger them manually
+  let panCallback: ((cam: object, progress: number) => void) | undefined;
+
+  const camera = {
+    zoom: 1,
+    scrollX: 0,
+    scrollY: 0,
+    width: 1280,
+    height: 720,
+    stopFollow: vi.fn(() => cameraCalls.push("stopFollow")),
+    startFollow: vi.fn(() => cameraCalls.push("startFollow")),
+    zoomTo: vi.fn((zoom: number, _duration: number, _ease?: string, _force?: boolean) => {
+      cameraCalls.push(`zoomTo:${zoom}`);
+    }),
+    pan: vi.fn(
+      (
+        x: number,
+        y: number,
+        _duration: number,
+        _ease?: string,
+        _force?: boolean,
+        cb?: (cam: object, progress: number) => void,
+      ) => {
+        cameraCalls.push(`pan:${x},${y}`);
+        panCallback = cb;
+        // Simulate completion asynchronously for tests that need it
+        if (cb) queueMicrotask(() => cb({}, 1.0));
+      },
+    ),
+  };
+
+  const scene = {
+    cameras: { main: camera },
+    scale: { width: 1280, height: 720 },
+    time: {
+      delayedCall: vi.fn((_ms: number, cb: () => void) => setTimeout(cb, 0)),
+    },
+  };
+
+  const stableSubs: Array<() => void> = [];
+  const sim = {
+    onStateStable: vi.fn((cb: () => void) => {
+      stableSubs.push(cb);
+      return () => {
+        const i = stableSubs.indexOf(cb);
+        if (i >= 0) stableSubs.splice(i, 1);
+      };
+    }),
+  };
+
+  const onTransitioningChanged = vi.fn();
+  const resolveFollowTarget = vi.fn((_id: string) => ({ x: 500, y: 300 }));
+
+  function fireStable() {
+    for (const sub of stableSubs) sub();
+  }
+
+  function firePanCallback(progress: number) {
+    if (panCallback) panCallback({}, progress);
+  }
+
+  return {
+    scene,
+    sim,
+    onTransitioningChanged,
+    resolveFollowTarget,
+    cameraCalls,
+    stableSubs,
+    fireStable,
+    firePanCallback,
+  };
+}
+
+function makeTurnTransition(mocks: ReturnType<typeof makeMocks>) {
+  return new TurnTransition({
+    scene: mocks.scene as never,
+    sim: mocks.sim as never,
+    worldWidthPx: 2560,
+    worldHeightPx: 1024,
+    resolveFollowTarget: mocks.resolveFollowTarget as never,
+    onTransitioningChanged: mocks.onTransitioningChanged,
+  });
+}
+
+describe("TurnTransition", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("begin() transitions from IDLE and fires expected camera calls + onTransitioningChanged(true)", () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    expect(tt.isTransitioning()).toBe(false);
+
+    tt.begin("red", "red-1");
+
+    expect(tt.isTransitioning()).toBe(true);
+    expect(mocks.onTransitioningChanged).toHaveBeenCalledWith(true);
+    expect(mocks.cameraCalls).toContain("stopFollow");
+    // zoomTo called with fit zoom (1280/2560 = 0.5)
+    expect(mocks.cameraCalls.some((c) => c.startsWith("zoomTo:"))).toBe(true);
+    // pan called toward world center
+    expect(mocks.cameraCalls.some((c) => c.startsWith("pan:"))).toBe(true);
+    expect(mocks.scene.cameras.main.zoomTo).toHaveBeenCalled();
+    expect(mocks.scene.cameras.main.pan).toHaveBeenCalled();
+  });
+
+  it("pan callback with progress=1.0 during ZOOMING_OUT moves state to HOLDING", async () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    // Wait for the queueMicrotask to fire the pan callback
+    await Promise.resolve();
+
+    // State should now be HOLDING - still transitioning
+    expect(tt.isTransitioning()).toBe(true);
+  });
+
+  it("HOLDING -> ZOOMING_IN when stable fires AND min hold elapses", async () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    // Wait for pan callback (ZOOMING_OUT -> HOLDING)
+    await Promise.resolve();
+
+    // Fire stable signal
+    mocks.fireStable();
+
+    // Still holding because min hold timer hasn't elapsed
+    expect(tt.isTransitioning()).toBe(true);
+
+    // Advance min hold timer
+    vi.advanceTimersByTime(700);
+
+    // Now should be ZOOMING_IN - another zoomTo + pan
+    expect(mocks.scene.cameras.main.zoomTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("zoom-in pan completion -> IDLE, startFollow called, onTransitioningChanged(false)", async () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    // ZOOMING_OUT -> HOLDING via pan callback
+    await Promise.resolve();
+
+    // stable + min hold
+    mocks.fireStable();
+    vi.advanceTimersByTime(700);
+
+    // ZOOMING_IN pan callback fires
+    await Promise.resolve();
+
+    // Should be IDLE now
+    expect(tt.isTransitioning()).toBe(false);
+    expect(mocks.onTransitioningChanged).toHaveBeenCalledWith(false);
+    expect(mocks.cameraCalls).toContain("startFollow");
+  });
+
+  it("cancel() during ZOOMING_OUT resets to IDLE and fires onTransitioningChanged(false)", () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+    expect(tt.isTransitioning()).toBe(true);
+
+    tt.cancel();
+
+    expect(tt.isTransitioning()).toBe(false);
+    expect(mocks.onTransitioningChanged).toHaveBeenCalledWith(false);
+  });
+
+  it("back-to-back begin() cancels in-flight and starts new transition", async () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+    expect(tt.isTransitioning()).toBe(true);
+
+    // Second begin cancels and restarts
+    tt.begin("blue", "blue-1");
+
+    expect(tt.isTransitioning()).toBe(true);
+    // onTransitioningChanged(false) from cancel then (true) from new begin
+    const calls = mocks.onTransitioningChanged.mock.calls.map((c) => c[0]);
+    expect(calls).toContain(false);
+    expect(calls[calls.length - 1]).toBe(true);
+  });
+
+  it("isTransitioning() reflects the current state", () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    expect(tt.isTransitioning()).toBe(false);
+
+    tt.begin("red", "red-1");
+    expect(tt.isTransitioning()).toBe(true);
+
+    tt.cancel();
+    expect(tt.isTransitioning()).toBe(false);
+  });
+
+  it("maxHoldTimer fires stable + advances even if onStateStable never fires", async () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+    await Promise.resolve();
+
+    // Advance past max hold without firing stable
+    vi.advanceTimersByTime(3000);
+
+    // Should have moved to ZOOMING_IN (max hold cap fired)
+    expect(mocks.scene.cameras.main.zoomTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("destroy() unsubscribes stable and cancels", () => {
+    const mocks = makeMocks();
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+    tt.destroy();
+
+    expect(tt.isTransitioning()).toBe(false);
+    // Stable sub should have been removed
+    expect(mocks.stableSubs.length).toBe(0);
+  });
+});

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -1,0 +1,197 @@
+import type Phaser from "phaser";
+import type { SimAdapter } from "../sim/SimAdapter";
+import { tuning } from "../tuning";
+
+export interface TurnTransitionInit {
+  scene: Phaser.Scene;
+  sim: SimAdapter;
+  worldWidthPx: number;
+  worldHeightPx: number;
+  /** Resolve the GameObject the camera should follow at zoom-in completion. */
+  resolveFollowTarget: (wormId: string) => Phaser.GameObjects.GameObject | null;
+  /** Called when transitioning state changes (for input gating). */
+  onTransitioningChanged: (transitioning: boolean) => void;
+}
+
+type State = "IDLE" | "ZOOMING_OUT" | "HOLDING" | "ZOOMING_IN";
+
+/**
+ * Owns the camera's turn-change animation: zoom out to world, hold
+ * for a min dwell (stretched adaptively while networked state is
+ * stabilizing), then zoom back in on the new active worm. Input is
+ * gated OFF for the duration.
+ *
+ * Integrates with SimAdapter.onStateStable to know when the server's
+ * next-turn state has settled (networked mode) or always-stable
+ * (offline).
+ */
+export class TurnTransition {
+  private readonly scene: Phaser.Scene;
+  private readonly sim: SimAdapter;
+  private readonly worldWidthPx: number;
+  private readonly worldHeightPx: number;
+  private readonly resolveFollowTarget: (wormId: string) => Phaser.GameObjects.GameObject | null;
+  private readonly onTransitioningChanged: (t: boolean) => void;
+  private readonly unsubStable: () => void;
+
+  private state: State = "IDLE";
+  private pendingWormId: string | null = null;
+  private stableObserved = false;
+  private minHoldTimer: ReturnType<typeof setTimeout> | null = null;
+  private maxHoldTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(init: TurnTransitionInit) {
+    this.scene = init.scene;
+    this.sim = init.sim;
+    this.worldWidthPx = init.worldWidthPx;
+    this.worldHeightPx = init.worldHeightPx;
+    this.resolveFollowTarget = init.resolveFollowTarget;
+    this.onTransitioningChanged = init.onTransitioningChanged;
+    this.unsubStable = this.sim.onStateStable(() => this.handleStateStable());
+  }
+
+  /** Kick off a new transition. Cancels any in-flight animation. */
+  begin(_teamId: string, wormId: string): void {
+    this.cancel();
+    this.pendingWormId = wormId;
+    this.stableObserved = false;
+    this.setState("ZOOMING_OUT");
+    this.onTransitioningChanged(true);
+
+    const camera = this.scene.cameras.main;
+    camera.stopFollow();
+
+    const fitZoom = this.computeFitZoom();
+    const centerX = this.worldWidthPx / 2;
+    const centerY = this.worldHeightPx / 2;
+
+    camera.zoomTo(fitZoom, tuning.camera.turnZoomOutMs, "Sine.easeInOut", true);
+    camera.pan(
+      centerX,
+      centerY,
+      tuning.camera.turnZoomOutMs,
+      "Sine.easeInOut",
+      true,
+      (_c: Phaser.Cameras.Scene2D.Camera, progress: number) => {
+        if (progress >= 1 && this.state === "ZOOMING_OUT") {
+          this.enterHolding();
+        }
+      },
+    );
+  }
+
+  /** Cancel any in-flight animation and return to IDLE. */
+  cancel(): void {
+    if (this.state === "IDLE") return;
+    const camera = this.scene.cameras.main;
+    // Stop in-flight tweens by issuing an instantaneous pan/zoom at current state.
+    camera.pan(
+      camera.scrollX + camera.width / 2,
+      camera.scrollY + camera.height / 2,
+      0,
+      "Linear",
+      true,
+    );
+    camera.zoomTo(camera.zoom, 0, "Linear", true);
+    if (this.minHoldTimer) clearTimeout(this.minHoldTimer);
+    if (this.maxHoldTimer) clearTimeout(this.maxHoldTimer);
+    this.minHoldTimer = null;
+    this.maxHoldTimer = null;
+    this.pendingWormId = null;
+    this.stableObserved = false;
+    this.setState("IDLE");
+    this.onTransitioningChanged(false);
+  }
+
+  isTransitioning(): boolean {
+    return this.state !== "IDLE";
+  }
+
+  destroy(): void {
+    this.cancel();
+    this.unsubStable();
+  }
+
+  // ---- Internal ----
+
+  private setState(next: State): void {
+    this.state = next;
+  }
+
+  private computeFitZoom(): number {
+    const vw = this.scene.scale.width;
+    const vh = this.scene.scale.height;
+    return Math.min(vw / this.worldWidthPx, vh / this.worldHeightPx);
+  }
+
+  private enterHolding(): void {
+    this.setState("HOLDING");
+
+    // Minimum dwell timer
+    this.minHoldTimer = setTimeout(() => {
+      this.minHoldTimer = null;
+      this.maybeLeaveHold();
+    }, tuning.camera.turnHoldMinMs);
+
+    // Maximum dwell safety cap (even if state never stabilizes)
+    this.maxHoldTimer = setTimeout(() => {
+      this.maxHoldTimer = null;
+      this.stableObserved = true;
+      this.maybeLeaveHold();
+    }, tuning.camera.turnHoldMaxMs);
+  }
+
+  private handleStateStable(): void {
+    if (this.state !== "HOLDING" && this.state !== "ZOOMING_OUT") return;
+    this.stableObserved = true;
+    if (this.state === "HOLDING") this.maybeLeaveHold();
+  }
+
+  private maybeLeaveHold(): void {
+    if (this.state !== "HOLDING") return;
+    if (!this.stableObserved) return;
+    if (this.minHoldTimer !== null) return; // min hold not yet elapsed
+    this.enterZoomingIn();
+  }
+
+  private enterZoomingIn(): void {
+    if (this.maxHoldTimer) clearTimeout(this.maxHoldTimer);
+    this.maxHoldTimer = null;
+    this.setState("ZOOMING_IN");
+
+    const camera = this.scene.cameras.main;
+    const target = this.pendingWormId ? this.resolveFollowTarget(this.pendingWormId) : null;
+
+    if (!target) {
+      // No target - fail gracefully back to idle without a zoom-in.
+      camera.zoomTo(1, tuning.camera.turnZoomInMs, "Sine.easeInOut", true);
+      this.scene.time.delayedCall(tuning.camera.turnZoomInMs, () => this.finishToIdle(null));
+      return;
+    }
+
+    // target is a Phaser GameObject with x/y we can read
+    const g = target as unknown as { x: number; y: number };
+    camera.zoomTo(1, tuning.camera.turnZoomInMs, "Sine.easeInOut", true);
+    camera.pan(
+      g.x,
+      g.y,
+      tuning.camera.turnZoomInMs,
+      "Sine.easeInOut",
+      true,
+      (_c: Phaser.Cameras.Scene2D.Camera, progress: number) => {
+        if (progress >= 1 && this.state === "ZOOMING_IN") {
+          this.finishToIdle(target);
+        }
+      },
+    );
+  }
+
+  private finishToIdle(followTarget: Phaser.GameObjects.GameObject | null): void {
+    const camera = this.scene.cameras.main;
+    if (followTarget) camera.startFollow(followTarget, true, 0.08, 0.08);
+    this.pendingWormId = null;
+    this.stableObserved = false;
+    this.setState("IDLE");
+    this.onTransitioningChanged(false);
+  }
+}

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -39,6 +39,15 @@ export class TurnTransition {
   private stableObserved = false;
   private minHoldTimer: ReturnType<typeof setTimeout> | null = null;
   private maxHoldTimer: ReturnType<typeof setTimeout> | null = null;
+  // Monotonic id for the current transition. Incremented on every begin()
+  // and cancel(). Tween callbacks and delayedCalls capture this value in
+  // closure and compare before acting, so a stale callback from a
+  // superseded transition can't flip state on a live one.
+  private generation = 0;
+  // Handle for the delayedCall scheduled in the null-target path of
+  // enterZoomingIn. Must be cleared on cancel(); otherwise a late fire
+  // could drop the live transition back to IDLE.
+  private zoomInDelayed: Phaser.Time.TimerEvent | null = null;
 
   constructor(init: TurnTransitionInit) {
     this.scene = init.scene;
@@ -53,6 +62,8 @@ export class TurnTransition {
   /** Kick off a new transition. Cancels any in-flight animation. */
   begin(_teamId: string, wormId: string): void {
     this.cancel();
+    this.generation += 1;
+    const gen = this.generation;
     this.pendingWormId = wormId;
     this.stableObserved = false;
     this.setState("ZOOMING_OUT");
@@ -73,7 +84,7 @@ export class TurnTransition {
       "Sine.easeInOut",
       true,
       (_c: Phaser.Cameras.Scene2D.Camera, progress: number) => {
-        if (progress >= 1 && this.state === "ZOOMING_OUT") {
+        if (progress >= 1 && this.state === "ZOOMING_OUT" && gen === this.generation) {
           this.enterHolding();
         }
       },
@@ -83,6 +94,9 @@ export class TurnTransition {
   /** Cancel any in-flight animation and return to IDLE. */
   cancel(): void {
     if (this.state === "IDLE") return;
+    // Bump generation so any pending tween / delayedCall callback is
+    // invalidated and becomes a no-op when it eventually fires.
+    this.generation += 1;
     const camera = this.scene.cameras.main;
     // Stop in-flight tweens by issuing an instantaneous pan/zoom at current state.
     camera.pan(
@@ -95,8 +109,10 @@ export class TurnTransition {
     camera.zoomTo(camera.zoom, 0, "Linear", true);
     if (this.minHoldTimer) clearTimeout(this.minHoldTimer);
     if (this.maxHoldTimer) clearTimeout(this.maxHoldTimer);
+    if (this.zoomInDelayed) this.zoomInDelayed.remove(false);
     this.minHoldTimer = null;
     this.maxHoldTimer = null;
+    this.zoomInDelayed = null;
     this.pendingWormId = null;
     this.stableObserved = false;
     this.setState("IDLE");
@@ -158,6 +174,7 @@ export class TurnTransition {
     if (this.maxHoldTimer) clearTimeout(this.maxHoldTimer);
     this.maxHoldTimer = null;
     this.setState("ZOOMING_IN");
+    const gen = this.generation;
 
     const camera = this.scene.cameras.main;
     const target = this.pendingWormId ? this.resolveFollowTarget(this.pendingWormId) : null;
@@ -165,7 +182,10 @@ export class TurnTransition {
     if (!target) {
       // No target - fail gracefully back to idle without a zoom-in.
       camera.zoomTo(1, tuning.camera.turnZoomInMs, "Sine.easeInOut", true);
-      this.scene.time.delayedCall(tuning.camera.turnZoomInMs, () => this.finishToIdle(null));
+      this.zoomInDelayed = this.scene.time.delayedCall(tuning.camera.turnZoomInMs, () => {
+        this.zoomInDelayed = null;
+        if (gen === this.generation) this.finishToIdle(null);
+      });
       return;
     }
 
@@ -179,7 +199,7 @@ export class TurnTransition {
       "Sine.easeInOut",
       true,
       (_c: Phaser.Cameras.Scene2D.Camera, progress: number) => {
-        if (progress >= 1 && this.state === "ZOOMING_IN") {
+        if (progress >= 1 && this.state === "ZOOMING_IN" && gen === this.generation) {
           this.finishToIdle(target);
         }
       },


### PR DESCRIPTION
## Summary

On every turn change the camera zooms out to fit the whole 2560×1024 world, holds at the overview for a minimum dwell (stretched adaptively while networked state is settling), then zooms in on the new active worm and resumes follow. Doubles as a natural mask for network turn-handshake latency - fast clients get a consistent 2s transition, slow clients hold longer at the overview instead of showing choppy in-between frames.

Also addresses the "Blue-1 walked off the edge because they couldn't see anyone" scenario: every turn start shows the full battlefield.

## Files changed

- `src/ui/TurnTransition.ts` (new): state machine (IDLE → ZOOMING_OUT → HOLDING → ZOOMING_IN), camera.zoomTo + camera.pan with force override, monotonic generation counter so stale callbacks from superseded transitions no-op.
- `src/ui/TurnTransition.test.ts` (new): 9 state-machine tests.
- `src/sim/SimAdapter.ts`: new `onStateStable(cb)` method on the interface.
- `src/sim/OfflineSimAdapter.ts`: fires stable via queueMicrotask after each turn change (trivially always-stable, no network to wait for).
- `src/sim/NetworkedSimAdapter.ts`: fires stable after N (=3) consecutive sim_state frames with matching activeTeamId/activeWormId since the last turn_changed. Also iterates a spread-copy of the subscriber list so unsub-during-fire doesn't skip subs.
- `src/scenes/GameScene.ts`: instantiates TurnTransition in create(), delegates camera follow from handleTurnChanged, cancels on game-over, destroys on SHUTDOWN.
- `src/input/InputController.ts`: new `setTransitioning(bool)` gate that ANDs with `inputAllowed` so the active player can't pre-fire before the camera lands.
- `src/tuning.ts`: new `camera` section (turnZoomOutMs=800, turnHoldMinMs=700, turnHoldMaxMs=3000, turnZoomInMs=500, networkStabilityFrames=3).

## Bug check

Ran 4 lenses over the state machine + networked stability path + GameScene wiring + Phaser Scale.FIT interaction. Three real fixes applied inline:

1. **Generation counter**: tween callbacks from superseded begin() calls now no-op against a captured gen vs live gen.
2. **delayedCall handle**: null-target zoom-in path stores the Phaser TimerEvent + removes it in cancel() so late fires can't drop state.
3. **stableSubs iteration**: NetworkedSimAdapter iterates `[...stableSubs]` instead of the live array so a subscriber that unsubs mid-fire doesn't skip the next sub.

Two "Critical" findings from one Haiku lens were false positives (counter-orphaned scenario misread the turn-change detection; spectator-null-init doesn't happen because `lastActive` starts as empty string and first sim_state always triggers turn-change).

## Known limitations

- No pinch-to-zoom or free-pan during a player's turn yet. If playtest shows the overview + follow isn't enough to plan shots, that's the next camera-UX epic.
- Dimensions passed to TurnTransition at create() time. If a future map uses non-default world dims before networked `game_started` lands, the fit-zoom could be slightly off on the first transition. Low risk since all maps are 2560×1024 today.

## Manual tests

- [ ] Every turn: camera zooms out to show the whole world, holds, zooms in on the new active worm
- [ ] Feels smooth; no visible jerk at transitions
- [ ] Active player can't walk/fire during the transition (input gated)
- [ ] Game over: banner appears cleanly without a zoom fighting it
- [ ] Networked mode on a slow connection: overview hold stretches naturally instead of skipping or double-transitioning
- [ ] Offline mode (\`?offline=1\`): transitions are always ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)