### PR TITLE
feat(debug): unified client+server logging with correlation IDs

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -304,4 +304,5 @@ export type ClientMsg =
   | { type: "input_jetpack_toggle"; seq: number }
   | { type: "input_jetpack_thrust"; active: boolean; seq: number }
   | { type: "input_jetpack_horizontal"; dir: -1 | 0 | 1; seq: number }
-  | { type: "leave" };
+  | { type: "leave" }
+  | { type: "client_log"; scope: string; event: string; data?: unknown; ts: number };

--- a/src/debug/logger.test.ts
+++ b/src/debug/logger.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { dlog, dlogUnthrottled, isLoggerEnabled, setLoggerEnabled } from "./logger";
+import {
+  _testGetThrottleMapSize,
+  _testResetFwdBudget,
+  dlog,
+  dlogUnthrottled,
+  getLogForwarder,
+  isLoggerEnabled,
+  setLogContext,
+  setLogForwarder,
+  setLoggerEnabled,
+} from "./logger";
 
 describe("logger", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -8,11 +18,17 @@ describe("logger", () => {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     // Start each test with logger disabled to avoid leaking state.
     setLoggerEnabled(false);
+    setLogContext({ room: undefined, turn: undefined });
+    setLogForwarder(null);
+    _testResetFwdBudget();
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
     setLoggerEnabled(false);
+    setLogContext({ room: undefined, turn: undefined });
+    setLogForwarder(null);
+    _testResetFwdBudget();
   });
 
   describe("when disabled", () => {
@@ -72,6 +88,90 @@ describe("logger", () => {
       setLoggerEnabled(true);
       dlogUnthrottled("camera", "follow_target_changed");
       expect(consoleSpy).toHaveBeenCalledWith("[camera] follow_target_changed");
+    });
+  });
+
+  describe("setLogContext", () => {
+    it("injects room and turn into log output", () => {
+      setLoggerEnabled(true);
+      setLogContext({ room: "WAVE", turn: 3 });
+      dlogUnthrottled("scene", "test");
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("room=WAVE turn=3"));
+    });
+
+    it("omits room= when room is empty string", () => {
+      setLoggerEnabled(true);
+      setLogContext({ room: "" });
+      dlogUnthrottled("scene", "test");
+      const call = consoleSpy.mock.calls[0];
+      expect(call).toBeDefined();
+      expect((call as unknown[])[0] as string).not.toContain("room=");
+    });
+  });
+
+  describe("forwarder", () => {
+    it("calls forwarder when set (non-net scope)", () => {
+      setLoggerEnabled(true);
+      const mock = vi.fn();
+      setLogForwarder(mock);
+      dlogUnthrottled("sim", "evt", { x: 1 });
+      expect(mock).toHaveBeenCalledWith("sim", "evt", { x: 1 });
+    });
+
+    it("rate-limits forwarder to 20 calls per second per scope", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1000);
+      setLoggerEnabled(true);
+      const mock = vi.fn();
+      setLogForwarder(mock);
+      // 25 calls with unique events to avoid 16ms console-throttle.
+      for (let i = 0; i < 25; i++) {
+        dlogUnthrottled("sim", `e${i}`, { i });
+      }
+      expect(mock).toHaveBeenCalledTimes(20);
+      vi.useRealTimers();
+    });
+
+    it("skips forwarding for scope=net to prevent feedback loops", () => {
+      setLoggerEnabled(true);
+      const mock = vi.fn();
+      setLogForwarder(mock);
+      dlogUnthrottled("net", "send");
+      expect(mock).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors thrown by forwarder", () => {
+      setLoggerEnabled(true);
+      setLogForwarder(() => { throw new Error("oops"); });
+      expect(() => dlogUnthrottled("sim", "test")).not.toThrow();
+    });
+  });
+
+  describe("LRU cap on throttle map", () => {
+    it("prunes the throttle map when it exceeds 256 keys", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      setLoggerEnabled(true);
+      // Insert 300 unique keys to trigger pruning.
+      for (let i = 0; i < 300; i++) {
+        vi.setSystemTime(i * 100); // advance time to bypass throttle
+        dlog("sim", `ev${i}`);
+      }
+      // Map should be at most 256 (pruned to half when exceeded, so <= 256).
+      expect(_testGetThrottleMapSize()).toBeLessThanOrEqual(256);
+      vi.useRealTimers();
+    });
+  });
+
+  describe("getLogForwarder", () => {
+    it("returns null when no forwarder is set", () => {
+      expect(getLogForwarder()).toBeNull();
+    });
+
+    it("returns the set forwarder", () => {
+      const fn = vi.fn();
+      setLogForwarder(fn);
+      expect(getLogForwarder()).toBe(fn);
     });
   });
 });

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -1,43 +1,94 @@
 /**
- * Diagnostic logger gated by `?debug=1` URL param.
+ * Client-side diagnostic logger gated by `?debug=1` URL param.
  *
  * Usage:
  *   dlog("scene", "GameScene.create");
  *   dlog("net", "state received", { phase });
- *   dlog("sim", "turn_changed", { teamId, wormId });
  *
  * - Zero cost when disabled (early return before any allocation).
  * - Per (scope, event) 16ms throttle so rAF-rate events don't flood console.
  * - Use dlogUnthrottled for one-shot lifecycle events you ALWAYS want.
+ * - Optional context (room, turn) set via setLogContext; appears in every log line.
+ * - Optional forwarder sends every log to the server via WebSocket; configured
+ *   by wsClient when a socket is open + logger is enabled. Rate-limited 20/sec
+ *   per scope, and scope="net" is skipped to avoid feedback loops.
  */
 
 type Scope = "scene" | "net" | "sim" | "camera" | "input";
 
