### PR TITLE
fix(scenes): LobbyScene tears down room listeners on shutdown (#119)

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -159,6 +159,7 @@ export class LobbyScene extends Phaser.Scene {
     });
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       dlogUnthrottled("scene", "LobbyScene.shutdown", { unsubCount: this.roomUnsubs.length });
+      this.tearDownRoomListeners();
     });
 
     if (this.pendingReconnectedRoom) {


### PR DESCRIPTION
## Summary

Closes #119. One-line fix: `LobbyScene` now calls `tearDownRoomListeners()` from its Phaser SHUTDOWN handler. Previously the handler only logged `unsubCount` and never cleaned up.

## Why renderRoom fired 1570x per match

`wireRoomListeners()` adds 4 subscriptions to the RoomHandle (onStateChange, onMessage error, onMessage game_started, onClose). When LobbyScene transitioned to GameScene via `scene.start("GameScene")`, Phaser fired SHUTDOWN, but the handler never iterated `roomUnsubs[]`. Subscription #1 (onStateChange → debounced renderRoom) kept firing on every 20Hz state broadcast for the entire match, holding closures over a dead scene's `this`.

GameScene already does this correctly (`GameScene.ts:255-290`). LobbyScene's handler matches that pattern now.

## Likely side-effect on #117

The same bug left subscription #3 (`onMessage("game_started")`) of the dead game-1 LobbyScene wired during game-2's lobby. When game 2's `start_game` broadcast fired, BOTH the dead and fresh LobbyScene's gameStarted handlers ran, with the dead one calling `this.scene.start("GameScene")` from a shutdown scene context. With this fix, only the active LobbyScene's gameStarted fires.

User is testing on 2 phones to confirm whether this + PR #120 close #117 entirely.

## Bug Check

VERDICT: CLEAN.

Two MEDIUM findings are pre-existing on master, not regressed by this PR:

- **Set mutation during dispatch (latent):** wsClient.ts iterates `messageSubs` Set directly while callbacks may unsubscribe themselves mid-iteration. JS spec guarantees this is safe for already-visited elements. Single-subscriber assumption holds today; would break if a second `game_started` listener were added.
- **Stale rAF rerender (latent):** the debounced `rerender()` queues a requestAnimationFrame. If state arrives in the same tick as `game_started`, the rAF could fire after teardown. With this fix, this drops from ~1570 stale calls per match to at most 1. A follow-up could capture and cancel the pending rAF in the SHUTDOWN handler.

Both are pre-existing, both worth a follow-up issue, neither blocks this PR.

## Test plan

- [x] tsc clean
- [x] root npm test 277/277 passing
- [ ] In-app: `?debug=1`, host + join, start game, play 2 turns. Expect `LobbyScene.renderRoom` log count during gameplay phase ~0 (was ~1500).
- [ ] In-app: return to lobby, start game 2. Expect single `LobbyScene.gameStarted` log on the new lobby (was duplicated from a stale game-1 handler).

Closes #119