### PR TITLE
fix: resolve pre-existing lint errors blocking CI

### DIFF
--- a/src/debug/logger.test.ts
+++ b/src/debug/logger.test.ts
@@ -142,7 +142,9 @@ describe("logger", () => {
 
     it("swallows errors thrown by forwarder", () => {
       setLoggerEnabled(true);
-      setLogForwarder(() => { throw new Error("oops"); });
+      setLogForwarder(() => {
+        throw new Error("oops");
+      });
       expect(() => dlogUnthrottled("sim", "test")).not.toThrow();
     });
   });

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -33,15 +33,31 @@ let forwarder: Forwarder | null = null;
 const lastEmit = new Map<string, number>();
 const fwdBudget = new Map<Scope, { count: number; windowStart: number }>();
 
-export function setLoggerEnabled(v: boolean): void { enabled = v; }
-export function isLoggerEnabled(): boolean { return enabled; }
-export function setLogContext(next: Partial<LogContext>): void { ctx = { ...ctx, ...next }; }
-export function getLogContext(): LogContext { return { ...ctx }; }
-export function setLogForwarder(f: Forwarder | null): void { forwarder = f; }
-export function getLogForwarder(): Forwarder | null { return forwarder; }
+export function setLoggerEnabled(v: boolean): void {
+  enabled = v;
+}
+export function isLoggerEnabled(): boolean {
+  return enabled;
+}
+export function setLogContext(next: Partial<LogContext>): void {
+  ctx = { ...ctx, ...next };
+}
+export function getLogContext(): LogContext {
+  return { ...ctx };
+}
+export function setLogForwarder(f: Forwarder | null): void {
+  forwarder = f;
+}
+export function getLogForwarder(): Forwarder | null {
+  return forwarder;
+}
 