-let enabled = typeof window !== "undefined" && window.location.search.includes("debug=1");
-
-const lastEmit = new Map<string, number>();
-
-/** Programmatic enable/disable (primarily for tests). */
-export function setLoggerEnabled(v: boolean): void {
-  enabled = v;
+interface LogContext {
+  room?: string;
+  turn?: number;
 }
 
-export function isLoggerEnabled(): boolean {
-  return enabled;
+type Forwarder = (scope: Scope, event: string, data?: unknown) => void;
+
+const THROTTLE_MS = 16;
+const MAX_THROTTLE_KEYS = 256;
+const FWD_MAX_PER_SEC = 20;
+
+let enabled = typeof window !== "undefined" && window.location.search.includes("debug=1");
+let ctx: LogContext = {};
+let forwarder: Forwarder | null = null;
+const lastEmit = new Map<string, number>();
+const fwdBudget = new Map<Scope, { count: number; windowStart: number }>();
+
+export function setLoggerEnabled(v: boolean): void { enabled = v; }
+export function isLoggerEnabled(): boolean { return enabled; }
+export function setLogContext(next: Partial<LogContext>): void { ctx = { ...ctx, ...next }; }
+export function getLogContext(): LogContext { return { ...ctx }; }
+export function setLogForwarder(f: Forwarder | null): void { forwarder = f; }
+export function getLogForwarder(): Forwarder | null { return forwarder; }
+
+export function _testGetThrottleMapSize(): number { return lastEmit.size; }
+export function _testResetFwdBudget(): void { fwdBudget.clear(); }
+
+function pruneIfNeeded(): void {
+  if (lastEmit.size <= MAX_THROTTLE_KEYS) return;
+  const keys = Array.from(lastEmit.keys());
+  const toDrop = Math.floor(keys.length / 2);
+  for (let i = 0; i < toDrop; i++) lastEmit.delete(keys[i]);
+}
+
+function formatCtx(): string {
+  const parts: string[] = [];
+  if (ctx.room !== undefined && ctx.room !== "") parts.push(`room=${ctx.room}`);
+  if (ctx.turn !== undefined) parts.push(`turn=${ctx.turn}`);
+  return parts.length > 0 ? " " + parts.join(" ") : "";
+}
+
+function tryForward(scope: Scope, event: string, data?: unknown): void {
+  if (!forwarder) return;
+  if (scope === "net") return; // prevent feedback loop via net:send / net:state received
+  const now = Date.now();
+  const b = fwdBudget.get(scope);
+  if (!b || now - b.windowStart > 1000) {
+    fwdBudget.set(scope, { count: 1, windowStart: now });
+  } else if (b.count >= FWD_MAX_PER_SEC) {
+    return;
+  } else {
+    b.count++;
+  }
+  try { forwarder(scope, event, data); } catch {}
 }
 
 export function dlog(scope: Scope, event: string, data?: unknown): void {
   if (!enabled) return;
   const key = `${scope}:${event}`;
   const now = Date.now();
-  if ((lastEmit.get(key) ?? 0) + 16 > now) return;
+  if ((lastEmit.get(key) ?? 0) + THROTTLE_MS > now) return;
   lastEmit.set(key, now);
-  if (data !== undefined) console.log(`[${scope}] ${event}`, data);
-  else console.log(`[${scope}] ${event}`);
+  pruneIfNeeded();
+  const prefix = `[${scope}] ${event}${formatCtx()}`;
+  if (data !== undefined) console.log(prefix, data);
+  else console.log(prefix);
+  tryForward(scope, event, data);
 }
 
 export function dlogUnthrottled(scope: Scope, event: string, data?: unknown): void {
   if (!enabled) return;
-  if (data !== undefined) console.log(`[${scope}] ${event}`, data);
-  else console.log(`[${scope}] ${event}`);
+  const prefix = `[${scope}] ${event}${formatCtx()}`;
+  if (data !== undefined) console.log(prefix, data);
+  else console.log(prefix);
+  tryForward(scope, event, data);
 }

--- a/src/net/wsClient.test.ts
+++ b/src/net/wsClient.test.ts
@@ -9,6 +9,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClientMsg, LobbyState, ServerMsg } from "../../shared/protocol";
+import { getLogForwarder, setLogContext, setLogForwarder, setLoggerEnabled } from "../debug/logger";
 import { createRoom, joinRoom } from "./wsClient";
 
 // ---------------------------------------------------------------------------
@@ -304,6 +305,47 @@ describe("joinRoom", () => {
     room.leave();
     expect(closeCodes).toEqual([1000]);
     expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+  });
+
+  it("stale socket close does not wipe log context set by a newer socket", async () => {
+    // Enable logging so the forwarder is installed on open.
+    setLoggerEnabled(true);
+
+    // --- First connection ---
+    const p1 = joinRoom("ws://example.test", "WAVE", "alice", "#ff4444");
+    const ws1 = MockWebSocket.instances[0];
+    if (!ws1) throw new Error("mock socket 1 not created");
+    ws1.open();
+    ws1.recv({
+      type: "welcome",
+      sessionId: "sid-1",
+      resumeToken: "resume-abc",
+      state: baselineState(),
+    });
+    await p1;
+
+    // Forwarder from first connection is now installed.
+    const fwd1 = getLogForwarder();
+    expect(fwd1).not.toBeNull();
+
+    // --- Second connection (reconnect) sets its own forwarder + log context ---
+    // Simulate new room context being set by a second joinRoom call.
+    // We install a fresh forwarder manually to represent the new socket's setup.
+    const fwd2 = vi.fn();
+    setLogForwarder(fwd2);
+    setLogContext({ room: "NEW_ROOM" });
+
+    // --- First socket's close fires late (stale) ---
+    // In production this happens when the OS flushes a delayed TCP FIN.
+    ws1.close(1001);
+
+    // The stale close must NOT have cleared the newer context/forwarder.
+    expect(getLogForwarder()).toBe(fwd2);
+
+    // Cleanup
+    setLoggerEnabled(false);
+    setLogForwarder(null);
+    setLogContext({ room: undefined });
   });
 
   it("ignores malformed JSON messages instead of crashing", async () => {

--- a/src/net/wsClient.ts
+++ b/src/net/wsClient.ts
@@ -235,8 +235,11 @@ export async function joinRoom(
     socket.addEventListener("close", (ev: CloseEvent) => {
       settleErr(new Error(`WebSocket closed before welcome (code ${ev.code})`));
       const cur = getLogForwarder();
-      if (cur && (cur as unknown as Record<string, unknown>)._socket === socket) setLogForwarder(null);
-      setLogContext({ room: undefined });
+      const isOurSocket = cur && (cur as unknown as Record<string, unknown>)._socket === socket;
+      if (isOurSocket) {
+        setLogForwarder(null);
+        setLogContext({ room: undefined });
+      }
       for (const cb of closeSubs) {
         try {
           cb(ev.code);

--- a/src/net/wsClient.ts
+++ b/src/net/wsClient.ts
@@ -27,7 +27,9 @@
  */
 
 import type { ClientMsg, LobbyState, ServerMsg } from "../../shared/protocol";
-import { dlog } from "../debug/logger";
+import { dlog, getLogForwarder, isLoggerEnabled, setLogContext, setLogForwarder } from "../debug/logger";
+
+type Forwarder = (scope: "scene" | "net" | "sim" | "camera" | "input", event: string, data?: unknown) => void;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -181,6 +183,15 @@ export async function joinRoom(
     socket.addEventListener("open", () => {
       // WebSocket-level open isn't enough: we wait for the `welcome`
       // application-layer message before surfacing a usable handle.
+      if (isLoggerEnabled()) {
+        const mySocket = socket;
+        const fn: Forwarder = (scope, event, data) => {
+          if (mySocket.readyState !== WebSocket.OPEN) return;
+          mySocket.send(JSON.stringify({ type: "client_log", scope, event, data, ts: Date.now() }));
+        };
+        (fn as unknown as Record<string, unknown>)._socket = mySocket;
+        setLogForwarder(fn);
+      }
     });
 
     socket.addEventListener("message", (ev: MessageEvent) => {
@@ -197,6 +208,7 @@ export async function joinRoom(
         sessionId = msg.sessionId;
         resumeTokenOut = msg.resumeToken;
         currentState = msg.state;
+        setLogContext({ room: currentState.code || code.toUpperCase() });
         settleOk();
         // Welcome ALSO fires onStateChange so callers get a single code
         // path for "state arrived" regardless of first vs subsequent.
@@ -222,6 +234,9 @@ export async function joinRoom(
 
     socket.addEventListener("close", (ev: CloseEvent) => {
       settleErr(new Error(`WebSocket closed before welcome (code ${ev.code})`));
+      const cur = getLogForwarder();
+      if (cur && (cur as unknown as Record<string, unknown>)._socket === socket) setLogForwarder(null);
+      setLogContext({ room: undefined });
       for (const cb of closeSubs) {
         try {
           cb(ev.code);

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -105,8 +105,6 @@ export class NetworkedSimAdapter implements SimAdapter {
   private lastActiveTeamId = "";
   private lastActiveWormId = "";
   private lastTurnEndsAt = 0;
-  private localTurnSeq = 0;
-
   // Aim throttling: drag-to-aim fires at 60+Hz but we only send max
   // one input_aim_{angle,power} pair every 50ms (20Hz). The last value
   // is remembered so a subsequent flush lands the final state before
@@ -457,8 +455,7 @@ export class NetworkedSimAdapter implements SimAdapter {
       this.stableFiredThisTurn = false;
       this.stableTurnTeamId = state.activeTeamId;
       this.stableTurnWormId = state.activeWormId;
-      this.localTurnSeq += 1;
-      setLogContext({ turn: this.localTurnSeq });
+      setLogContext({ turn: this.room.state.turnSeq });
       dlogUnthrottled("sim", "NetworkedSimAdapter.turn_changed", {
         teamId: state.activeTeamId,
         wormId: state.activeWormId,

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -15,7 +15,7 @@
  * Calls log a warning and drop.
  */
 
-import { dlogUnthrottled } from "../debug/logger";
+import { dlogUnthrottled, setLogContext } from "../debug/logger";
 import type {
   ClientMsg,
   DamageEventMessage,
@@ -105,6 +105,7 @@ export class NetworkedSimAdapter implements SimAdapter {
   private lastActiveTeamId = "";
   private lastActiveWormId = "";
   private lastTurnEndsAt = 0;
+  private localTurnSeq = 0;
 
   // Aim throttling: drag-to-aim fires at 60+Hz but we only send max
   // one input_aim_{angle,power} pair every 50ms (20Hz). The last value
@@ -456,6 +457,8 @@ export class NetworkedSimAdapter implements SimAdapter {
       this.stableFiredThisTurn = false;
       this.stableTurnTeamId = state.activeTeamId;
       this.stableTurnWormId = state.activeWormId;
+      this.localTurnSeq += 1;
+      setLogContext({ turn: this.localTurnSeq });
       dlogUnthrottled("sim", "NetworkedSimAdapter.turn_changed", {
         teamId: state.activeTeamId,
         wormId: state.activeWormId,

--- a/worker/src/debug/logger.ts
+++ b/worker/src/debug/logger.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-side diagnostic logger.
+ *
+ * Always-on (DEBUG=true). Output goes to Cloudflare Worker logs,
+ * visible via `wrangler tail`. No user-facing cost, no persistence.
+ *
+ * Every log line includes correlation IDs (room code + turn seq) so
+ * multi-room tails are greppable by room.
+ */
+
+const DEBUG = true;
+const THROTTLE_MS = 16;
+const MAX_THROTTLE_KEYS = 256;
+
+export type ServerScope = "room" | "net" | "sim" | "turn" | "client";
+
+export interface LogContext {
+  room?: string;
+  turn?: number;
+}
+
+const lastEmit = new Map<string, number>();
+
+function pruneIfNeeded(): void {
+  if (lastEmit.size <= MAX_THROTTLE_KEYS) return;
+  const keys = Array.from(lastEmit.keys());
+  const toDrop = Math.floor(keys.length / 2);
+  for (let i = 0; i < toDrop; i++) lastEmit.delete(keys[i]);
+}
+
+function formatCtx(ctx?: LogContext): string {
+  if (!ctx) return "";
+  const parts: string[] = [];
+  if (ctx.room !== undefined && ctx.room !== "") parts.push(`room=${ctx.room}`);
+  if (ctx.turn !== undefined) parts.push(`turn=${ctx.turn}`);
+  return parts.length > 0 ? " " + parts.join(" ") : "";
+}
+
+export function dlog(scope: ServerScope, event: string, ctx?: LogContext, data?: unknown): void {
+  if (!DEBUG) return;
+  const key = `${scope}:${event}`;
+  const now = Date.now();
+  if ((lastEmit.get(key) ?? 0) + THROTTLE_MS > now) return;
+  lastEmit.set(key, now);
+  pruneIfNeeded();
+  const prefix = `[${scope}] ${event}${formatCtx(ctx)}`;
+  if (data !== undefined) console.log(prefix + " |", data);
+  else console.log(prefix);
+}
+
+export function dlogUnthrottled(scope: ServerScope, event: string, ctx?: LogContext, data?: unknown): void {
+  if (!DEBUG) return;
+  const prefix = `[${scope}] ${event}${formatCtx(ctx)}`;
+  if (data !== undefined) console.log(prefix + " |", data);
+  else console.log(prefix);
+}

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -25,12 +25,7 @@ import {
   unpackMask,
 } from "../../shared/maskPack.js";
 
-const DEBUG = true;
-function dlog(event: string, data?: unknown): void {
-  if (!DEBUG) return;
-  if (data !== undefined) console.log(`[room] ${event}`, data);
-  else console.log(`[room] ${event}`);
-}
+import { dlog, type LogContext } from "./debug/logger.js";
 import {
   ALLOWED_COLORS,
   type LobbyPlayer,
@@ -140,11 +135,16 @@ export class Room implements DurableObject {
   private simBootstrap: SimBootstrap | null = null;
   private pendingInputs: PendingInput[] = [];
   private tickInProgress = false;
+  private clientLogBudget = new Map<WebSocket, { count: number; windowStart: number }>();
 
   constructor(state: DurableObjectState, env: unknown) {
     this.state = state;
     this.env = env;
     void this.env;
+  }
+
+  private logCtx(): LogContext {
+    return { room: this.code ?? undefined, turn: this.lobby?.turnSeq };
   }
 
   // ---- storage helpers ----
@@ -248,6 +248,7 @@ export class Room implements DurableObject {
       mask,
       teams: bootstrap.teams,
       seed: bootstrap.seed,
+      logCtx: () => this.logCtx(),
     });
     const persisted = await this.state.storage.get<SerializedSim>("simState");
     if (persisted) this.sim.restore(persisted);
@@ -438,7 +439,7 @@ export class Room implements DurableObject {
     const player = lobby.players[attachment.sessionId];
     if (!player) return;
 
-    dlog("webSocketMessage", { type, sid: attachment.sessionId, phase: lobby.phase });
+    dlog("room", "webSocketMessage", this.logCtx(), { type, sid: attachment.sessionId, phase: lobby.phase });
 
     switch (type) {
       case "set_nickname":
@@ -473,6 +474,9 @@ export class Room implements DurableObject {
       case "input_jetpack_horizontal":
         this.queueInput(attachment.sessionId, type, msg);
         break;
+      case "client_log":
+        this.onClientLog(ws, player, msg);
+        break;
       case "leave":
         try {
           ws.close(1000, "client_leave");
@@ -500,6 +504,8 @@ export class Room implements DurableObject {
     const lobby = this.ensureLobby();
     const player = lobby.players[attachment.sessionId];
     if (!player) return;
+
+    this.clientLogBudget.delete(ws);
 
     const liveForSession = this.state.getWebSockets().some((other) => {
       if (other === ws) return false;
@@ -534,7 +540,7 @@ export class Room implements DurableObject {
     try {
       await this.loadState();
       const lobby = this.ensureLobby();
-      dlog("alarm fire", {
+      dlog("room", "alarm fire", this.logCtx(), {
         phase: lobby.phase,
         tickInProgress: this.tickInProgress,
         hasSim: this.sim !== null,
@@ -640,6 +646,25 @@ export class Room implements DurableObject {
 
   // ---- message handlers ----
 
+  private onClientLog(ws: WebSocket, player: LobbyPlayer, msg: unknown): void {
+    const m = msg as { scope?: string; event?: string; data?: unknown };
+    if (typeof m.scope !== "string" || typeof m.event !== "string") return;
+    const now = Date.now();
+    const b = this.clientLogBudget.get(ws);
+    if (!b || now - b.windowStart > 1000) {
+      this.clientLogBudget.set(ws, { count: 1, windowStart: now });
+    } else if (b.count >= 30) {
+      return; // drop
+    } else {
+      b.count++;
+    }
+    const scope = m.scope.slice(0, 16);
+    const event = m.event.slice(0, 64);
+    const sid = player.sessionId?.slice(0, 8) ?? "?";
+    const safeData = typeof m.data === "object" && m.data !== null ? (m.data as Record<string, unknown>) : {};
+    dlog("client", event, this.logCtx(), { ...safeData, clientScope: scope, sid });
+  }
+
   private onSetNickname(ws: WebSocket, player: LobbyPlayer, msg: unknown): void {
     const nickname = normaliseNickname((msg as { nickname?: unknown }).nickname);
     if (!isValidNickname(nickname)) {
@@ -669,7 +694,7 @@ export class Room implements DurableObject {
 
   private onSetReady(player: LobbyPlayer, msg: unknown): void {
     const lobby = this.ensureLobby();
-    dlog("onSetReady", {
+    dlog("room", "onSetReady", this.logCtx(), {
       sid: player.sessionId ?? "?",
       ready: Boolean((msg as { ready?: unknown }).ready),
       phase: lobby.phase,
@@ -705,7 +730,7 @@ export class Room implements DurableObject {
    */
   private async onReturnToLobby(ws: WebSocket, player: LobbyPlayer): Promise<void> {
     const lobby = this.ensureLobby();
-    dlog("onReturnToLobby entry", { sid: player.sessionId ?? "?", phase: lobby.phase });
+    dlog("room", "onReturnToLobby entry", this.logCtx(), { sid: player.sessionId ?? "?", phase: lobby.phase });
     if (!player.isHost) {
       this.sendError(ws, "not_host", "Only the host may return to the lobby.");
       return;
@@ -744,7 +769,7 @@ export class Room implements DurableObject {
       if (!p.isHost) p.ready = false;
     }
     await this.persistLobby();
-    dlog("onReturnToLobby exit", { phase: this.ensureLobby().phase });
+    dlog("room", "onReturnToLobby exit", this.logCtx(), { phase: this.ensureLobby().phase });
     this.broadcastState();
   }
 
@@ -865,6 +890,7 @@ export class Room implements DurableObject {
       mask,
       teams: simTeams,
       seed,
+      logCtx: () => this.logCtx(),
     });
     await this.persistSim();
 
@@ -1115,7 +1141,7 @@ export class Room implements DurableObject {
 
   private broadcastState(): void {
     const lobby = this.ensureLobby();
-    dlog("broadcastState", {
+    dlog("room", "broadcastState", this.logCtx(), {
       phase: lobby.phase,
       sockets: this.state.getWebSockets().length,
       players: Object.keys(lobby.players).length,
@@ -1164,6 +1190,9 @@ export class Room implements DurableObject {
     return {
       get state() {
         return self.ensureLobby();
+      },
+      get code() {
+        return self.code ?? "";
       },
       broadcast(type, payload): void {
         self.broadcast({ type, ...(payload as object) } as ServerMsg);

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -649,6 +649,7 @@ export class Room implements DurableObject {
   private onClientLog(ws: WebSocket, player: LobbyPlayer, msg: unknown): void {
     const m = msg as { scope?: string; event?: string; data?: unknown };
     if (typeof m.scope !== "string" || typeof m.event !== "string") return;
+    if (m.scope.length === 0 || m.event.length === 0) return;
     const now = Date.now();
     const b = this.clientLogBudget.get(ws);
     if (!b || now - b.windowStart > 1000) {
@@ -661,7 +662,10 @@ export class Room implements DurableObject {
     const scope = m.scope.slice(0, 16);
     const event = m.event.slice(0, 64);
     const sid = player.sessionId?.slice(0, 8) ?? "?";
-    const safeData = typeof m.data === "object" && m.data !== null ? (m.data as Record<string, unknown>) : {};
+    const safeData =
+      typeof m.data === "object" && m.data !== null && !Array.isArray(m.data)
+        ? (m.data as Record<string, unknown>)
+        : {};
     dlog("client", event, this.logCtx(), { ...safeData, clientScope: scope, sid });
   }
 

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Contact, ContactImpulse } from "planck";
+import { dlog, type LogContext } from "../debug/logger.js";
 import {
   Projectile,
   type ProjectileRenderState,
@@ -104,6 +105,7 @@ export interface SimulationInit {
   mask: Uint8Array;
   teams: SimTeamInit[];
   seed: number;
+  logCtx?: () => LogContext;
 }
 
 /** Snapshot for DO storage / hibernation recovery. */
@@ -170,11 +172,13 @@ export class Simulation {
    * -1 means infinite. Finite weapons (e.g. holygrenade=2) are tracked here.
    */
   private readonly teamAmmo: Map<string, Record<string, number>> = new Map();
+  private readonly getLogCtx: () => LogContext;
 
   constructor(init: SimulationInit) {
     this.widthPx = init.widthPx;
     this.heightPx = init.heightPx;
     this.seed = init.seed;
+    this.getLogCtx = init.logCtx ?? (() => ({}));
     this.world = createPhysicsWorld(init.gravity ?? { x: 0, y: 10 });
     this.terrain = new Terrain({
       world: this.world,
@@ -355,6 +359,7 @@ export class Simulation {
       power: worm.aimPower,
       facing: worm.facing,
     });
+    dlog("sim", "fire", this.getLogCtx(), { weaponId: weapon.id, wormId: worm.id });
 
     for (const ex of result.explodeResults) {
       this.emitExplodeEvents(ex, null);
@@ -418,6 +423,7 @@ export class Simulation {
         if (!worm.alive && !this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);
           this.events.push({ type: "worm_died", wormId: worm.id });
+          dlog("sim", "worm_died", this.getLogCtx(), { wormId: worm.id, cause: "fall" });
         }
       }
     }
@@ -473,6 +479,7 @@ export class Simulation {
         if (!this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);
           this.events.push({ type: "worm_died", wormId: worm.id });
+          dlog("sim", "worm_died", this.getLogCtx(), { wormId: worm.id, cause: "off_map" });
         }
       }
     }
@@ -490,6 +497,7 @@ export class Simulation {
           if (!this.diedThisTick.has(worm.id)) {
             this.diedThisTick.add(worm.id);
             this.events.push({ type: "worm_died", wormId: worm.id });
+            dlog("sim", "worm_died", this.getLogCtx(), { wormId: worm.id, cause: "drown" });
             this.events.push({
               type: "damage_event",
               wormId: worm.id,
@@ -706,6 +714,7 @@ export class Simulation {
       r: ex.cut.r,
       seq: ex.cut.seq,
     });
+    dlog("sim", "terrain_cut", this.getLogCtx(), { x: ex.cut.x, y: ex.cut.y, r: ex.cut.r });
     for (const d of ex.damaged) {
       this.events.push({
         type: "damage_event",
@@ -717,6 +726,7 @@ export class Simulation {
       if (d.died && !this.diedThisTick.has(d.wormId)) {
         this.diedThisTick.add(d.wormId);
         this.events.push({ type: "worm_died", wormId: d.wormId });
+        dlog("sim", "worm_died", this.getLogCtx(), { wormId: d.wormId, cause: "explosion" });
       }
     }
   }
@@ -725,6 +735,7 @@ export class Simulation {
     if (proj.detonated) return;
     proj.markDetonated();
     const pos = proj.body.getPosition();
+    dlog("sim", "detonate", this.getLogCtx(), { weaponId: proj.config.id, x: toPixels(pos.x), y: toPixels(pos.y) });
     const centerPx = { x: toPixels(pos.x), y: toPixels(pos.y) };
     const result = explode({
       world: this.world,

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -18,6 +18,7 @@
  */
 
 import type { LobbyState } from "./messages.js";
+import { dlog, type LogContext } from "./debug/logger.js";
 
 /** Shared timing constants. */
 export const TURN_DURATION_MS = 45_000;
@@ -51,6 +52,7 @@ export interface AliveCountsProvider {
  */
 export interface ArbiterRoomAdapter {
   readonly state: LobbyState;
+  readonly code: string;
   /** Broadcast a typed payload to every connected client. */
   broadcast(type: string, payload: unknown): void;
   /** Session ids currently present. Disconnected-grace players may still be here. */
@@ -100,6 +102,10 @@ export class TurnArbiter {
 
   constructor(room: ArbiterRoomAdapter) {
     this.room = room;
+  }
+
+  private logCtx(): LogContext {
+    return { room: this.room.code, turn: this.room.state.turnSeq };
   }
 
   toJSON(): ArbiterPersistedState {
@@ -176,6 +182,7 @@ export class TurnArbiter {
       if (provider?.isAllSettled(EARLY_SETTLE_VEL_THRESHOLD_MPS)) {
         this.settleHoldMs += Math.max(0, dtMs);
         if (this.settleHoldMs >= EARLY_SETTLE_HOLD_MS) {
+          dlog("turn", "early_settled", this.logCtx(), { heldMs: this.settleHoldMs });
           this.advanceTurn();
           return;
         }
@@ -185,6 +192,7 @@ export class TurnArbiter {
     }
     // Safety cap: advance unconditionally after SETTLE_GRACE_MS.
     if (now > this.room.state.turnEndsAt + SETTLE_GRACE_MS) {
+      dlog("turn", "safety_cap", this.logCtx());
       this.advanceTurn();
     }
   }
@@ -218,6 +226,7 @@ export class TurnArbiter {
     if (retreatEnd < this.room.state.turnEndsAt) {
       this.room.state.turnEndsAt = retreatEnd;
     }
+    dlog("turn", "fire_committed", this.logCtx(), { retreatEndsAt: retreatEnd });
   }
 
   /**
@@ -227,8 +236,22 @@ export class TurnArbiter {
    * ignored so the player can't sneak another fire after the timer hits 0).
    */
   canFire(): boolean {
-    if (!this.areInputsAccepted()) return false;
-    if (this.hasFiredThisTurn) return false;
+    if (this.gameOver) {
+      dlog("turn", "fire_rejected", this.logCtx(), { reason: "gameOver" });
+      return false;
+    }
+    if (this.pausedRemainingMs !== null) {
+      dlog("turn", "fire_rejected", this.logCtx(), { reason: "inputsClosed" });
+      return false;
+    }
+    if (Date.now() > this.room.state.turnEndsAt) {
+      dlog("turn", "fire_rejected", this.logCtx(), { reason: "inputsClosed" });
+      return false;
+    }
+    if (this.hasFiredThisTurn) {
+      dlog("turn", "fire_rejected", this.logCtx(), { reason: "alreadyFired" });
+      return false;
+    }
     return true;
   }
 
@@ -291,6 +314,7 @@ export class TurnArbiter {
     const remaining = Math.max(0, this.room.state.turnEndsAt - Date.now());
     this.pausedRemainingMs = remaining;
     this.room.state.turnEndsAt = Number.MAX_SAFE_INTEGER;
+    dlog("turn", "paused", this.logCtx(), { remainingMs: this.pausedRemainingMs });
   }
 
   onOwnerReconnected(sessionId: string): void {
@@ -303,6 +327,7 @@ export class TurnArbiter {
     this.room.state.turnEndsAt = Date.now() + this.pausedRemainingMs;
     this.pausedRemainingMs = null;
     this.settleHoldMs = 0;
+    dlog("turn", "resumed", this.logCtx());
   }
 
   onTeamForfeit(teamId: string): void {
@@ -338,6 +363,7 @@ export class TurnArbiter {
   }
 
   private advanceTurn(): void {
+    const fromTeam = this.room.state.currentTeamId;
     this.settleHoldMs = 0;
     const teamsWithAliveWorms: string[] = [];
     for (const teamId of this.room.state.teamOrder) {
@@ -378,6 +404,7 @@ export class TurnArbiter {
     this.room.state.turnSeq += 1;
     this.room.state.turnEndsAt = Date.now() + this.turnDurationMs;
     this.pausedRemainingMs = null;
+    dlog("turn", "advance", this.logCtx(), { fromTeam, toTeam: nextTeamId });
     this.fireTurnStart();
   }
 

--- a/worker/test/clientLog.test.ts
+++ b/worker/test/clientLog.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the client_log rate-limit and validation logic.
+ *
+ * The core logic is extracted as a pure helper so it's testable without
+ * spinning up a full Durable Object.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Pure helper mirroring the onClientLog logic in Room
+// ---------------------------------------------------------------------------
+
+interface BudgetEntry {
+  count: number;
+  windowStart: number;
+}
+
+/**
+ * Process a client_log message. Returns the log object that would be passed
+ * to dlog, or null if the message is dropped (invalid or rate-limited).
+ */
+function processClientLog(
+  msg: unknown,
+  sessionId: string,
+  budget: Map<symbol, BudgetEntry>,
+  socketKey: symbol,
+  now: number,
+): { event: string; data: Record<string, unknown> } | null {
+  const m = msg as { scope?: string; event?: string; data?: unknown };
+  if (typeof m.scope !== "string" || typeof m.event !== "string") return null;
+
+  const b = budget.get(socketKey);
+  if (!b || now - b.windowStart > 1000) {
+    budget.set(socketKey, { count: 1, windowStart: now });
+  } else if (b.count >= 30) {
+    return null; // drop
+  } else {
+    b.count++;
+  }
+
+  const scope = m.scope.slice(0, 16);
+  const event = m.event.slice(0, 64);
+  const sid = sessionId.slice(0, 8);
+  const safeData =
+    typeof m.data === "object" && m.data !== null ? (m.data as Record<string, unknown>) : {};
+
+  return {
+    event,
+    data: { ...safeData, clientScope: scope, sid },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("clientLog processing", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("valid msg emits with clientScope and sid fields", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "sim", event: "test", data: { x: 1 }, ts: 123 },
+      "abc12345xyz",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.event).toBe("test");
+    expect(result!.data.clientScope).toBe("sim");
+    expect(result!.data.sid).toBe("abc12345");
+    expect(result!.data.x).toBe(1);
+  });
+
+  it("non-string scope returns null (silent drop)", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: 42, event: "test" },
+      "abc",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("non-string event returns null (silent drop)", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "sim", event: null },
+      "abc",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("truncates scope to 16 chars and event to 64 chars", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const longScope = "a".repeat(30);
+    const longEvent = "b".repeat(100);
+    const result = processClientLog(
+      { scope: longScope, event: longEvent },
+      "sid",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.data.clientScope).toHaveLength(16);
+    expect(result!.event).toHaveLength(64);
+  });
+
+  it("spread-first protection: trusted fields (sid, clientScope) overwrite client data", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "sim", event: "test", data: { sid: "evil", clientScope: "evil" } },
+      "trustedSid",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).not.toBeNull();
+    // sid and clientScope should come from trusted fields, NOT from client data
+    expect(result!.data.sid).toBe("trustedS"); // first 8 chars of "trustedSid"
+    expect(result!.data.clientScope).toBe("sim");
+    expect(result!.data.sid).not.toBe("evil");
+    expect(result!.data.clientScope).not.toBe("evil");
+  });
+
+  it("rate limits: 35 calls in same second -> only 30 emit", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const now = Date.now();
+    let emitted = 0;
+    for (let i = 0; i < 35; i++) {
+      const result = processClientLog(
+        { scope: "sim", event: `ev${i}` },
+        "sid",
+        budget,
+        key,
+        now, // same timestamp = same second window
+      );
+      if (result !== null) emitted++;
+    }
+    expect(emitted).toBe(30);
+  });
+
+  it("rate limit resets after 1000ms window", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const now = 1000;
+    // Fill up the budget
+    for (let i = 0; i < 30; i++) {
+      processClientLog({ scope: "sim", event: `ev${i}` }, "sid", budget, key, now);
+    }
+    // Should be rate-limited now
+    const blocked = processClientLog({ scope: "sim", event: "blocked" }, "sid", budget, key, now);
+    expect(blocked).toBeNull();
+    // After 1001ms, window resets
+    const after = processClientLog(
+      { scope: "sim", event: "allowed" },
+      "sid",
+      budget,
+      key,
+      now + 1001,
+    );
+    expect(after).not.toBeNull();
+  });
+});

--- a/worker/test/clientLog.test.ts
+++ b/worker/test/clientLog.test.ts
@@ -29,6 +29,7 @@ function processClientLog(
 ): { event: string; data: Record<string, unknown> } | null {
   const m = msg as { scope?: string; event?: string; data?: unknown };
   if (typeof m.scope !== "string" || typeof m.event !== "string") return null;
+  if (m.scope.length === 0 || m.event.length === 0) return null;
 
   const b = budget.get(socketKey);
   if (!b || now - b.windowStart > 1000) {
@@ -43,7 +44,9 @@ function processClientLog(
   const event = m.event.slice(0, 64);
   const sid = sessionId.slice(0, 8);
   const safeData =
-    typeof m.data === "object" && m.data !== null ? (m.data as Record<string, unknown>) : {};
+    typeof m.data === "object" && m.data !== null && !Array.isArray(m.data)
+      ? (m.data as Record<string, unknown>)
+      : {};
 
   return {
     event,
@@ -182,5 +185,51 @@ describe("clientLog processing", () => {
       now + 1001,
     );
     expect(after).not.toBeNull();
+  });
+
+  it("array m.data does not spread numeric keys into log data", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "sim", event: "test", data: [1, 2, 3] },
+      "abc12345",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).not.toBeNull();
+    // Numeric keys from array spread must NOT appear
+    expect(result!.data[0]).toBeUndefined();
+    expect(result!.data[1]).toBeUndefined();
+    expect(result!.data[2]).toBeUndefined();
+    // Only trusted fields should be present
+    expect(result!.data.clientScope).toBe("sim");
+    expect(result!.data.sid).toBe("abc12345");
+  });
+
+  it("empty scope returns null (silent drop)", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "", event: "test" },
+      "abc",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("empty event returns null (silent drop)", () => {
+    const budget = new Map<symbol, BudgetEntry>();
+    const key = Symbol("ws");
+    const result = processClientLog(
+      { scope: "sim", event: "" },
+      "abc",
+      budget,
+      key,
+      Date.now(),
+    );
+    expect(result).toBeNull();
   });
 });

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -46,6 +46,7 @@ class StubAliveCountsProvider implements AliveCountsProvider {
 
 class StubRoom implements ArbiterRoomAdapter {
   state = makeState();
+  code = "TEST";
   broadcasts: Array<{ type: string; payload: unknown }> = [];
   connected = new Set<string>();
   disconnectedPlayers = new Set<string>();


### PR DESCRIPTION
## Summary

Unified debug logging stream across client and server. `wrangler tail --format pretty` during play now shows interleaved client + server events, grep-filterable by room code.

**Server side** — new `worker/src/debug/logger.ts` with the same API shape as the client logger (16ms per-scope throttle, LRU-capped map). Coverage added to:
- `turnArbiter`: fire_committed, fire_rejected (with reason), advance, early_settled, safety_cap, paused, resumed
- `simulation`: fire, detonate, worm_died, terrain_cut
- `room`: existing calls updated to new signature

**Correlation IDs** — every log line includes `room=<code> turn=<seq>`. Server reads authoritative `this.room.state.turnSeq`; client reads the same value from `room.state.turnSeq` (LobbyState, broadcast on every state update). No local counters.

**Client-to-server forwarder** — when `?debug=1`, every client `dlog()` call also sends a `client_log` WebSocket message to the server, which prints it with `[client]` prefix. Result: one stream, both sides, interleaved in `wrangler tail`.

**Guards**:
- Feedback-loop prevention: forwarder skips `scope === "net"` entirely (so `net:send` / `net:state received` don't recurse).
- Forwarder bypasses `wsClient.send()` and calls `socket.send()` directly (avoids its own dlog).
- Rate limits: 20/sec/scope on the client forwarder, 30/sec/socket on the server.
- LRU cap at 256 keys on the throttle Map (bounds memory if many unique events).

## Bug check

Clean after two fix commits (f4caba7 + 21e5718):
- Fixed: client used a local turn counter that would desync from server on reconnect.
- Fixed: onClientLog passed array `data` through `typeof === "object"`; spread produced `{0: v0, 1: v1, ...}` in logs.
- Fixed: socket close unconditionally cleared the log room context; on reconnect the stale close wiped the fresh context. Now gated on captured-socket identity.
- Fixed: empty `scope`/`event` strings produced ugly `[client]  room=...` lines. Now rejected.

## Known non-issues

- `ts` field on the `client_log` ClientMsg is included by the forwarder but not validated/used server-side. Harmless dead metadata — could be pruned in a follow-up.
- No phase gate on `client_log`. Per plan; lobby-phase client_logs are harmless and helpful for lobby debugging.
- Always-on server logging (option a). Chosen explicitly given current play-testing phase; ~1-2% DO CPU overhead at single-digit concurrent rooms, zero storage cost. Off-ramp is a 5-line change if ever needed.

## Test plan

- [ ] `wrangler tail --format pretty` during live play shows interleaved `[client] event room=WAVE turn=3`, `[turn] fire_committed room=WAVE turn=3`, `[sim] detonate room=WAVE turn=3` lines
- [ ] `wrangler tail | grep "room=WAVE"` filters cleanly
- [ ] Two concurrent rooms — events do not cross-contaminate
- [ ] Reconnect a client; new session's logs still show correct `room=` and `turn=`
- [ ] Client without `?debug=1` sends no `client_log` messages (forwarder stays null)
- [ ] 277 tests pass (client + worker)