### PR TITLE
feat(camera): follow projectile after fire, return to worm on despawn

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -18,6 +18,7 @@ import { TerrainRenderer } from "../terrain/TerrainRenderer";
 import { WaterRenderer } from "../terrain/WaterRenderer";
 import { tuning } from "../tuning";
 import { AimHUD } from "../ui/AimHUD";
+import { CameraFollower } from "../ui/CameraFollower";
 import { ReconnectingOverlay } from "../ui/ReconnectingOverlay";
 import { SpectatorHUD } from "../ui/SpectatorHUD";
 import { TouchControls } from "../ui/TouchControls";
@@ -84,6 +85,7 @@ export class GameScene extends Phaser.Scene {
   private utilityDPad: UtilityDPad | null = null;
   private utilityDPadVisible = false;
   private turnTransition: TurnTransition | null = null;
+  private cameraFollower: CameraFollower | null = null;
 
   // ---- Pointer-gesture state (primary pointer only) ----
   /** Gesture state machine shared across pointer events. Stores last-release
@@ -253,6 +255,8 @@ export class GameScene extends Phaser.Scene {
       // destroys can't leave an active onStateChange listener that keeps
       // firing (and attempting scene.start) after we've moved on.
       this.tearDownRoomListeners();
+      this.cameraFollower?.destroy();
+      this.cameraFollower = null;
       this.turnTransition?.destroy();
       this.turnTransition = null;
       try {
@@ -389,6 +393,8 @@ export class GameScene extends Phaser.Scene {
     // once handleTurnChanged fires.
     this.cameras.main.setBounds(0, 0, sceneWidthPx, sceneHeightPx);
 
+    this.cameraFollower = new CameraFollower({ scene: this });
+
     this.turnTransition = new TurnTransition({
       scene: this,
       sim: this.sim,
@@ -403,6 +409,10 @@ export class GameScene extends Phaser.Scene {
       },
       onTransitioningChanged: (t) => {
         this.inputController?.setTransitioning(t);
+        this.cameraFollower?.setSuspended(t);
+      },
+      onActiveWormResolved: (target) => {
+        this.cameraFollower?.setActiveWormTarget(target);
       },
     });
 
@@ -454,6 +464,17 @@ export class GameScene extends Phaser.Scene {
     if (this.networkedSim) {
       this.renderNetworkedWorms();
       this.renderNetworkedProjectiles();
+      // Feed networked projectile entries to CameraFollower each frame.
+      if (this.cameraFollower) {
+        const entries: Array<{ id: string; gfx: Phaser.GameObjects.GameObject }> = [];
+        for (const [id, gfx] of this.projectileGraphics) {
+          entries.push({ id, gfx });
+        }
+        this.cameraFollower.update(entries);
+      }
+    } else if (this.offlineSim && this.cameraFollower) {
+      // Offline: projectile graphics are managed by ProjectileManager.
+      this.cameraFollower.update(this.offlineSim.getProjectilesWithGfx());
     }
     // Offline: Worm.update draws each worm's own sprite + HUD text. Nothing
     // to do at the scene level for worm rendering.

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -215,6 +215,18 @@ export class OfflineSimAdapter implements SimAdapter {
     return this.projectileManager.count;
   }
 
+  /**
+   * Returns live offline projectiles with their Phaser Graphics objects so
+   * CameraFollower can track them. Each entry has a stable id for the
+   * projectile's lifetime.
+   */
+  getProjectilesWithGfx(): ReadonlyArray<{
+    id: string;
+    gfx: import("phaser").GameObjects.Graphics;
+  }> {
+    return this.projectileManager.getProjectilesWithGfx();
+  }
+
   // -------------------------------------------------------------------------
   // SimAdapter API
   // -------------------------------------------------------------------------

--- a/src/ui/CameraFollower.test.ts
+++ b/src/ui/CameraFollower.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { CameraFollower } from "./CameraFollower";
+
+function makeMocks() {
+  const startFollowCalls: Array<{ target: object }> = [];
+
+  const camera = {
+    startFollow: vi.fn((target: object) => {
+      startFollowCalls.push({ target });
+    }),
+  };
+
+  const scene = {
+    cameras: { main: camera },
+  };
+
+  function makeFollower() {
+    return new CameraFollower({ scene: scene as never });
+  }
+
+  function makeGfx(label: string) {
+    return { __label: label } as unknown as import("phaser").GameObjects.GameObject;
+  }
+
+  return { scene, camera, startFollowCalls, makeFollower, makeGfx };
+}
+
+describe("CameraFollower", () => {
+  it("update([]) with active worm set follows worm; subsequent empty updates do not re-call startFollow", () => {
+    const { camera, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+
+    follower.setActiveWormTarget(worm);
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(worm, true, 0.08, 0.08);
+
+    // Further empty updates should not call startFollow again (no target change).
+    follower.update([]);
+    follower.update([]);
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+  });
+
+  it("update with a projectile entry starts following that projectile", () => {
+    const { camera, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+    const projGfx = makeGfx("proj");
+
+    follower.setActiveWormTarget(worm);
+    camera.startFollow.mockClear();
+
+    follower.update([{ id: "p1", gfx: projGfx }]);
+
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(projGfx, true, 0.08, 0.08);
+  });
+
+  it("after following p1, update([]) returns camera to active worm", () => {
+    const { camera, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+    const projGfx = makeGfx("proj");
+
+    follower.setActiveWormTarget(worm);
+    follower.update([{ id: "p1", gfx: projGfx }]);
+    camera.startFollow.mockClear();
+
+    // Projectile despawns.
+    follower.update([]);
+
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(worm, true, 0.08, 0.08);
+  });
+
+  it("setSuspended(true) makes update() a no-op; setSuspended(false) restores worm follow", () => {
+    const { camera, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+    const projGfx = makeGfx("proj");
+
+    follower.setActiveWormTarget(worm);
+    camera.startFollow.mockClear();
+
+    follower.setSuspended(true);
+
+    // update() with a projectile while suspended should be a no-op.
+    follower.update([{ id: "p1", gfx: projGfx }]);
+    expect(camera.startFollow).toHaveBeenCalledTimes(0);
+
+    follower.update([{ id: "p1", gfx: projGfx }]);
+    expect(camera.startFollow).toHaveBeenCalledTimes(0);
+
+    // Resuming should return to the active worm.
+    follower.setSuspended(false);
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(worm, true, 0.08, 0.08);
+  });
+
+  it("multi-projectile: follows first; when first despawns with second still alive, returns to worm not second", () => {
+    const { camera, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+    const proj1 = makeGfx("proj1");
+    const proj2 = makeGfx("proj2");
+
+    follower.setActiveWormTarget(worm);
+    camera.startFollow.mockClear();
+
+    // Both projectiles appear; follower should lock onto first (p1).
+    follower.update([
+      { id: "p1", gfx: proj1 },
+      { id: "p2", gfx: proj2 },
+    ]);
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(proj1, true, 0.08, 0.08);
+    camera.startFollow.mockClear();
+
+    // p1 despawns, p2 still alive - should return to worm, NOT hop to p2.
+    follower.update([{ id: "p2", gfx: proj2 }]);
+    expect(camera.startFollow).toHaveBeenCalledTimes(1);
+    expect(camera.startFollow).toHaveBeenCalledWith(worm, true, 0.08, 0.08);
+  });
+});

--- a/src/ui/CameraFollower.ts
+++ b/src/ui/CameraFollower.ts
@@ -1,0 +1,87 @@
+import type Phaser from "phaser";
+
+export interface CameraFollowerInit {
+  scene: Phaser.Scene;
+}
+
+/**
+ * Decides what the camera follows. Between turns the camera is
+ * controlled by TurnTransition. Within a turn, follows the active
+ * worm by default. If a projectile spawns, detaches from the worm
+ * and follows the projectile until it despawns; then returns to the
+ * active worm.
+ *
+ * Multi-projectile case: sticks with the first followed projectile;
+ * ignores subsequent spawns. When the followed projectile despawns
+ * AND other projectiles still exist (e.g. cluster children), returns
+ * to the worm rather than hopping to an arbitrary other projectile.
+ */
+export class CameraFollower {
+  private readonly scene: Phaser.Scene;
+  private activeWormTarget: Phaser.GameObjects.GameObject | null = null;
+  private followedProjectileId: string | null = null;
+  private suspended = false; // set true while TurnTransition owns the camera
+
+  constructor(init: CameraFollowerInit) {
+    this.scene = init.scene;
+  }
+
+  /** Called by GameScene when TurnTransition lands the camera on a worm at zoom-in completion. */
+  setActiveWormTarget(target: Phaser.GameObjects.GameObject | null): void {
+    this.activeWormTarget = target;
+    // If we're currently following a worm (not projectile) and not suspended, swap to the new target.
+    if (!this.suspended && this.followedProjectileId === null && target) {
+      this.scene.cameras.main.startFollow(target, true, 0.08, 0.08);
+    }
+  }
+
+  /** Called when TurnTransition starts + ends, so CameraFollower knows to yield or resume. */
+  setSuspended(suspended: boolean): void {
+    this.suspended = suspended;
+    if (suspended) {
+      // Drop our tracking; TurnTransition owns the camera now.
+      this.followedProjectileId = null;
+    } else {
+      // Resumed - return to active worm if we have one.
+      if (this.activeWormTarget) {
+        this.scene.cameras.main.startFollow(this.activeWormTarget, true, 0.08, 0.08);
+      }
+    }
+  }
+
+  /**
+   * Called every frame with the current list of projectile gfx entries.
+   * Only calls startFollow when the follow target changes - not every frame.
+   */
+  update(projectiles: ReadonlyArray<{ id: string; gfx: Phaser.GameObjects.GameObject }>): void {
+    if (this.suspended) return;
+
+    const followedStillExists =
+      this.followedProjectileId !== null &&
+      projectiles.some((p) => p.id === this.followedProjectileId);
+
+    if (this.followedProjectileId !== null && !followedStillExists) {
+      // Our followed projectile despawned. Return to worm.
+      this.followedProjectileId = null;
+      if (this.activeWormTarget) {
+        this.scene.cameras.main.startFollow(this.activeWormTarget, true, 0.08, 0.08);
+      }
+      return;
+    }
+
+    if (this.followedProjectileId === null && projectiles.length > 0) {
+      // No current follow target and a projectile just appeared - follow the first one.
+      const first = projectiles[0];
+      if (first) {
+        this.followedProjectileId = first.id;
+        this.scene.cameras.main.startFollow(first.gfx, true, 0.08, 0.08);
+      }
+    }
+  }
+
+  destroy(): void {
+    // Nothing to clean up; camera follow state is owned by the scene lifecycle.
+    this.activeWormTarget = null;
+    this.followedProjectileId = null;
+  }
+}

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -11,6 +11,12 @@ export interface TurnTransitionInit {
   resolveFollowTarget: (wormId: string) => Phaser.GameObjects.GameObject | null;
   /** Called when transitioning state changes (for input gating). */
   onTransitioningChanged: (transitioning: boolean) => void;
+  /**
+   * Called at zoom-in completion with the resolved follow target (or null).
+   * Used by CameraFollower to learn which worm the camera should return to
+   * after a projectile despawns.
+   */
+  onActiveWormResolved?: (target: Phaser.GameObjects.GameObject | null) => void;
 }
 
 type State = "IDLE" | "ZOOMING_OUT" | "HOLDING" | "ZOOMING_IN";
@@ -32,6 +38,9 @@ export class TurnTransition {
   private readonly worldHeightPx: number;
   private readonly resolveFollowTarget: (wormId: string) => Phaser.GameObjects.GameObject | null;
   private readonly onTransitioningChanged: (t: boolean) => void;
+  private readonly onActiveWormResolved:
+    | ((target: Phaser.GameObjects.GameObject | null) => void)
+    | undefined;
   private readonly unsubStable: () => void;
 
   private state: State = "IDLE";
@@ -56,6 +65,7 @@ export class TurnTransition {
     this.worldHeightPx = init.worldHeightPx;
     this.resolveFollowTarget = init.resolveFollowTarget;
     this.onTransitioningChanged = init.onTransitioningChanged;
+    this.onActiveWormResolved = init.onActiveWormResolved;
     this.unsubStable = this.sim.onStateStable(() => this.handleStateStable());
   }
 
@@ -212,6 +222,7 @@ export class TurnTransition {
     this.pendingWormId = null;
     this.stableObserved = false;
     this.setState("IDLE");
+    this.onActiveWormResolved?.(followTarget);
     this.onTransitioningChanged(false);
   }
 }

--- a/src/weapons/ProjectileManager.ts
+++ b/src/weapons/ProjectileManager.ts
@@ -14,6 +14,7 @@ import { explode } from "./explode";
 import type { WeaponConfig } from "./types";
 
 interface ActiveProjectile {
+  id: string;
   body: Body;
   graphic: Phaser.GameObjects.Graphics;
   spawnedAt: number; // ms since scene start
@@ -38,6 +39,7 @@ export class ProjectileManager {
   private readonly projectiles: ActiveProjectile[] = [];
   private readonly pendingDetonate: ActiveProjectile[] = [];
   private elapsedMs = 0;
+  private nextProjectileId = 0;
 
   constructor(init: ProjectileManagerInit) {
     this.scene = init.scene;
@@ -93,6 +95,7 @@ export class ProjectileManager {
     graphic.fillCircle(0, 0, rPx);
 
     const proj: ActiveProjectile = {
+      id: `offline-proj-${this.nextProjectileId++}`,
       body,
       graphic,
       spawnedAt: this.elapsedMs,
@@ -147,6 +150,15 @@ export class ProjectileManager {
   /** Number of live projectiles (useful for settle detection). */
   get count(): number {
     return this.projectiles.length;
+  }
+
+  /**
+   * Returns a snapshot of live projectiles with their Phaser Graphics objects.
+   * Used by CameraFollower to follow an in-flight projectile in offline mode.
+   * Each entry: { id, gfx } where id is stable for the lifetime of the projectile.
+   */
+  getProjectilesWithGfx(): ReadonlyArray<{ id: string; gfx: Phaser.GameObjects.Graphics }> {
+    return this.projectiles.filter((p) => !p.detonated).map((p) => ({ id: p.id, gfx: p.graphic }));
   }
 
   destroy(): void {


### PR DESCRIPTION
## Summary

Classic Worms behavior: when a bazooka, grenade, or dynamite is fired, the camera detaches from the active worm and follows the projectile until it detonates or despawns, then returns to the active worm. Hitscan weapons (shotgun, uzi) are unchanged — no projectile entity spawns, so camera stays locked on the worm.

Fixes the "I can shoot at something offscreen but can't see where it lands" feeling Scott flagged in playtest.

## Implementation

- **New `src/ui/CameraFollower.ts`** (87 lines): per-frame reconciler. Owns the decision of "what is the camera following" — active worm target vs first-spawned projectile vs suspended (when TurnTransition owns the camera).
- **Multi-projectile rule**: follows the first-spawned projectile. When it despawns and other projectiles still exist (e.g. future cluster bombs), returns to the active worm rather than hopping to an arbitrary remaining projectile.
- **TurnTransition integration**: new `onActiveWormResolved` callback fires at zoom-in completion with the active worm target. CameraFollower's `setSuspended(true)` is called when TurnTransition starts, yielding camera control; resumed with `setSuspended(false)` at completion.
- **Stable projectile ids**: `ProjectileManager` now assigns monotonic ids to offline projectiles (`offline-proj-N`), used by CameraFollower to track the followed entity across frames. Networked projectiles already have server-assigned ids.

## Files

- `src/ui/CameraFollower.ts` (new) + test
- `src/ui/TurnTransition.ts`: add `onActiveWormResolved` callback
- `src/scenes/GameScene.ts`: wire CameraFollower into both offline + networked render paths
- `src/weapons/ProjectileManager.ts`: add id + `getProjectilesWithGfx()`
- `src/sim/OfflineSimAdapter.ts`: delegate `getProjectilesWithGfx()` to manager

## Bug check

Four focused lenses ran. One false-positive HIGH finding (lifecycle/rematch — verified the networked adapter derives projectiles from the current server frame, not a local accumulator, so no stale entries after rematch). Two low-severity findings deemed non-blocking: double `startFollow` on TurnTransition handoff (harmless redundancy with identical lerp args) and 4 test-coverage gaps on edge paths. Tests are 220/220 green.

## Manual tests

- [ ] Fire a bazooka on Terraworld: camera follows the rocket arc to impact
- [ ] Fire a grenade: camera follows bouncing until detonation
- [ ] Fire a dynamite throw: camera follows until settle + fuse
- [ ] After detonation: camera returns smoothly to the active worm for retreat window
- [ ] Fire shotgun / uzi: no camera change (hitscan stays on worm)
- [ ] End of turn: TurnTransition runs as before, no projectile-follow interference
- [ ] Networked mode with 2 devices: both clients should follow the same projectile (server-assigned ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)