### PR TITLE
fix: advance turn as soon as sim settles, not flat 6s

### DIFF
--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -674,6 +674,23 @@ export class Simulation {
     return this.projectiles.length;
   }
 
+  /**
+   * True when every alive worm has linear velocity magnitude below the
+   * threshold AND no projectiles/throwables are currently in flight.
+   * Used by turnArbiter to advance the turn as soon as the sim is quiet
+   * instead of waiting the full SETTLE_GRACE_MS safety cap.
+   */
+  isAllSettled(velThresholdMps: number): boolean {
+    const threshSq = velThresholdMps * velThresholdMps;
+    for (const worm of this.worms.values()) {
+      if (!worm.alive) continue;
+      const v = worm.body.getLinearVelocity();
+      if (v.x * v.x + v.y * v.y >= threshSq) return false;
+    }
+    if (this.projectiles.length > 0) return false;
+    return true;
+  }
+
   // ---- private ----
 
   private nextProjectileId(): string {

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -24,11 +24,25 @@ export const TURN_DURATION_MS = 45_000;
 export const SETTLE_GRACE_MS = 6_000;
 export const DISCONNECT_GRACE_MS = 60_000;
 
+/**
+ * Early-settle tunables. Mirror tuning.turn.settleVelThresholdMps and
+ * tuning.turn.settleHoldMs on the client so server and client feel
+ * consistent. Kept as local consts rather than imported from the client
+ * tuning module to avoid a client->worker dependency.
+ */
+const EARLY_SETTLE_VEL_THRESHOLD_MPS = 0.15;
+const EARLY_SETTLE_HOLD_MS = 500;
+
 /** Provider of authoritative alive counts (the Simulation). */
 export interface AliveCountsProvider {
   aliveWormsByTeam(): Map<string, number>;
   /** Per-worm liveness so the arbiter can skip dead worms during rotation. */
   isWormAlive(wormId: string): boolean;
+  /**
+   * True when every alive worm has linear velocity below the threshold
+   * and no projectiles are in flight. Used by early-settle detection.
+   */
+  isAllSettled(velThresholdMps: number): boolean;
 }
 
 /**
@@ -82,6 +96,7 @@ export class TurnArbiter {
   private pausedRemainingMs: number | null = null;
   private pendingAdvance = false;
   private hasFiredThisTurn = false;
+  private settleHoldMs = 0;
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
@@ -113,6 +128,7 @@ export class TurnArbiter {
   }
 
   start(teamOrder: string[], rosters: TeamRoster[], turnDurationMs: number): void {
+    this.settleHoldMs = 0;
     this.teamRosters.clear();
     this.teamWormCursor.clear();
     this.forfeitedTeams.clear();
@@ -141,7 +157,7 @@ export class TurnArbiter {
    * game_over condition every tick (a worm may have died off-map even
    * without the turn timer expiring).
    */
-  onTick(_dtMs: number): void {
+  onTick(dtMs: number): void {
     if (this.gameOver) return;
     this.checkGameOver();
     if (this.gameOver) return;
@@ -152,6 +168,22 @@ export class TurnArbiter {
     }
     if (this.pausedRemainingMs !== null) return;
     const now = Date.now();
+    // Early-advance: if retreat window is over and the sim has stopped
+    // moving for EARLY_SETTLE_HOLD_MS, advance now instead of waiting
+    // the full SETTLE_GRACE_MS safety cap.
+    if (now > this.room.state.turnEndsAt) {
+      const provider = this.room.getAliveCountsProvider();
+      if (provider?.isAllSettled(EARLY_SETTLE_VEL_THRESHOLD_MPS)) {
+        this.settleHoldMs += dtMs;
+        if (this.settleHoldMs >= EARLY_SETTLE_HOLD_MS) {
+          this.advanceTurn();
+          return;
+        }
+      } else {
+        this.settleHoldMs = 0;
+      }
+    }
+    // Safety cap: advance unconditionally after SETTLE_GRACE_MS.
     if (now > this.room.state.turnEndsAt + SETTLE_GRACE_MS) {
       this.advanceTurn();
     }
@@ -305,6 +337,7 @@ export class TurnArbiter {
   }
 
   private advanceTurn(): void {
+    this.settleHoldMs = 0;
     const teamsWithAliveWorms: string[] = [];
     for (const teamId of this.room.state.teamOrder) {
       if (this.teamAliveCount(teamId) > 0) teamsWithAliveWorms.push(teamId);

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -174,7 +174,7 @@ export class TurnArbiter {
     if (now > this.room.state.turnEndsAt) {
       const provider = this.room.getAliveCountsProvider();
       if (provider?.isAllSettled(EARLY_SETTLE_VEL_THRESHOLD_MPS)) {
-        this.settleHoldMs += dtMs;
+        this.settleHoldMs += Math.max(0, dtMs);
         if (this.settleHoldMs >= EARLY_SETTLE_HOLD_MS) {
           this.advanceTurn();
           return;
@@ -302,6 +302,7 @@ export class TurnArbiter {
     if (!activeTeam || activeTeam.ownerSessionId !== sessionId) return;
     this.room.state.turnEndsAt = Date.now() + this.pausedRemainingMs;
     this.pausedRemainingMs = null;
+    this.settleHoldMs = 0;
   }
 
   onTeamForfeit(teamId: string): void {

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -664,6 +664,57 @@ describe("Simulation - Holy Grenade ammo enforcement", () => {
   });
 });
 
+describe("Simulation - isAllSettled", () => {
+  it("returns true when all worms are at rest and no projectiles are active", () => {
+    const sim = makeSim(twoTeams());
+    // Settle worms onto floor.
+    for (let i = 0; i < 60; i++) sim.tick(50);
+    expect(sim.isAllSettled(0.15)).toBe(true);
+  });
+
+  it("returns false when any worm velocity magnitude is above the threshold", () => {
+    const sim = makeSim(twoTeams());
+    for (let i = 0; i < 30; i++) sim.tick(50);
+    // Give Red-1 a large upward velocity well above threshold.
+    const worm = requireWorm(sim, "Red-1");
+    worm.body.setLinearVelocity({ x: 0, y: -5 });
+    expect(sim.isAllSettled(0.15)).toBe(false);
+  });
+
+  it("returns false when a projectile is active even if all worms are at rest", () => {
+    const sim = makeSim(twoTeams());
+    for (let i = 0; i < 30; i++) sim.tick(50);
+
+    // Fire a projectile aimed upward so it stays in flight.
+    sim.applyAimAngle("Red-1", -Math.PI / 2 + 0.05); // nearly straight up
+    sim.applyAimPower("Red-1", 0.5);
+    sim.applySelectWeapon("Red-1", "bazooka");
+    sim.applyFire("Red-1");
+    // One tick to let the projectile enter the world.
+    sim.tick(50);
+
+    expect(sim.projectileCount()).toBeGreaterThan(0);
+    expect(sim.isAllSettled(0.15)).toBe(false);
+  });
+
+  it("returns true again after all projectiles resolve and worms come to rest", () => {
+    const sim = makeSim(twoTeams());
+    for (let i = 0; i < 30; i++) sim.tick(50);
+
+    // Fire upward; wait until projectile detonates.
+    sim.applyAimAngle("Red-1", -Math.PI / 2 + 0.05);
+    sim.applyAimPower("Red-1", 0.3);
+    sim.applySelectWeapon("Red-1", "bazooka");
+    sim.applyFire("Red-1");
+
+    // Tick up to 4s for the projectile to detonate and worms to settle.
+    for (let i = 0; i < 80; i++) sim.tick(50);
+
+    // After everything settles, isAllSettled should be true.
+    expect(sim.isAllSettled(0.15)).toBe(true);
+  });
+});
+
 describe("Simulation - aim input", () => {
   it("applyAimAngle clamps to [-PI/2, PI/2]", () => {
     const sim = makeSim(twoTeams());

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -379,6 +379,28 @@ describe("TurnArbiter - early-settle", () => {
     expect(room.state.turnSeq).toBeGreaterThan(turnSeqBefore);
   });
 
+  it("dtMs guard: zero and negative ticks do not advance turn or make settleHoldMs go negative", () => {
+    const { room, arbiter } = makeSettleRoom(true);
+
+    // Expire the turn timer.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+    const turnSeqBefore = room.state.turnSeq;
+
+    // Feed zero and negative ticks several times.
+    arbiter.onTick(0);
+    arbiter.onTick(-5);
+    arbiter.onTick(0);
+    arbiter.onTick(-100);
+    arbiter.onTick(0);
+
+    // Turn should NOT have advanced - zero/negative ticks add 0 so 500ms
+    // hold is never reached.
+    expect(room.state.turnSeq).toBe(turnSeqBefore);
+
+    // settleHoldMs should be exactly 0 (never went negative).
+    expect((arbiter as unknown as { settleHoldMs: number }).settleHoldMs).toBe(0);
+  });
+
   it("resets settleHoldMs when sim un-settles mid-wait", () => {
     const { room, arbiter } = makeSettleRoom(true);
 
@@ -401,6 +423,37 @@ describe("TurnArbiter - early-settle", () => {
     expect(room.state.turnSeq).toBe(turnSeqBefore);
 
     // 10th tick crosses the 500ms hold and triggers advance.
+    arbiter.onTick(50);
+    expect(room.state.turnSeq).toBeGreaterThan(turnSeqBefore);
+  });
+
+  it("pause resume resets settleHoldMs so the full 500ms hold is required post-resume", () => {
+    const { room, arbiter } = makeSettleRoom(true);
+
+    // Expire the turn timer so early-settle accumulation can begin.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+    const turnSeqBefore = room.state.turnSeq;
+
+    // Accumulate 300ms of settled ticks (6 x 50ms).
+    for (let i = 0; i < 6; i++) arbiter.onTick(50);
+    expect(room.state.turnSeq).toBe(turnSeqBefore); // not yet at 500ms
+
+    // Pause the turn (owner disconnects).
+    arbiter.onOwnerDisconnected("alice");
+
+    // Resume - settleHoldMs should be reset to 0.
+    arbiter.onOwnerReconnected("alice");
+    expect((arbiter as unknown as { settleHoldMs: number }).settleHoldMs).toBe(0);
+
+    // Now the new turnEndsAt is in the future (pause restored remaining time).
+    // Push time past it so early-settle logic can fire.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+
+    // 9 ticks = only 450ms since resume - should NOT advance yet.
+    for (let i = 0; i < 9; i++) arbiter.onTick(50);
+    expect(room.state.turnSeq).toBe(turnSeqBefore);
+
+    // 10th tick brings holdMs to 500ms - should advance now.
     arbiter.onTick(50);
     expect(room.state.turnSeq).toBeGreaterThan(turnSeqBefore);
   });

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LobbyState } from "../src/messages.js";
 import {
   type AliveCountsProvider,
   type ArbiterRoomAdapter,
+  SETTLE_GRACE_MS,
   TURN_DURATION_MS,
   type TeamRoster,
   TurnArbiter,
@@ -31,11 +32,15 @@ function makeState(): LobbyState {
 class StubAliveCountsProvider implements AliveCountsProvider {
   counts = new Map<string, number>();
   deadWorms = new Set<string>();
+  settled = true;
   aliveWormsByTeam(): Map<string, number> {
     return new Map(this.counts);
   }
   isWormAlive(wormId: string): boolean {
     return !this.deadWorms.has(wormId);
+  }
+  isAllSettled(_velThresholdMps: number): boolean {
+    return this.settled;
   }
 }
 
@@ -312,5 +317,91 @@ describe("TurnArbiter", () => {
     // Should NOT have extended it - 1s < 5s so retreat window would extend it,
     // but the guard prevents extension.
     expect(room.state.turnEndsAt).toBe(shortened);
+  });
+});
+
+describe("TurnArbiter - early-settle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeSettleRoom(settled: boolean): { room: StubRoom; arbiter: TurnArbiter } {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+    room.provider.settled = settled;
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+    return { room, arbiter };
+  }
+
+  it("advances turn within ~500ms of ticks when sim is settled after turnEndsAt", () => {
+    const { room, arbiter } = makeSettleRoom(true);
+
+    // Expire the turn timer.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+
+    // Accumulate 10 ticks at 50ms each = 500ms. Should trigger advance.
+    let advanced = false;
+    const turnSeqBefore = room.state.turnSeq;
+    for (let i = 0; i < 10; i++) {
+      arbiter.onTick(50);
+      if (room.state.turnSeq !== turnSeqBefore) {
+        advanced = true;
+        break;
+      }
+    }
+    expect(advanced).toBe(true);
+    // Should NOT have taken the full 6s safety cap.
+    expect(Date.now()).toBeLessThan(room.state.turnEndsAt + SETTLE_GRACE_MS);
+  });
+
+  it("does NOT advance early when sim is not settled; safety cap still fires at 6s", () => {
+    const { room, arbiter } = makeSettleRoom(false);
+
+    // Expire the turn timer but not yet the 6s grace.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+    const turnSeqBefore = room.state.turnSeq;
+
+    // Tick 9 times (450ms) - not settled, so hold counter stays 0.
+    for (let i = 0; i < 9; i++) arbiter.onTick(50);
+    // Turn should NOT have advanced yet.
+    expect(room.state.turnSeq).toBe(turnSeqBefore);
+
+    // Advance past the 6s safety cap.
+    vi.setSystemTime(room.state.turnEndsAt + SETTLE_GRACE_MS + 100);
+    arbiter.onTick(50);
+    expect(room.state.turnSeq).toBeGreaterThan(turnSeqBefore);
+  });
+
+  it("resets settleHoldMs when sim un-settles mid-wait", () => {
+    const { room, arbiter } = makeSettleRoom(true);
+
+    // Expire the turn timer.
+    vi.setSystemTime(room.state.turnEndsAt + 100);
+    const turnSeqBefore = room.state.turnSeq;
+
+    // Accumulate 4 ticks (200ms) while settled.
+    for (let i = 0; i < 4; i++) arbiter.onTick(50);
+    expect(room.state.turnSeq).toBe(turnSeqBefore); // not yet at 500ms
+
+    // Sim becomes un-settled (explosion mid-settle) - resets the counter.
+    room.provider.settled = false;
+    arbiter.onTick(50);
+
+    // Sim settles again; we need a fresh 500ms (10 ticks) accumulation.
+    room.provider.settled = true;
+    // 9 ticks = only 450ms since reset - should NOT advance yet.
+    for (let i = 0; i < 9; i++) arbiter.onTick(50);
+    expect(room.state.turnSeq).toBe(turnSeqBefore);
+
+    // 10th tick crosses the 500ms hold and triggers advance.
+    arbiter.onTick(50);
+    expect(room.state.turnSeq).toBeGreaterThan(turnSeqBefore);
   });
 });


### PR DESCRIPTION
## Summary

Server-side mirror of the client's settle detection. Before this change, `turnArbiter.onTick()` waited a flat `SETTLE_GRACE_MS = 6000` after `turnEndsAt` before advancing, regardless of whether the world was already quiet. Players saw 5-6s of dead air post-fire and it felt like a connection delay.

Now the server checks `sim.isAllSettled(0.15)` each tick once the retreat window is over. After 500ms of consecutive "settled" detections, the turn advances. The 6s safety cap is preserved for runaway sims (bouncing forever, drill tunneling without resolution).

Constants mirror the client (`tuning.turn.settleVelThresholdMps = 0.15`, `settleHoldMs = 500`) for consistent feel.

## Changes

- `worker/src/sim/simulation.ts`: new `isAllSettled(velThresholdMps)` method. False if any alive worm's velocity magnitude is at/above threshold, or any projectile is active (catches fuses ticking on a body at rest - dynamite dropped at feet still counts as "unsettled" until it explodes).
- `worker/src/turnArbiter.ts`: `EARLY_SETTLE_VEL_THRESHOLD_MPS`, `EARLY_SETTLE_HOLD_MS` consts; `settleHoldMs` accumulator; early-advance block in `onTick` before the existing 6s cap. Reset on `start()`, `advanceTurn()`, and pause resume. `dtMs` clamped to `>=0`.
- `worker/test/sim.test.ts`: 4 tests for `isAllSettled`.
- `worker/test/turnArbiter.test.ts`: 5 tests for early-settle behavior, dtMs guard, pause-resume reset.

## Bug Check

Clean. Critical/High findings were investigated and either disputed (threshold comparison false positive - both sides agree at the boundary) or deemed non-blocking (impulse-application lag is filtered by the 500ms hold). Medium findings (dtMs guard, pause-resume reset) fixed in 437e2cf.

## Known non-issues (unchanged by this PR)

- Client-side Epic 9 settle infrastructure (`adoptServerTurn`, `onLocalTurnFinished`, `setExternallyDriven`) is dead code post-Epic 45's continuous `sim_state` protocol. Pre-existing, not touched here. Worth a cleanup issue later.

## Test plan

- [ ] Fire bazooka at a far worm. Retreat runs 5s. Sim settles quickly. Next turn should start ~500ms after retreat ends, not 6s later.
- [ ] Fire dynamite. Fuse ticks 5s on a stationary body. Turn should NOT advance during the fuse (active projectile keeps sim "unsettled"). Turn advances ~500ms after explosion settles.
- [ ] Fire drill. Tunnels for up to 3.5s. Turn advances after it detonates and debris settles.
- [ ] Fire shotgun (hitscan, no projectile left in flight). Retreat runs. Turn advances ~500ms after retreat ends.
- [ ] Edge case: stuck projectile bouncing forever - 6s safety cap still fires.