### PR TITLE
fix(camera): snap to projectile last position on despawn (#133)

### DIFF
--- a/src/ui/CameraFollower.test.ts
+++ b/src/ui/CameraFollower.test.ts
@@ -4,12 +4,16 @@ import { CameraFollower } from "./CameraFollower";
 
 function makeMocks() {
   const startFollowCalls: Array<{ target: object }> = [];
+  const centerOnCalls: Array<{ x: number; y: number }> = [];
 
   const camera = {
     startFollow: vi.fn((target: object) => {
       startFollowCalls.push({ target });
     }),
     stopFollow: vi.fn(),
+    centerOn: vi.fn((x: number, y: number) => {
+      centerOnCalls.push({ x, y });
+    }),
   };
 
   const scene = {
@@ -20,11 +24,11 @@ function makeMocks() {
     return new CameraFollower({ scene: scene as never, now });
   }
 
-  function makeGfx(label: string) {
-    return { __label: label } as unknown as import("phaser").GameObjects.GameObject;
+  function makeGfx(label: string, x = 0, y = 0) {
+    return { __label: label, x, y } as unknown as import("phaser").GameObjects.GameObject;
   }
 
-  return { scene, camera, startFollowCalls, makeFollower, makeGfx };
+  return { scene, camera, startFollowCalls, centerOnCalls, makeFollower, makeGfx };
 }
 
 const wormLerp = tuning.camera.wormLerp;
@@ -238,6 +242,30 @@ describe("CameraFollower", () => {
     follower.setSuspended(false);
     expect(camera.startFollow).toHaveBeenCalledTimes(1);
     expect(camera.startFollow).toHaveBeenCalledWith(worm, true, wormLerp, wormLerp);
+  });
+
+  it("snaps camera to last projectile position when projectile despawns", () => {
+    const { camera, centerOnCalls, makeFollower, makeGfx } = makeMocks();
+    const follower = makeFollower();
+    const worm = makeGfx("worm");
+
+    // First update: projectile at (1000, 600) - CameraFollower acquires it and caches position.
+    const projGfxA = makeGfx("proj", 1000, 600);
+    follower.setActiveWormTarget(worm);
+    follower.update([{ id: "p1", gfx: projGfxA }]);
+    expect(camera.startFollow).toHaveBeenCalledWith(projGfxA, true, projLerp, projLerp);
+    expect(camera.centerOn).not.toHaveBeenCalled();
+
+    // Second update: same projectile, moved to (1500, 800) - position cache updates.
+    const projGfxB = makeGfx("proj", 1500, 800);
+    follower.update([{ id: "p1", gfx: projGfxB }]);
+    expect(camera.centerOn).not.toHaveBeenCalled();
+
+    // Third update: projectile despawned - should stopFollow AND centerOn last cached position.
+    follower.update([]);
+    expect(camera.stopFollow).toHaveBeenCalledTimes(1);
+    expect(camera.centerOn).toHaveBeenCalledTimes(1);
+    expect(centerOnCalls[0]).toEqual({ x: 1500, y: 800 });
   });
 
   it("worm follow uses wormLerp, projectile follow uses projectileLerp", () => {

--- a/src/ui/CameraFollower.ts
+++ b/src/ui/CameraFollower.ts
@@ -30,6 +30,7 @@ export class CameraFollower {
   private followedProjectileId: string | null = null;
   private lingerUntilMs: number | null = null;
   private suspended = false; // set true while TurnTransition owns the camera
+  private lastFollowedPos: { x: number; y: number } | null = null;
 
   constructor(init: CameraFollowerInit) {
     this.scene = init.scene;
@@ -67,6 +68,7 @@ export class CameraFollower {
       // Drop our tracking; TurnTransition owns the camera now.
       this.followedProjectileId = null;
       this.lingerUntilMs = null;
+      this.lastFollowedPos = null;
     } else {
       // Resumed - return to active worm if we have one.
       if (this.activeWormTarget) {
@@ -104,13 +106,23 @@ export class CameraFollower {
 
     // Followed projectile just despawned - enter linger.
     if (this.followedProjectileId !== null) {
-      const stillExists = projectiles.some((p) => p.id === this.followedProjectileId);
-      if (!stillExists) {
-        this.scene.cameras.main.stopFollow();
-        this.lingerUntilMs = this.now() + tuning.camera.postImpactLingerMs;
+      const cur = projectiles.find((p) => p.id === this.followedProjectileId);
+      if (cur) {
+        // Cache position each frame so we know where to snap on despawn.
+        const g = cur.gfx as unknown as { x: number; y: number };
+        this.lastFollowedPos = { x: g.x, y: g.y };
         return;
       }
-      return; // still following this projectile
+      // Followed projectile just despawned. Snap to last known position
+      // so the impact VFX is visible regardless of camera lerp lag.
+      const cam = this.scene.cameras.main;
+      cam.stopFollow();
+      if (this.lastFollowedPos) {
+        cam.centerOn(this.lastFollowedPos.x, this.lastFollowedPos.y);
+      }
+      this.lastFollowedPos = null;
+      this.lingerUntilMs = this.now() + tuning.camera.postImpactLingerMs;
+      return;
     }
 
     // No current projectile follow target.
@@ -118,6 +130,8 @@ export class CameraFollower {
       const first = projectiles[0];
       if (first) {
         this.followedProjectileId = first.id;
+        const g = first.gfx as unknown as { x: number; y: number };
+        this.lastFollowedPos = { x: g.x, y: g.y };
         this.followProjectile(first.gfx);
       }
     }
@@ -128,5 +142,6 @@ export class CameraFollower {
     this.activeWormTarget = null;
     this.followedProjectileId = null;
     this.lingerUntilMs = null;
+    this.lastFollowedPos = null;
   }
 }


### PR DESCRIPTION
## Summary

Closes #133. Fixes the perceived "grenade despawns without exploding" bug, which is actually a CAMERA visibility issue, not a sim issue. Server logs confirmed every grenade fire is followed by a detonate + terrain_cut event - explosions ARE happening. The user just couldn't see them because they were off-screen.

### Root cause

\`src/ui/CameraFollower.ts\` follows projectiles with \`projectileLerp = 0.05\` (slow smoothing for visual stability). For fast-bouncing grenades with high restitution (0.55), the projectile races ahead while the camera lags 200-400 px behind. When the projectile despawns, \`stopFollow()\` froze the camera at its CURRENT (lagging) position - not at the impact site. The terrain_cut VFX fired at the actual impact x/y outside the viewport, and the linger phase held the camera at the wrong location.

### Fix

Track the projectile's gfx position each frame (\`lastFollowedPos\`). On despawn, \`cameras.main.centerOn(lastFollowedPos)\` before entering the linger phase. The impact is now visible regardless of how far the camera was lagging. \`centerOn\` respects camera bounds (already set in GameScene via \`setBounds\`), so off-world despawns clamp gracefully.

## Bug Check

VERDICT: CLEAN.

Two LOW observations included for the record, not blocking:

- The \`if (this.lastFollowedPos)\` guard silently no-ops if the invariant ever breaks. Could be tightened to an assert; the invariant holds today.
- The \`gfx as unknown as { x, y }\` cast is safe given current callers (Phaser Graphics implements Transform). A narrower type would eliminate the cast.

NO ISSUE on snap-during-linger-interruption (cache is refreshed in the new-projectile acquire block), camera bounds (centerOn clamps), performance (60Hz cache writes are trivial), test coverage of the main case, or existing tests (none asserted absence of centerOn).

## Test plan

- [x] tsc clean, lint clean, build clean
- [x] 278 tests pass (1 new: snap-on-despawn behavior)
- [ ] In-app: throw a hand grenade hard so it bounces far. Camera should pan to wherever it lands and the explosion should be visible.
- [ ] In-app: holy grenade with similar long bounce - same expectation.
- [ ] In-app: bazooka direct hit - existing camera behavior unchanged (projectile is faster but follows + lingers normally).

Closes #133