### PR TITLE
fix(drill): no bounce + firer self-immunity (#137, #140)

### DIFF
--- a/src/weapons/ProjectileManager.ts
+++ b/src/weapons/ProjectileManager.ts
@@ -104,7 +104,10 @@ export class ProjectileManager {
       weapon,
       firer,
       detonated: false,
-      msSinceLastCut: 0,
+      // For tunneling weapons (drill), force the first cut to happen on the
+      // next tick rather than waiting cutIntervalMs. Without this, the projectile
+      // has time to bounce on first terrain contact before the tunnel begins.
+      msSinceLastCut: weapon.tunnel ? weapon.tunnel.cutIntervalMs : 0,
     };
 
     // Link body userData back to the ActiveProjectile for contact lookup

--- a/src/weapons/drill.ts
+++ b/src/weapons/drill.ts
@@ -11,6 +11,7 @@ export const drill: WeaponConfig = {
   projectileColor: 0xbbccdd,
   projectileRadiusPx: 6,
   powerCapMps: 18,
+  restitution: 0, // no bounce - tunnels into terrain on first contact
   fuseMs: 3500, // after 3.5s, detonate
   tunnel: { cutRadiusPx: 14, cutIntervalMs: 40 }, // carves a tunnel every 40ms
   explosion: {

--- a/worker/src/entities/projectile.ts
+++ b/worker/src/entities/projectile.ts
@@ -80,6 +80,13 @@ export class Projectile {
       restitution: init.config.restitution ?? 0.1,
     });
 
+    // For tunneling weapons (drill), force the first cut to happen on the
+    // next tick rather than waiting cutIntervalMs. Without this, the projectile
+    // has time to bounce on first terrain contact before the tunnel begins.
+    if (init.config.tunnel) {
+      this.msSinceLastCut = init.config.tunnel.cutIntervalMs;
+    }
+
     const userData: ProjectileUserData = { kind: "projectile", projectile: this };
     this.body.setUserData(userData);
   }

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -770,7 +770,17 @@ export class Simulation {
         // rather than tunneling through it harmlessly.
         // For terrain/other contacts, keep the original fuse-null gate so
         // fused projectiles (drill) keep tunneling until the fuse expires.
-        if (ud.projectile.fuseRemainingMs === null || isWormContact) {
+
+        // Skip detonation when the projectile contacts its own firer. Without
+        // this, drill fired straight down spawns inside the firer's foot sensor
+        // and self-destructs (the foot sensor's body userData is kind:"worm",
+        // so otherBody.getUserData() reports a worm contact). Bazooka into one's
+        // own feet also no longer self-detonates - acceptable edge case;
+        // fused weapons still detonate via fuse expiration regardless.
+        const otherWormRef = (otherUd as { worm?: { id: string } } | null)?.worm;
+        const isFirerSelfContact = isWormContact && otherWormRef?.id === ud.projectile.ownerId;
+
+        if (!isFirerSelfContact && (ud.projectile.fuseRemainingMs === null || isWormContact)) {
           this.pendingDetonate.push(ud.projectile);
         }
       }

--- a/worker/src/weapons/drill.ts
+++ b/worker/src/weapons/drill.ts
@@ -11,6 +11,7 @@ export const drill: WeaponConfig = {
   projectileColor: 0xbbccdd,
   projectileRadiusPx: 6,
   powerCapMps: 18,
+  restitution: 0, // no bounce - tunnels into terrain on first contact
   fuseMs: 3500, // after 3.5s, detonate
   tunnel: { cutRadiusPx: 14, cutIntervalMs: 40 }, // carves a tunnel every 40ms
   explosion: {


### PR DESCRIPTION
## Summary

Three drill bugs analyzed; this PR fixes #137 + #140 and notes #138 for post-deploy verification.

### #137 - drill bounces before digging
- Drill projectile had no `restitution` override (defaulted to `0.1`).
- Tunnel cuts run on a 40ms cadence; the first cut was delayed by `cutIntervalMs` after spawn, so a bounce happened before any terrain was carved.

### #140 - drill explodes immediately when fired straight down
- The worm body's userData is `{ kind: "worm" }` (worm.ts:142). The foot sensor fixture has its own `kind: "worm-foot"` userData but the contact handler reads `otherBody.getUserData()` which always returns the body-level data.
- When fired straight down, the drill spawn position (wormRadius + projRadius + 2 = 20px below firer center) overlaps the foot sensor by ~1.6px on spawn, triggering a "worm contact" that detonated the drill immediately.

### #138 - worm appears to follow drill into terrain (NOT fixed in this PR)
- No physics linkage exists; verified.
- Most likely downstream of #140: drill self-detonating on spawn drove an explosion impulse on the firer.
- Marked for verification once #140 ships. If reproduced, file a follow-up with server-side instrumentation.

## Fixes

1. **Drill restitution = 0** in both `src/weapons/drill.ts` and `worker/src/weapons/drill.ts`.
2. **First tunnel cut fires immediately** by initializing `msSinceLastCut = cutIntervalMs` in projectile spawn (server `worker/src/entities/projectile.ts` + client `src/weapons/ProjectileManager.ts`).
3. **Server contact handler skips self-detonation** when a projectile is contacting its own firer (`worker/src/sim/simulation.ts:onBeginContact`). Bazooka into one's own feet no longer self-detonates - acceptable edge case; fuse-based weapons still detonate via fuse expiration regardless.

Client-side `ProjectileManager.onBeginContact` was NOT changed: its existing gate (`fuseMs === null` only) means fused weapons like drill never self-detonated on the client anyway, so offline play is unaffected by this bug class.

## Bug check

Two parallel lens reviews (edge cases, regressions). No critical or high findings.
- Dead-firer self-immunity behavior is correct (drill won't detonate on the firer's corpse either).
- Both `WormUserData` and `WormFootUserData` carry `.worm.id`, so the body-userData read is safe.
- `restitution: 0` settles into corners cleanly because the tunnel cut fires on the very next tick (no stall).
- No test asserts firer self-detonation; sim.test.ts drill+enemy worm test still passes.

## Tests

- `npm test` (client vitest): 32 files, 278 tests passing
- `cd worker && npm test`: 8 files, 94 tests passing
- Lint + typecheck clean (3 pre-existing test typecheck errors unrelated to this PR)

## Manual verification (post-deploy)

- [ ] Fire drill horizontally - immediate dig, no bounce
- [ ] Fire drill straight down - digs into ground, does NOT explode
- [ ] Watch firer worm during drill flight - confirm worm stays at firing position. If still appears to follow drill, file follow-up against #138.

Closes #137
Closes #140