### PR TITLE
ci: run worker integration tests on PRs (#129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,5 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test:run
+      - run: cd worker && npm ci
+      - run: cd worker && npm test


### PR DESCRIPTION
## Summary

Closes #129. Two steps added to `.github/workflows/ci.yml` after the existing root test step:

```yaml
- run: cd worker && npm ci
- run: cd worker && npm test
```

The root vitest config only globs `src/` and `shared/`. Worker tests live under `worker/test/` with their own vitest config, so the integration harness from #127 was invisible to CI. With this change, the lobby-cycle integration test (and any future scenarios under `worker/test/integration/`) gates merges.

## Bug Check

VERDICT: APPROVE. Non-blocking optional improvements noted but not landed in this PR:

- Worker `npm ci` doesn't share cache with root (cache key uses root lockfile only). Performance hit ~20-30s per CI run; can add `cache-dependency-path` later if it matters.
- `vitest run` is single-threaded by default so the two test files don't race for port 8787; if pool is ever changed to threads, port collision becomes possible. Worth a comment in vitest.config later.
- `lobby-cycle.test.ts` has `{ timeout: 30_000 }` and `unstable_dev` cold-start can be 15-20s on a loaded runner. Marginal headroom. Will revisit if CI flake materializes.
- `worker/test/global-setup.ts`'s stub path is dead in CI (build runs first); useful only for local dev.

PASS findings: lockfile committed, `local: true` confirmed in both test files, build order is correct, no Cloudflare auth secrets needed, GHA short-circuits on failure.

## Test plan

- [x] YAML parses, 9 steps total (7 original + 2 new)
- [x] worker/package-lock.json committed
- [x] worker/package.json `test` script is `vitest run` (not watch mode)
- [ ] CI run on this PR completes successfully (live verification)

Closes #129