### PR TITLE
fix(ui): hit zone outside container so radial responds to touch

### DIFF
--- a/src/ui/WeaponRadial.test.ts
+++ b/src/ui/WeaponRadial.test.ts
@@ -84,7 +84,10 @@ function makeScene() {
     const listeners: Map<string, Array<(...args: unknown[]) => void>> = new Map();
     const obj = {
       setOrigin: vi.fn(() => obj),
+      setScrollFactor: vi.fn(() => obj),
+      setDepth: vi.fn(() => obj),
       setInteractive: vi.fn(() => obj),
+      destroy: vi.fn(),
       on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
         if (!listeners.has(event)) listeners.set(event, []);
         listeners.get(event)?.push(handler);

--- a/src/ui/WeaponRadial.ts
+++ b/src/ui/WeaponRadial.ts
@@ -62,6 +62,7 @@ export class WeaponRadial {
   private readonly container: Phaser.GameObjects.Container;
   private readonly trigger: Phaser.GameObjects.Container;
   private readonly iconNodes: IconNode[] = [];
+  private hitZone!: Phaser.GameObjects.Zone;
 
   private state: State = "CLOSED";
   private activePointerId: number | null = null;
@@ -125,12 +126,19 @@ export class WeaponRadial {
     this.container.add(this.trigger);
 
     // --- Hit zone for the trigger (generous for thumb) ---
-    const hit = this.scene.add
-      .zone(0, 0, 80, 80)
+    // IMPORTANT: do NOT add this zone to the radial container. Phaser 3's
+    // input hit test on an interactive child of a Container with
+    // setScrollFactor(0) has frame-coord issues in some configurations
+    // (the visual renders at the transformed position but the hit region
+    // uses local coords). Living at the scene root with explicit
+    // setScrollFactor(0) keeps the hit region exactly where the visual is.
+    this.hitZone = this.scene.add
+      .zone(triggerX, triggerY, 80, 80)
       .setOrigin(0.5)
+      .setScrollFactor(0)
+      .setDepth(101)
       .setInteractive({ useHandCursor: true });
-    this.container.add(hit);
-    hit.on("pointerdown", (p: Phaser.Input.Pointer) => {
+    this.hitZone.on("pointerdown", (p: Phaser.Input.Pointer) => {
       this.onTriggerDown(p);
     });
 
@@ -173,6 +181,7 @@ export class WeaponRadial {
     this.scene.input.off("pointermove", this.onPointerMove, this);
     this.scene.input.off("pointerup", this.onPointerUp, this);
     this.scene.input.off("pointerdown", this.onGlobalPointerDown, this);
+    this.hitZone.destroy();
     this.container.destroy();
   }
 


### PR DESCRIPTION
Scott reported: radial menu not responding to touch after #113 shipped.

**Root cause**: Phaser 3 has a subtle gotcha where an interactive child of a \`Container\` with \`setScrollFactor(0)\` can have inconsistent hit testing — the visual renders at the transformed position (bottom-right of screen) but the hit region uses local coords (0,0 = screen origin). Phaser was looking for touches in the top-left corner while the trigger was drawn in the bottom-right.

**Fix**: lift the invisible hit zone out of the radial container. Create it at world coords \`(w - 80, h - 80)\` with \`setScrollFactor(0)\` + \`setDepth(101)\` directly on the zone so the hit region matches the visual. Visuals + tweens stay in the radial container as before; only the interactive zone moves.

**Tests**: radial test mock now exposes \`setScrollFactor\` / \`setDepth\` / \`destroy\` on the zone. All 267 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)