### PR TITLE
fix(117): instrument scene/ws lifecycle, server-driven debug flag

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -239,7 +239,13 @@ export interface WormDiedEvent {
 // ---------------------------------------------------------------------------
 
 export type ServerMsg =
-  | { type: "welcome"; sessionId: string; resumeToken: string; state: LobbyState }
+  | {
+      type: "welcome";
+      sessionId: string;
+      resumeToken: string;
+      state: LobbyState;
+      debugLogEnabled: boolean;
+    }
   | { type: "state"; state: LobbyState }
   | {
       type: "game_started";

--- a/src/net/wsClient.test.ts
+++ b/src/net/wsClient.test.ts
@@ -132,6 +132,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
 
     const room = await p;
@@ -151,6 +152,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     await p;
     expect(MockWebSocket.lastUrl).toContain("ws://example.test/api/room/WAVE");
@@ -178,6 +180,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState({ selectedMapId: "flat" }),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -201,6 +204,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -236,6 +240,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -258,6 +263,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -278,6 +284,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -296,6 +303,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -321,6 +329,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     await p1;
 
@@ -359,6 +368,7 @@ describe("joinRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 
@@ -400,6 +410,7 @@ describe("createRoom", () => {
       sessionId: "sid-1",
       resumeToken: "resume-abc",
       state: baselineState(),
+      debugLogEnabled: false,
     });
     const room = await p;
 

--- a/src/net/wsClient.ts
+++ b/src/net/wsClient.ts
@@ -29,10 +29,12 @@
 import type { ClientMsg, LobbyState, ServerMsg } from "../../shared/protocol";
 import {
   dlog,
+  dlogUnthrottled,
   getLogForwarder,
   isLoggerEnabled,
   setLogContext,
   setLogForwarder,
+  setLoggerEnabled,
 } from "../debug/logger";
 
 type Forwarder = (
@@ -132,6 +134,7 @@ export async function joinRoom(
   qs.set("color", color);
   if (resumeToken) qs.set("resumeToken", resumeToken);
   const url = `${ws}/api/room/${encodeURIComponent(code.toUpperCase())}?${qs.toString()}`;
+  dlogUnthrottled("net", "joinRoom", { code, hasResumeToken: !!resumeToken });
 
   const socket = new WebSocket(url);
 
@@ -148,6 +151,7 @@ export async function joinRoom(
   let resumeTokenOut = "";
 
   const dispatchMessage = (msg: ServerMsg): void => {
+    dlog("net", "dispatch", { type: msg.type, count: messageSubs.get(msg.type)?.size ?? 0 });
     const subs = messageSubs.get(msg.type);
     if (!subs) return;
     for (const cb of subs) {
@@ -162,6 +166,7 @@ export async function joinRoom(
 
   const dispatchStateChange = (): void => {
     if (!currentState) return;
+    dlog("net", "stateChange", { count: stateSubs.size, phase: currentState?.phase });
     dlog("net", "state received", {
       phase: currentState?.phase,
       playerCount: currentState ? Object.keys(currentState.players).length : 0,
@@ -193,6 +198,7 @@ export async function joinRoom(
     socket.addEventListener("open", () => {
       // WebSocket-level open isn't enough: we wait for the `welcome`
       // application-layer message before surfacing a usable handle.
+      dlogUnthrottled("net", "ws_open", { code: currentState?.code ?? "?" });
       if (isLoggerEnabled()) {
         const mySocket = socket;
         const fn: Forwarder = (scope, event, data) => {
@@ -219,6 +225,24 @@ export async function joinRoom(
         resumeTokenOut = msg.resumeToken;
         currentState = msg.state;
         setLogContext({ room: currentState.code || code.toUpperCase() });
+        // Server-controlled debug flag: OR with local ?debug=1 so either path
+        // enables the logger. Never disable if URL param is already set.
+        if (msg.debugLogEnabled) {
+          setLoggerEnabled(true);
+          // Wire the log forwarder now that the logger is enabled. The open
+          // handler only wires it when the logger was already enabled at
+          // open-time (URL ?debug=1), so we replicate the setup here for the
+          // server-flag path.
+          const mySocket = socket;
+          const fn: Forwarder = (scope, event, data) => {
+            if (mySocket.readyState !== WebSocket.OPEN) return;
+            mySocket.send(
+              JSON.stringify({ type: "client_log", scope, event, data, ts: Date.now() }),
+            );
+          };
+          (fn as unknown as Record<string, unknown>)._socket = mySocket;
+          setLogForwarder(fn);
+        }
         settleOk();
         // Welcome ALSO fires onStateChange so callers get a single code
         // path for "state arrived" regardless of first vs subsequent.
@@ -243,6 +267,7 @@ export async function joinRoom(
     });
 
     socket.addEventListener("close", (ev: CloseEvent) => {
+      dlogUnthrottled("net", "ws_close", { code: ev.code });
       settleErr(new Error(`WebSocket closed before welcome (code ${ev.code})`));
       const cur = getLogForwarder();
       const isOurSocket = cur && (cur as unknown as Record<string, unknown>)._socket === socket;
@@ -316,6 +341,7 @@ export async function joinRoom(
       }
       const wrapped = cb as (msg: ServerMsg) => void;
       set.add(wrapped);
+      dlog("net", "subscribe", { type, count: set.size });
       return () => {
         set?.delete(wrapped);
       };

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -253,7 +253,7 @@ export class GameScene extends Phaser.Scene {
     // on SHUTDOWN to tear down adapter + unsubs.
     // ------------------------------------------------------------------
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      dlogUnthrottled("scene", "GameScene.shutdown");
+      dlogUnthrottled("scene", "GameScene.shutdown", { unsubCount: this.roomUnsubs.length });
       // Tear down room listeners FIRST so a throw in any of the downstream
       // destroys can't leave an active onStateChange listener that keeps
       // firing (and attempting scene.start) after we've moved on.
@@ -819,6 +819,7 @@ export class GameScene extends Phaser.Scene {
     // freeze on rematch-ready.
     let phaseSub: (() => void) | null = null;
     phaseSub = this.room.onStateChange((state) => {
+      dlogUnthrottled("scene", "GameScene.phaseObserved", { phase: state.phase });
       if (state.phase !== "lobby") return;
       dlogUnthrottled("scene", "GameScene.phaseSub fired", { phase: state.phase });
       phaseSub?.();

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -818,8 +818,15 @@ export class GameScene extends Phaser.Scene {
     // the transition is async and state keeps flowing. That produced a
     // freeze on rematch-ready.
     let phaseSub: (() => void) | null = null;
+    let lastObservedPhase: string | undefined;
     phaseSub = this.room.onStateChange((state) => {
-      dlogUnthrottled("scene", "GameScene.phaseObserved", { phase: state.phase });
+      if (state.phase !== lastObservedPhase) {
+        dlogUnthrottled("scene", "GameScene.phaseObserved", {
+          phase: state.phase,
+          prev: lastObservedPhase ?? null,
+        });
+        lastObservedPhase = state.phase;
+      }
       if (state.phase !== "lobby") return;
       dlogUnthrottled("scene", "GameScene.phaseSub fired", { phase: state.phase });
       phaseSub?.();

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -92,6 +92,9 @@ const INPUT_CSS =
  * and rebuild (original fix for #56 - Ready button click-through).
  */
 export class LobbyScene extends Phaser.Scene {
+  private static instanceCount = 0;
+  private readonly instanceId = LobbyScene.instanceCount++;
+
   private netClient!: NetClient;
   private autoJoinCode: string | null = null;
 
@@ -158,7 +161,10 @@ export class LobbyScene extends Phaser.Scene {
       hasPendingRoom: this.pendingReconnectedRoom !== null,
     });
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      dlogUnthrottled("scene", "LobbyScene.shutdown", { unsubCount: this.roomUnsubs.length });
+      dlogUnthrottled("scene", "LobbyScene.shutdown", {
+        instanceId: this.instanceId,
+        unsubCount: this.roomUnsubs.length,
+      });
       this.tearDownRoomListeners();
     });
 
@@ -378,6 +384,21 @@ export class LobbyScene extends Phaser.Scene {
     this.room = room;
     this.currentRoomCode = room.state?.code ?? room.code ?? "";
     this.wireRoomListeners(room);
+    dlogUnthrottled("scene", "LobbyScene.wired", {
+      unsubCount: this.roomUnsubs.length,
+      phase: room.state?.phase,
+    });
+
+    // Backstop: if we re-entered the lobby but the server already says we're
+    // in 'playing' phase, the game_started broadcast may have been missed
+    // (race during scene transition or stale state). Log only for now - if
+    // the next playtest shows this firing, we'll know this is the failing
+    // path and add a re-request mechanism in the next PR.
+    const currentPhase = room.state?.phase;
+    if (currentPhase === "playing") {
+      dlogUnthrottled("scene", "LobbyScene.backstop_to_game", { reason: "phase_already_playing" });
+    }
+
     this.view = "room";
     this.clearHome();
     // Hide any overlay left behind from a previous reconnect attempt.
@@ -459,7 +480,10 @@ export class LobbyScene extends Phaser.Scene {
 
     this.roomUnsubs.push(
       room.onMessage("game_started", (msg: GameStartedMessage) => {
-        dlogUnthrottled("scene", "LobbyScene.gameStarted", { mapId: msg.mapId });
+        dlogUnthrottled("scene", "LobbyScene.gameStarted", {
+          mapId: msg.mapId,
+          phase: room.state?.phase,
+        });
         // Host clicked Start. Server includes the authoritative mask +
         // spawn points so every client renders pixel-identical terrain
         // (server's physics and client's visuals match).

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -140,7 +140,6 @@ export class Room implements DurableObject {
   constructor(state: DurableObjectState, env: unknown) {
     this.state = state;
     this.env = env;
-    void this.env;
   }
 
   private logCtx(): LogContext {
@@ -384,11 +383,13 @@ export class Room implements DurableObject {
 
     await this.persistLobby();
 
+    const debugLogEnabled = ((this.env as Record<string, unknown>).DEBUG_LOG ?? "1") === "1";
     const welcome: ServerMsg = {
       type: "welcome",
       sessionId: attachment.sessionId,
       resumeToken: attachment.resumeToken,
       state: this.ensureLobby(),
+      debugLogEnabled,
     };
     try {
       server.send(JSON.stringify(welcome));

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -9,6 +9,7 @@ routes = [
 
 [vars]
 PATH_PREFIX = "/worms"
+DEBUG_LOG = "1"
 
 [assets]
 directory = "../dist"


### PR DESCRIPTION
## Summary

Instrumentation + observability investment for #117 (lobby freeze on game 2). Two prior PRs (#120, #124) shipped guesses without confirming root cause; both didn't fix it. This PR pivots to "look before fix" with three layered changes.

### 1. Server-controlled debug toggle (always-on by default)

\`worker/wrangler.toml\` adds \`DEBUG_LOG = "1"\`. The Room DO reads this and adds \`debugLogEnabled\` to the welcome message. The client respects the server flag and enables the debug logger on welcome - no \`?debug=1\` URL param needed for normal playtest. URL param still works as a per-tab override (logical OR). To disable later: flip \`DEBUG_LOG="0"\` in wrangler.toml + redeploy.

### 2. Client-side diagnostics

Strategic dlog calls across:
- \`src/net/wsClient.ts\` - subscribe (per onMessage), dispatch (per server message), stateChange (per state broadcast), ws_open / ws_close, joinRoom invocation
- \`src/scenes/LobbyScene.ts\` - per-instance counter for cross-cycle tracing, post-wireRoomListeners log with unsub count, room.state.phase included in game_started handler
- \`src/scenes/GameScene.ts\` - phase-transition log (only fires when phase actually changes; bugcheck-fixed during this PR)

### 3. Defensive backstop log

In \`LobbyScene.onRoomJoined\`, log a warning if the room arrives with \`state.phase === "playing"\`. Log-only, no behavior change. If this fires on the next playtest's repro, we know one specific failure mode (missed game_started during scene transition race) is the cause.

## What this does NOT do

This PR does NOT close #117. It buys observability for the next playtest. The plan is:
1. Ship + redeploy
2. User reproduces the freeze (debug logging now always-on)
3. Pull logs from brain EC2, identify which dispatch/subscribe/phase log is missing or out of order
4. Targeted fix + integration test in the next PR

## Bug Check

VERDICT: CLEAN after fix.

One HIGH caught and fixed pre-merge: \`GameScene.phaseObserved\` was placed before the early-return on non-lobby phases, firing on every 20Hz state broadcast and saturating the 20/sec scene-scope forwarder budget. Fixed by tracking \`lastObservedPhase\` and logging only on transitions.

Other findings: LOW on welcome contract backward-compat (falsy access is safe), LOW on env var cast (correct given Cloudflare's typing limitations), MEDIUM on log volume (bounded by existing 20/sec scope budgets, won't overwhelm brain disk on 7-day rotation). NO ISSUE on subscribe/dispatch/stateChange spam (scope=net is excluded from forwarder), backstop side-effects (log-only, existing reconnect guard still runs), test fixture semantics, double-forwarder risk, URL param interaction, welcome timing.

## Test plan

- [x] tsc clean, lint clean, build clean
- [x] 277 client tests + 94 worker tests pass
- [ ] Deploy + replay #117. Watch the brain EC2 logs for the first time the freeze happens with full client-side telemetry.
- [ ] Look for: was \`game_started\` dispatch logged on the affected client? Was a fresh LobbyScene listener wired before that dispatch? Did the backstop log fire (phase already playing)?

Related to #117 (does NOT close it).