### PR TITLE
fix(pwa): landscape fills viewport, suppress launch splash flash (#121)

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,19 +86,27 @@
     <script>
       (function () {
         var root = document.documentElement;
-        root.classList.add("boot-grace");
-        setTimeout(function () { root.classList.remove("boot-grace"); }, 700);
+        // Only suppress the splash during launch if dimensions already say
+        // landscape. Real portrait launches show the splash immediately.
+        if (window.innerWidth >= window.innerHeight) {
+          root.classList.add("boot-grace");
+          setTimeout(function () { root.classList.remove("boot-grace"); }, 700);
+        }
 
         function update() {
           var portrait = window.innerHeight > window.innerWidth;
           root.setAttribute("data-portrait", portrait ? "1" : "0");
         }
         window.addEventListener("resize", update);
-        window.addEventListener("orientationchange", function () {
+        function onOrientationChange() {
           // iOS reports new dimensions after a delay; recheck twice.
           setTimeout(update, 100);
           setTimeout(update, 500);
-        });
+        }
+        window.addEventListener("orientationchange", onOrientationChange);
+        if (window.screen && screen.orientation && typeof screen.orientation.addEventListener === "function") {
+          screen.orientation.addEventListener("change", onOrientationChange);
+        }
         update();
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
     <title>Worms</title>
     <style>
       :root { color-scheme: dark; }
-      html, body { margin: 0; padding: 0; height: 100%; background: #0b0b0f; color: #e0e0e0; font-family: system-ui, sans-serif; }
+      html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #0b0b0f; color: #e0e0e0; font-family: system-ui, sans-serif; }
       body { display: flex; align-items: center; justify-content: center; }
-      #game-container { background: #1a1a22; }
+      #game-container { width: 100%; height: 100%; background: #1a1a22; }
 
       /*
        * Portrait rotate splash. Covers every scene (BootScene, LobbyScene,
@@ -68,6 +68,7 @@
       }
       html[data-portrait="1"] #rotate-splash { display: flex; }
       html[data-portrait="0"] #rotate-splash { display: none; }
+      html.boot-grace #rotate-splash { display: none !important; }
     </style>
   </head>
   <body>
@@ -83,17 +84,21 @@
       <p>This game is designed for landscape.</p>
     </div>
     <script>
-      // JS fallback: some desktop browsers with narrow tall windows do not
-      // trigger the orientation media query reliably. Compare dimensions
-      // directly and flip a data attribute on <html>.
       (function () {
         var root = document.documentElement;
+        root.classList.add("boot-grace");
+        setTimeout(function () { root.classList.remove("boot-grace"); }, 700);
+
         function update() {
           var portrait = window.innerHeight > window.innerWidth;
           root.setAttribute("data-portrait", portrait ? "1" : "0");
         }
         window.addEventListener("resize", update);
-        window.addEventListener("orientationchange", update);
+        window.addEventListener("orientationchange", function () {
+          // iOS reports new dimensions after a delay; recheck twice.
+          setTimeout(update, 100);
+          setTimeout(update, 500);
+        });
         update();
       })();
     </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,4 +19,11 @@ const config: Phaser.Types.Core.GameConfig = {
   },
 };
 
-new Phaser.Game(config);
+const game = new Phaser.Game(config);
+
+// iOS Safari/PWA report new innerWidth/innerHeight asynchronously after
+// orientationchange. Refresh Phaser's scale twice to catch both windows.
+window.addEventListener("orientationchange", () => {
+  setTimeout(() => game.scale.refresh(), 100);
+  setTimeout(() => game.scale.refresh(), 500);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,14 @@ const config: Phaser.Types.Core.GameConfig = {
 const game = new Phaser.Game(config);
 
 // iOS Safari/PWA report new innerWidth/innerHeight asynchronously after
-// orientationchange. Refresh Phaser's scale twice to catch both windows.
-window.addEventListener("orientationchange", () => {
+// the rotation event. Refresh Phaser's scale twice to catch both windows.
+// iOS 16.4+ uses screen.orientation.change; older Safari still fires
+// window.orientationchange. Listen to both - refresh is idempotent.
+const refreshScale = () => {
   setTimeout(() => game.scale.refresh(), 100);
   setTimeout(() => game.scale.refresh(), 500);
-});
+};
+window.addEventListener("orientationchange", refreshScale);
+if (typeof screen !== "undefined" && screen.orientation && typeof screen.orientation.addEventListener === "function") {
+  screen.orientation.addEventListener("change", refreshScale);
+}


### PR DESCRIPTION
## Summary

Closes #121. Three problems with mobile PWA in landscape mode:

1. **Splash flash on cold launch.** iOS PWA reports portrait dimensions briefly during init (before manifest's landscape lock applies), so the rotate splash flashes for ~300ms even when the user IS in landscape. Fixed with a 700ms `boot-grace` class on `<html>` that suppresses the splash during this window. The class is only added if launch dimensions already look landscape - genuine portrait launches still show the splash immediately.

2. **Canvas doesn't fill after rotation.** iOS Safari/PWA report new innerWidth/innerHeight asynchronously after a rotation event. Phaser's scale manager picks up stale dimensions and never recomputes. Now we listen on both `window.orientationchange` (legacy) and `screen.orientation.change` (iOS 16.4+/modern) and call `game.scale.refresh()` at 100ms and 500ms after each event - catching both the early and late dimension-update windows.

3. **Viewport not pinned.** `html, body` had `height: 100%` but no `width`, and `#game-container` had no dimensions. Phaser's `Scale.FIT` against an indeterminate parent gave inconsistent results. Now html/body are `width: 100%; height: 100%; overflow: hidden` and `#game-container` is `width: 100%; height: 100%`.

Same listener architecture (legacy + screen.orientation) used for the splash detection IIFE so its `update()` (data-portrait toggle) also fires reliably on iOS 16.4+.

## Bug Check

VERDICT: CLEAN after fixes.

Two MEDIUM findings caught and fixed pre-merge:
- Boot-grace originally unconditional, suppressing splash for genuine portrait launches → now gated on `innerWidth >= innerHeight`.
- Both orientation listeners only used `window.orientationchange`, which iOS 16.4+ may not dispatch when `screen.orientation` is available → now listen on both.

Other findings: NO ISSUE on overflow:hidden clipping splash (fixed-position immune), iOS viewport unit chain in standalone, Phaser input handlers, PWA resume timing, stale cache. LOW: dead `display: flex` centering on body (no-op once #game-container fills 100%).

## Test plan

- [x] tsc clean, 277/277 tests pass, vite build succeeds
- [ ] iPhone PWA cold launch in landscape: NO splash flash
- [ ] iPhone PWA cold launch in portrait: splash appears immediately (no 700ms delay)
- [ ] Phone in browser, rotate portrait → landscape: canvas fills viewport (was: stayed sized for old orientation)
- [ ] Desktop browser window resize: canvas scales correctly (regression check)

Closes #121