### PR TITLE
fix(ui): widen weapon radial orbit so 7 buttons don't overlap (#122)

### DIFF
--- a/src/ui/WeaponRadial.test.ts
+++ b/src/ui/WeaponRadial.test.ts
@@ -418,10 +418,10 @@ describe("WeaponRadial", () => {
     // The icons fan out to positions based on arc math. With 7 weapons the
     // first icon is at 90 deg (straight up), so its target position is:
     //   targetX = ORBIT_RADIUS * cos(90deg) = ~0
-    //   targetY = -ORBIT_RADIUS * sin(90deg) = -130
-    // Absolute screen position: (trigX + 0, trigY - 130) = (1200, 510).
+    //   targetY = -ORBIT_RADIUS * sin(90deg) = -300
+    // Absolute screen position: (trigX + 0, trigY - 300) = (1200, 340).
     // Fire a global pointerdown near that icon position.
-    const iconPtr = { x: trigX, y: trigY - 130, id: 7 } as Phaser.Input.Pointer;
+    const iconPtr = { x: trigX, y: trigY - 300, id: 7 } as Phaser.Input.Pointer;
     scene._fireInput("pointerdown", iconPtr);
 
     // selectWeapon should have been called with a weapon id string.

--- a/src/ui/WeaponRadial.ts
+++ b/src/ui/WeaponRadial.ts
@@ -16,7 +16,7 @@ type State = "CLOSED" | "OPEN" | "CLOSING";
 // Tunable constants - easy to migrate to tuning.ts later
 const TRIGGER_RADIUS = 34;
 const ICON_RADIUS = 26;
-const ORBIT_RADIUS = 130;
+const ORBIT_RADIUS = 300;
 const ARC_START_DEG = 90; // straight up
 const ARC_SPAN_DEG = 90; // 90-degree fan to the left
 const EXPAND_MS = 160;


### PR DESCRIPTION
## Summary

Closes #122. `ORBIT_RADIUS` in `src/ui/WeaponRadial.ts` was 130, sized for the original 3 weapons on a 90 deg arc. PR #113 added 4 more weapons (now 7 total). At 130px, adjacent icon centers are 33.9px apart but icons are 52px wide, so all 6 adjacent pairs overlapped by ~18px. Bumping to 300px gives 78.3px between centers - 26px clear gap between icon visuals and 10px gap between hit zones. All icons fit comfortably within the 1280x720 logical canvas (top icon at y=340, left at x=900, both with 300+ px margin from canvas edges).

Test fixture updated to match the new radius. No changes to game logic, protocol, or interaction model. Drag-to-select still picks by angle (radius-independent).

## Bug Check

VERDICT: CLEAN. No issues across out-of-bounds, hit zones, angle computation, or test invariants. Subjective LOW: the expand animation tween now travels 2.3x farther in the same 160ms duration - snappier/bouncier visually with the existing `Back.Out` ease. Acceptable tradeoff.

## Test plan

- [x] tsc clean, 277/277 tests pass, vite build succeeds
- [ ] In-app: tap the weapon button, see 7 weapons fan out clearly with visible gaps between them
- [ ] In-app: drag-and-release weapon select feels snappy, no mis-clicks on adjacent weapons
- [ ] In-app: sticky-tap mode (quick tap to open, then tap a weapon) hits the intended weapon

Closes #122