### PR TITLE
fix(117): TerrainRenderer addCanvas fails on game 2 - remove before add

### DIFF
--- a/src/terrain/Terrain.ts
+++ b/src/terrain/Terrain.ts
@@ -68,7 +68,12 @@ export class Terrain {
     // regardless of whether the generator painted its own RGB.
     applyStratumPaint(this.ctx, this.widthPx, this.heightPx);
 
-    // Register canvas with Phaser TextureManager
+    // Register canvas with Phaser TextureManager. A previous Terrain
+    // instance in the same scene session leaves its texture registered;
+    // addCanvas returns null on duplicate keys, so remove first.
+    if (this.scene.textures.exists(this.textureKey)) {
+      this.scene.textures.remove(this.textureKey);
+    }
     const canvasTexture = this.scene.textures.addCanvas(this.textureKey, this.buffer);
     if (!canvasTexture) throw new Error(`Terrain: addCanvas failed for key "${this.textureKey}"`);
     this.canvasTexture = canvasTexture;

--- a/src/terrain/TerrainRenderer.ts
+++ b/src/terrain/TerrainRenderer.ts
@@ -51,6 +51,13 @@ export class TerrainRenderer {
 
     applyStratumPaint(this.ctx, this.widthPx, this.heightPx);
 
+    // A previous TerrainRenderer instance in the same scene session (e.g.
+    // game 1 -> return to lobby -> game 2) leaves its canvas texture
+    // registered in Phaser's TextureManager. addCanvas returns null on
+    // duplicate keys, so remove any stale registration first.
+    if (init.scene.textures.exists(this.textureKey)) {
+      init.scene.textures.remove(this.textureKey);
+    }
     const canvasTexture = init.scene.textures.addCanvas(this.textureKey, this.buffer);
     if (!canvasTexture) {
       throw new Error(`TerrainRenderer: addCanvas failed for key "${this.textureKey}"`);


### PR DESCRIPTION
## Summary

Closes #117. Diagnostic logs from PR #145 (which shipped instrumentation, not a fix) gave us the smoking gun on the next playtest:

\`\`\`
[client] create.error room=TAML turn=1 | {
  step: 'exception',
  name: 'Error',
  msg: 'TerrainRenderer: addCanvas failed for key "terrain"',
  stack: 'Vd@.../index-CBePdAWZ.js:6384:41128
          create@.../index-CBePdAWZ.js:6384:66650 (TerrainRenderer ctor)
          create@.../index-CBePdAWZ.js:5021:3583 (GameScene.create)
          ...'
}
\`\`\`

Both clients hit this on game 2, which is exactly why neither could transition out of the lobby UI: the GameScene.create exception aborted before NetworkedSimAdapter could be constructed and wire WebSocket subs. Server saw 2 sockets, no inputs, auto-advanced turns alone.

## Root cause

Phaser's \`scene.textures.addCanvas(key, canvas)\` returns \`null\` if a texture with that key already exists. \`TerrainRenderer.destroy()\` deliberately left the registration in place, with this comment:

\`\`\`ts
// canvasTexture is owned by Phaser's TextureManager; leaving it
// registered lets the scene restart reuse the key without churn.
\`\`\`

But the next \`TerrainRenderer\` constructor builds a fresh \`HTMLCanvasElement\` and tries to \`addCanvas\` with the same key. Phaser refuses the duplicate, returns null, the constructor throws \`TerrainRenderer: addCanvas failed for key "terrain"\`. The "reuse without churn" plan never worked because nothing actually reuses the registration.

Same bug pattern in \`src/terrain/Terrain.ts\` (offline-mode equivalent at line 72). Fixed for symmetry.

## Fix

In both constructors, before \`addCanvas\`, check \`textures.exists(key)\` and remove the stale registration. Buffer is always a fresh canvas in the constructor, so reusing the old registration was never going to work anyway.

\`\`\`ts
if (init.scene.textures.exists(this.textureKey)) {
  init.scene.textures.remove(this.textureKey);
}
const canvasTexture = init.scene.textures.addCanvas(this.textureKey, this.buffer);
\`\`\`

8 lines added across 2 files.

## Test coverage

Phaser scene construction is hard to unit-test (heavy DOM/canvas setup). Skipping a regression test for now - the integration harness from #127 is server-only and can't catch client-side Phaser texture lifecycle bugs. If we want client-side regression coverage long-term, the right fix is option #3 from the testing layers (headless Phaser via JSDOM + node-canvas), filed as a future ticket if scene bugs become recurring.

The diagnostic logs from #145 will catch any future similar bug class on the first repro - we now know to look for create.error events.

## Test plan

- [x] tsc clean, lint clean, build clean, all 277+94 tests pass
- [ ] Replay the #117 repro: host a game, end it, return to lobby, host start game 2 - both clients should transition to GameScene cleanly with the camera+sim wiring up, just like game 1

Closes #117