-export function _testGetThrottleMapSize(): number { return lastEmit.size; }
-export function _testResetFwdBudget(): void { fwdBudget.clear(); }
+export function _testGetThrottleMapSize(): number {
+  return lastEmit.size;
+}
+export function _testResetFwdBudget(): void {
+  fwdBudget.clear();
+}
 
 function pruneIfNeeded(): void {
   if (lastEmit.size <= MAX_THROTTLE_KEYS) return;
@@ -54,7 +70,7 @@ function formatCtx(): string {
   const parts: string[] = [];
   if (ctx.room !== undefined && ctx.room !== "") parts.push(`room=${ctx.room}`);
   if (ctx.turn !== undefined) parts.push(`turn=${ctx.turn}`);
-  return parts.length > 0 ? " " + parts.join(" ") : "";
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
 }
 
 function tryForward(scope: Scope, event: string, data?: unknown): void {
@@ -69,7 +85,9 @@ function tryForward(scope: Scope, event: string, data?: unknown): void {
   } else {
     b.count++;
   }
-  try { forwarder(scope, event, data); } catch {}
+  try {
+    forwarder(scope, event, data);
+  } catch {}
 }
 
 export function dlog(scope: Scope, event: string, data?: unknown): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,10 @@ const refreshScale = () => {
   setTimeout(() => game.scale.refresh(), 500);
 };
 window.addEventListener("orientationchange", refreshScale);
-if (typeof screen !== "undefined" && screen.orientation && typeof screen.orientation.addEventListener === "function") {
+if (
+  typeof screen !== "undefined" &&
+  screen.orientation &&
+  typeof screen.orientation.addEventListener === "function"
+) {
   screen.orientation.addEventListener("change", refreshScale);
 }

--- a/src/net/wsClient.ts
+++ b/src/net/wsClient.ts
@@ -27,9 +27,19 @@
  */
 
 import type { ClientMsg, LobbyState, ServerMsg } from "../../shared/protocol";
-import { dlog, getLogForwarder, isLoggerEnabled, setLogContext, setLogForwarder } from "../debug/logger";
+import {
+  dlog,
+  getLogForwarder,
+  isLoggerEnabled,
+  setLogContext,
+  setLogForwarder,
+} from "../debug/logger";
 
-type Forwarder = (scope: "scene" | "net" | "sim" | "camera" | "input", event: string, data?: unknown) => void;
+type Forwarder = (
+  scope: "scene" | "net" | "sim" | "camera" | "input",
+  event: string,
+  data?: unknown,
+) => void;
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/worker/src/debug/logger.ts
+++ b/worker/src/debug/logger.ts
@@ -33,7 +33,7 @@ function formatCtx(ctx?: LogContext): string {
   const parts: string[] = [];
   if (ctx.room !== undefined && ctx.room !== "") parts.push(`room=${ctx.room}`);
   if (ctx.turn !== undefined) parts.push(`turn=${ctx.turn}`);
-  return parts.length > 0 ? " " + parts.join(" ") : "";
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
 }
 
 export function dlog(scope: ServerScope, event: string, ctx?: LogContext, data?: unknown): void {
@@ -44,13 +44,18 @@ export function dlog(scope: ServerScope, event: string, ctx?: LogContext, data?:
   lastEmit.set(key, now);
   pruneIfNeeded();
   const prefix = `[${scope}] ${event}${formatCtx(ctx)}`;
-  if (data !== undefined) console.log(prefix + " |", data);
+  if (data !== undefined) console.log(`${prefix} |`, data);
   else console.log(prefix);
 }
 
-export function dlogUnthrottled(scope: ServerScope, event: string, ctx?: LogContext, data?: unknown): void {
+export function dlogUnthrottled(
+  scope: ServerScope,
+  event: string,
+  ctx?: LogContext,
+  data?: unknown,
+): void {
   if (!DEBUG) return;
   const prefix = `[${scope}] ${event}${formatCtx(ctx)}`;
-  if (data !== undefined) console.log(prefix + " |", data);
+  if (data !== undefined) console.log(`${prefix} |`, data);
   else console.log(prefix);
 }

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -25,7 +25,7 @@ import {
   unpackMask,
 } from "../../shared/maskPack.js";
 
-import { dlog, type LogContext } from "./debug/logger.js";
+import { type LogContext, dlog } from "./debug/logger.js";
 import {
   ALLOWED_COLORS,
   type LobbyPlayer,
@@ -436,7 +436,11 @@ export class Room implements DurableObject {
     const player = lobby.players[attachment.sessionId];
     if (!player) return;
 
-    dlog("room", "webSocketMessage", this.logCtx(), { type, sid: attachment.sessionId, phase: lobby.phase });
+    dlog("room", "webSocketMessage", this.logCtx(), {
+      type,
+      sid: attachment.sessionId,
+      phase: lobby.phase,
+    });
 
     switch (type) {
       case "set_nickname":
@@ -731,7 +735,10 @@ export class Room implements DurableObject {
    */
   private async onReturnToLobby(ws: WebSocket, player: LobbyPlayer): Promise<void> {
     const lobby = this.ensureLobby();
-    dlog("room", "onReturnToLobby entry", this.logCtx(), { sid: player.sessionId ?? "?", phase: lobby.phase });
+    dlog("room", "onReturnToLobby entry", this.logCtx(), {
+      sid: player.sessionId ?? "?",
+      phase: lobby.phase,
+    });
     if (!player.isHost) {
       this.sendError(ws, "not_host", "Only the host may return to the lobby.");
       return;

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -22,7 +22,7 @@
  */
 
 import type { Contact, ContactImpulse } from "planck";
-import { dlog, type LogContext } from "../debug/logger.js";
+import { type LogContext, dlog } from "../debug/logger.js";
 import {
   Projectile,
   type ProjectileRenderState,
@@ -735,7 +735,11 @@ export class Simulation {
     if (proj.detonated) return;
     proj.markDetonated();
     const pos = proj.body.getPosition();
-    dlog("sim", "detonate", this.getLogCtx(), { weaponId: proj.config.id, x: toPixels(pos.x), y: toPixels(pos.y) });
+    dlog("sim", "detonate", this.getLogCtx(), {
+      weaponId: proj.config.id,
+      x: toPixels(pos.x),
+      y: toPixels(pos.y),
+    });
     const centerPx = { x: toPixels(pos.x), y: toPixels(pos.y) };
     const result = explode({
       world: this.world,

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -17,8 +17,8 @@
  *   - persistence for DO hibernation recovery
  */
 
+import { type LogContext, dlog } from "./debug/logger.js";
 import type { LobbyState } from "./messages.js";
-import { dlog, type LogContext } from "./debug/logger.js";
 
 /** Shared timing constants. */
 export const TURN_DURATION_MS = 45_000;
@@ -157,7 +157,10 @@ export class TurnArbiter {
     this.room.state.currentWormId = this.pickNextWormInTeam(firstTeamId);
     this.room.state.turnSeq = 1;
     this.room.state.turnEndsAt = Date.now() + turnDurationMs;
-    dlog("turn", "start", this.logCtx(), { turnDurationMs, turnEndsAt: this.room.state.turnEndsAt });
+    dlog("turn", "start", this.logCtx(), {
+      turnDurationMs,
+      turnEndsAt: this.room.state.turnEndsAt,
+    });
     this.fireTurnStart();
   }
 
@@ -408,7 +411,11 @@ export class TurnArbiter {
     this.room.state.turnSeq += 1;
     this.room.state.turnEndsAt = Date.now() + this.turnDurationMs;
     this.pausedRemainingMs = null;
-    dlog("turn", "advance_reset_timer", this.logCtx(), { now: Date.now(), turnEndsAt: this.room.state.turnEndsAt, turnDurationMs: this.turnDurationMs });
+    dlog("turn", "advance_reset_timer", this.logCtx(), {
+      now: Date.now(),
+      turnEndsAt: this.room.state.turnEndsAt,
+      turnDurationMs: this.turnDurationMs,
+    });
     dlog("turn", "advance", this.logCtx(), { fromTeam, toTeam: nextTeamId });
     this.fireTurnStart();
   }

--- a/worker/test/clientLog.test.ts
+++ b/worker/test/clientLog.test.ts
@@ -80,35 +80,23 @@ describe("clientLog processing", () => {
       Date.now(),
     );
     expect(result).not.toBeNull();
-    expect(result!.event).toBe("test");
-    expect(result!.data.clientScope).toBe("sim");
-    expect(result!.data.sid).toBe("abc12345");
-    expect(result!.data.x).toBe(1);
+    expect(result?.event).toBe("test");
+    expect(result?.data.clientScope).toBe("sim");
+    expect(result?.data.sid).toBe("abc12345");
+    expect(result?.data.x).toBe(1);
   });
 
   it("non-string scope returns null (silent drop)", () => {
     const budget = new Map<symbol, BudgetEntry>();
     const key = Symbol("ws");
-    const result = processClientLog(
-      { scope: 42, event: "test" },
-      "abc",
-      budget,
-      key,
-      Date.now(),
-    );
+    const result = processClientLog({ scope: 42, event: "test" }, "abc", budget, key, Date.now());
     expect(result).toBeNull();
   });
 
   it("non-string event returns null (silent drop)", () => {
     const budget = new Map<symbol, BudgetEntry>();
     const key = Symbol("ws");
-    const result = processClientLog(
-      { scope: "sim", event: null },
-      "abc",
-      budget,
-      key,
-      Date.now(),
-    );
+    const result = processClientLog({ scope: "sim", event: null }, "abc", budget, key, Date.now());
     expect(result).toBeNull();
   });
 
@@ -125,8 +113,8 @@ describe("clientLog processing", () => {
       Date.now(),
     );
     expect(result).not.toBeNull();
-    expect(result!.data.clientScope).toHaveLength(16);
-    expect(result!.event).toHaveLength(64);
+    expect(result?.data.clientScope).toHaveLength(16);
+    expect(result?.event).toHaveLength(64);
   });
 
   it("spread-first protection: trusted fields (sid, clientScope) overwrite client data", () => {
@@ -141,10 +129,10 @@ describe("clientLog processing", () => {
     );
     expect(result).not.toBeNull();
     // sid and clientScope should come from trusted fields, NOT from client data
-    expect(result!.data.sid).toBe("trustedS"); // first 8 chars of "trustedSid"
-    expect(result!.data.clientScope).toBe("sim");
-    expect(result!.data.sid).not.toBe("evil");
-    expect(result!.data.clientScope).not.toBe("evil");
+    expect(result?.data.sid).toBe("trustedS"); // first 8 chars of "trustedSid"
+    expect(result?.data.clientScope).toBe("sim");
+    expect(result?.data.sid).not.toBe("evil");
+    expect(result?.data.clientScope).not.toBe("evil");
   });
 
   it("rate limits: 35 calls in same second -> only 30 emit", () => {
@@ -199,37 +187,25 @@ describe("clientLog processing", () => {
     );
     expect(result).not.toBeNull();
     // Numeric keys from array spread must NOT appear
-    expect(result!.data[0]).toBeUndefined();
-    expect(result!.data[1]).toBeUndefined();
-    expect(result!.data[2]).toBeUndefined();
+    expect(result?.data[0]).toBeUndefined();
+    expect(result?.data[1]).toBeUndefined();
+    expect(result?.data[2]).toBeUndefined();
     // Only trusted fields should be present
-    expect(result!.data.clientScope).toBe("sim");
-    expect(result!.data.sid).toBe("abc12345");
+    expect(result?.data.clientScope).toBe("sim");
+    expect(result?.data.sid).toBe("abc12345");
   });
 
   it("empty scope returns null (silent drop)", () => {
     const budget = new Map<symbol, BudgetEntry>();
     const key = Symbol("ws");
-    const result = processClientLog(
-      { scope: "", event: "test" },
-      "abc",
-      budget,
-      key,
-      Date.now(),
-    );
+    const result = processClientLog({ scope: "", event: "test" }, "abc", budget, key, Date.now());
     expect(result).toBeNull();
   });
 
   it("empty event returns null (silent drop)", () => {
     const budget = new Map<symbol, BudgetEntry>();
     const key = Symbol("ws");
-    const result = processClientLog(
-      { scope: "sim", event: "" },
-      "abc",
-      budget,
-      key,
-      Date.now(),
-    );
+    const result = processClientLog({ scope: "sim", event: "" }, "abc", budget, key, Date.now());
     expect(result).toBeNull();
   });
 });

--- a/worker/test/fireHitscan.test.ts
+++ b/worker/test/fireHitscan.test.ts
@@ -13,15 +13,16 @@
  */
 
 import { World } from "planck";
+import type { Fixture } from "planck";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fire } from "../src/weapons/fire.js";
-import type { FireContext } from "../src/weapons/fire.js";
 import type { Terrain } from "../src/entities/terrain.js";
 import type { Worm } from "../src/entities/worm.js";
 import { toMeters } from "../src/physics/scale.js";
-import { shotgun } from "../src/weapons/shotgun.js";
-import { minigun } from "../src/weapons/minigun.js";
 import { bazooka } from "../src/weapons/bazooka.js";
+import { fire } from "../src/weapons/fire.js";
+import type { FireContext } from "../src/weapons/fire.js";
+import { minigun } from "../src/weapons/minigun.js";
+import { shotgun } from "../src/weapons/shotgun.js";
 
 // ---- Minimal stubs ----
 
@@ -32,14 +33,22 @@ function makeAlwaysHitWorld(): World {
   // The stub fixture only needs getBody() returning null (not firer.body) so the
   // server-side raycastFirstHit() accepts the hit. We escape type-checking here
   // because we're only testing loop count, not planck fixture internals.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (world as any).rayCast = (
+  (world as unknown as Pick<World, "rayCast">).rayCast = (
     _from: unknown,
     _to: unknown,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (fixture: any, point: { x: number; y: number }, normal: { x: number; y: number }, fraction: number) => number,
+    callback: (
+      fixture: Fixture,
+      point: { x: number; y: number },
+      normal: { x: number; y: number },
+      fraction: number,
+    ) => number,
   ) => {
-    callback({ getBody: () => null }, { x: toMeters(100), y: toMeters(100) }, { x: -1, y: 0 }, 0.5);
+    callback(
+      { getBody: () => null } as unknown as Fixture,
+      { x: toMeters(100), y: toMeters(100) },
+      { x: -1, y: 0 },
+      0.5,
+    );
   };
   return world;
 }
@@ -48,12 +57,15 @@ function makeAlwaysHitWorld(): World {
 function makeNeverHitWorld(): World {
   const world = new World();
   // Override rayCast to never call the callback; simulates no surface intersection.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (world as any).rayCast = (
+  (world as unknown as Pick<World, "rayCast">).rayCast = (
     _from: unknown,
     _to: unknown,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    _callback: (fixture: any, point: { x: number; y: number }, normal: { x: number; y: number }, fraction: number) => number,
+    _callback: (
+      fixture: Fixture,
+      point: { x: number; y: number },
+      normal: { x: number; y: number },
+      fraction: number,
+    ) => number,
   ) => {
     // No callback invocation; rayCast returns with no hits found.
   };

--- a/worker/test/global-setup.ts
+++ b/worker/test/global-setup.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile, access } from "node:fs/promises";
-import { join, dirname } from "node:path";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));

--- a/worker/test/integration/lobby-cycle.test.ts
+++ b/worker/test/integration/lobby-cycle.test.ts
@@ -84,10 +84,7 @@ class TestClient {
   waitFor(match: (msg: Message) => boolean, timeoutMs = 8000): Promise<Message> {
     for (const m of this.messages) if (match(m)) return Promise.resolve(m);
     return new Promise<Message>((resolve, reject) => {
-      const t = setTimeout(
-        () => reject(new Error("timeout waiting for message")),
-        timeoutMs,
-      );
+      const t = setTimeout(() => reject(new Error("timeout waiting for message")), timeoutMs);
       this.waiters.push({
         match,
         resolve: (m) => {
@@ -113,10 +110,7 @@ class TestClient {
       if (m && match(m)) return Promise.resolve(m);
     }
     return new Promise<Message>((resolve, reject) => {
-      const t = setTimeout(
-        () => reject(new Error("timeout waiting for message")),
-        timeoutMs,
-      );
+      const t = setTimeout(() => reject(new Error("timeout waiting for message")), timeoutMs);
       // The waiter fires on every new message pushed to this.messages.
       // We compare this.messages.length at push time against fromIndex
       // to reject messages that arrived before the bookmark.
@@ -167,11 +161,7 @@ async function createRoom(): Promise<string> {
   return body.code as string;
 }
 
-async function joinRoom(
-  code: string,
-  nickname: string,
-  color: string,
-): Promise<TestClient> {
+async function joinRoom(code: string, nickname: string, color: string): Promise<TestClient> {
   const params = new URLSearchParams({ nickname, color });
   const ws = new WebSocket(`${baseWs}/api/room/${code}?${params.toString()}`);
   const client = new TestClient(ws);
@@ -191,13 +181,8 @@ function bothReadyAfter(
     fromIndex,
     (m) => {
       if (m.type !== "state") return false;
-      const players = (
-        m.state as { players: Record<string, { ready: boolean }> }
-      ).players;
-      return (
-        players[aliceSessionId]?.ready === true &&
-        players[bobSessionId]?.ready === true
-      );
+      const players = (m.state as { players: Record<string, { ready: boolean }> }).players;
+      return players[aliceSessionId]?.ready === true && players[bobSessionId]?.ready === true;
     },
     8000,
   );
@@ -216,27 +201,23 @@ describe("lobby-cycle integration (#117 regression)", () => {
 
       // ---- 2. Connect Alice (host) and Bob ----
       const alice = await joinRoom(code, "Alice", "#ff4444");
-      const aliceWelcome = (await alice.waitFor(
-        (m) => m.type === "welcome",
-      )) as unknown as {
+      const aliceWelcome = (await alice.waitFor((m) => m.type === "welcome")) as unknown as {
         sessionId: string;
         resumeToken: string;
       };
       const aliceSessionId = aliceWelcome.sessionId;
 
       const bob = await joinRoom(code, "Bob", "#4488ff");
-      const bobWelcome = (await bob.waitFor(
-        (m) => m.type === "welcome",
-      )) as unknown as { sessionId: string };
+      const bobWelcome = (await bob.waitFor((m) => m.type === "welcome")) as unknown as {
+        sessionId: string;
+      };
       const bobSessionId = bobWelcome.sessionId;
 
       // Wait for Alice to see Bob in the lobby (2-player state).
       await alice.waitFor(
         (m) =>
           m.type === "state" &&
-          Object.keys(
-            (m.state as { players: Record<string, unknown> }).players,
-          ).length === 2,
+          Object.keys((m.state as { players: Record<string, unknown> }).players).length === 2,
       );
 
       // ---- 3. Both set ready for game 1 ----
@@ -251,15 +232,12 @@ describe("lobby-cycle integration (#117 regression)", () => {
 
       // Wait for the "playing" state to arrive so we know the turn timer is live.
       const playingState1 = await alice.waitFor(
-        (m) =>
-          m.type === "state" &&
-          (m.state as { phase: string }).phase === "playing",
+        (m) => m.type === "state" && (m.state as { phase: string }).phase === "playing",
         10_000,
       );
 
       // Capture the game-1 turnEndsAt for the later assertion.
-      const turnEndsAt1 = (playingState1.state as { turnEndsAt: number })
-        .turnEndsAt;
+      const turnEndsAt1 = (playingState1.state as { turnEndsAt: number }).turnEndsAt;
 
       // ---- 5. Host sends input_return_to_lobby ----
       // We skip the optional fire step to avoid racing the 45s timer.
@@ -277,16 +255,12 @@ describe("lobby-cycle integration (#117 regression)", () => {
       // ---- 6. Both wait for lobby phase (after game 1 ended) ----
       await alice.waitForAfter(
         bookmarkAfterGame1,
-        (m) =>
-          m.type === "state" &&
-          (m.state as { phase: string }).phase === "lobby",
+        (m) => m.type === "state" && (m.state as { phase: string }).phase === "lobby",
         10_000,
       );
       await bob.waitForAfter(
         bookmarkAfterGame1Bob,
-        (m) =>
-          m.type === "state" &&
-          (m.state as { phase: string }).phase === "lobby",
+        (m) => m.type === "state" && (m.state as { phase: string }).phase === "lobby",
         10_000,
       );
 
@@ -300,27 +274,18 @@ describe("lobby-cycle integration (#117 regression)", () => {
       // Bookmark the message cursor so waitForAfter skips game-1 messages.
       const bookmarkBeforeGame2 = alice.messageCount;
       alice.send({ type: "start_game" });
-      await alice.waitForAfter(
-        bookmarkBeforeGame2,
-        (m) => m.type === "game_started",
-        10_000,
-      );
+      await alice.waitForAfter(bookmarkBeforeGame2, (m) => m.type === "game_started", 10_000);
 
       // Wait for the "playing" state carrying fresh turn info.
       // Use waitForAfter so we don't re-match game-1's playing state.
       const playingState2 = await alice.waitForAfter(
         bookmarkBeforeGame2,
-        (m) =>
-          m.type === "state" &&
-          (m.state as { phase: string }).phase === "playing",
+        (m) => m.type === "state" && (m.state as { phase: string }).phase === "playing",
         10_000,
       );
 
-      const turnEndsAt2 = (playingState2.state as { turnEndsAt: number })
-        .turnEndsAt;
-      const currentTeamId2 = (
-        playingState2.state as { currentTeamId: string }
-      ).currentTeamId;
+      const turnEndsAt2 = (playingState2.state as { turnEndsAt: number }).turnEndsAt;
+      const currentTeamId2 = (playingState2.state as { currentTeamId: string }).currentTeamId;
 
       // ---- 9. Assertions ----
 
@@ -336,15 +301,12 @@ describe("lobby-cycle integration (#117 regression)", () => {
       await new Promise((r) => setTimeout(r, 1500));
 
       // Collect any state messages that arrived during the wait.
-      const latestState = alice.messages
-        .filter((m) => m.type === "state")
-        .at(-1);
+      const latestState = alice.messages.filter((m) => m.type === "state").at(-1);
       if (latestState) {
         const phase = (latestState.state as { phase: string }).phase;
         if (phase === "playing") {
-          const currentTeamIdAfterWait = (
-            latestState.state as { currentTeamId: string }
-          ).currentTeamId;
+          const currentTeamIdAfterWait = (latestState.state as { currentTeamId: string })
+            .currentTeamId;
           expect(currentTeamIdAfterWait).toBe(currentTeamId2);
         }
         // If phase changed to something else that would be unexpected, but


### PR DESCRIPTION
## Summary

Master CI has been failing on lint since at least 2026-04-24. PRs #123 (multi-shot) and #116 (logger) added violations that biome rejects: useTemplate, noNonNullAssertion in test mocks, noExplicitAny, organizeImports. Auto-merge with \`gh pr merge --auto\` doesn't actually wait for checks unless branch protection requires them, so several PRs have landed red since then.

PR #130 (the worker-test CI step) merged before its own CI run finished, exposing the issue. This PR clears the lint backlog so CI is green again, after which the \`build\` status check can be enforced via branch protection.

## Changes

12 files: mostly biome --write auto-fixes (formatter wraps long lines, organizeImports, useTemplate replacements). Two manual edits in \`worker/test/fireHitscan.test.ts\` to replace test-stub \`any\` with \`Pick<World, "rayCast">\` and \`Fixture\` from planck.

No behavior changes. All 277 client tests + 94 worker tests still pass.

## Verification

- \`npm run lint\` clean (was: 35+ errors)
- \`npm run typecheck\` clean
- \`npm run build\` succeeds
- \`npm test\` 277 pass
- \`cd worker && npm test\` 94 pass

## Followup

Once this lands and master has a green CI run, GitHub's branch protection dropdown will populate \`build\` as a required check, locking out future red merges.