### PR TITLE
fix: worm physics batch (#104 #141 #144)

### DIFF
--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -118,6 +118,7 @@ export class Worm {
       fixedRotation: true,
       linearDamping,
     });
+    this.body.setBullet(true);
 
     // Main circle body.
     this.body.createFixture({

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -468,13 +468,15 @@ export class Simulation {
 
     // 5. Off-map kill: any worm pushed outside the map (in any direction,
     //    plus a margin) is marked dead. Absorbs issue #53.
-    const killMin = -OFF_MAP_MARGIN_PX / 30; // meters
+    //    Top boundary intentionally excluded: gravity returns airborne worms;
+    //    turn timer caps duration. Fix for issue #141.
+    const killMinX = -OFF_MAP_MARGIN_PX / 30; // meters
     const killMaxX = (this.widthPx + OFF_MAP_MARGIN_PX) / 30;
     const killMaxY = (this.heightPx + OFF_MAP_MARGIN_PX) / 30;
     for (const worm of this.worms.values()) {
       if (!worm.alive) continue;
       const pos = worm.body.getPosition();
-      if (pos.x < killMin || pos.x > killMaxX || pos.y < killMin || pos.y > killMaxY) {
+      if (pos.x < killMinX || pos.x > killMaxX || pos.y > killMaxY) {
         worm.kill();
         if (!this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -272,6 +272,9 @@ export class TurnArbiter {
     if (this.gameOver) return false;
     if (this.pausedRemainingMs !== null) return false;
     if (Date.now() > this.room.state.turnEndsAt) return false;
+    const currentId = this.room.state.currentWormId;
+    const provider = this.room.getAliveCountsProvider();
+    if (currentId && provider && !provider.isWormAlive(currentId)) return false;
     return true;
   }
 
@@ -284,7 +287,7 @@ export class TurnArbiter {
     this.checkGameOver();
     if (this.gameOver) return;
     if (wormId && wormId === this.room.state.currentWormId) {
-      this.pendingAdvance = true;
+      this.advanceTurn();
     }
   }
 

--- a/worker/test/turnArbiter.test.ts
+++ b/worker/test/turnArbiter.test.ts
@@ -363,6 +363,33 @@ describe("TurnArbiter", () => {
     expect(room.state.currentTeamId).toBe("blue");
   });
 
+  it("onWormDied advances turn immediately when the active worm dies (no onTick needed)", () => {
+    const room = new StubRoom();
+    room.connected = new Set(["alice", "bob"]);
+    const rosters = [rosterFor("red", "alice"), rosterFor("blue", "bob")];
+    setAllAlive(room.provider, rosters);
+    const arbiter = new TurnArbiter(room);
+    arbiter.start(["red", "blue"], rosters, TURN_DURATION_MS);
+
+    // Capture the active worm before the call.
+    const dyingWormId = room.state.currentWormId;
+    expect(dyingWormId).toBe("red-0");
+
+    // Mark the worm dead in the provider so alive counts reflect reality.
+    room.provider.deadWorms.add(dyingWormId);
+    room.provider.counts.set("red", 1); // one worm left on red
+
+    // Call onWormDied once - do NOT call onTick after.
+    arbiter.onWormDied(dyingWormId);
+
+    // Turn must have advanced without any onTick call.
+    expect(room.state.currentWormId).not.toBe(dyingWormId);
+    expect(room.state.currentTeamId).toBe("blue");
+
+    // pendingAdvance must not be the gating factor - advance already happened.
+    expect((arbiter as unknown as { pendingAdvance: boolean }).pendingAdvance).toBe(false);
+  });
+
   it("start() resets gameOver when a second match follows a completed game", () => {
     const room = new StubRoom();
     const arbiter = new TurnArbiter(room);


### PR DESCRIPTION
## Summary

Three independent worm-physics fixes, batched together. De-risks the upcoming world expansion (#150) since the new bugs would be amplified by a larger map.

- **#104** turn arbiter race — when the active worm dies mid-turn, advance the turn IMMEDIATELY instead of deferring to next onTick. Adds an alive-check defense in `areInputsAccepted`. New test verifies same-call advance.
- **#141** off-screen-upward survival — removed the top-Y kill boundary. Worms launched above the world (y < 0) now stay alive; gravity returns them; existing fall-damage on landing handles impact. Side and bottom boundaries unchanged.
- **#144** worm CCD — added `body.setBullet(true)` on worm bodies so fast-falling worms don't tunnel through thin terrain (e.g., a freshly-carved cave floor).

## Bug Check

Ran 6-lens bugcheck (edge cases, regression, multiplayer/state via Sonnet investigator).

- Critical: none
- High: none (one HIGH was raised on #104 race; investigation confirmed snapshot event loop + gameOver guard make all event orderings correct)
- Tests: 278/278 pass on the integration branch

## Known Issues (non-blocking)

- **[M1] Soaring-worm early settle** — A worm decelerating to ~zero velocity high above the world could trigger early settle. Covered today by the existing 6s ` SETTLE_GRACE_MS` cap so the turn ends correctly, but landing damage may not fully resolve before turn rotates. File a follow-up if observed in playtest.
- **[M2] Silent input rejection** — Pre-existing UX gap (already true via `canFire()`). Inputs from a client whose worm just died server-side are dropped without feedback. Worth a separate UX issue, not introduced by this PR.

## Verification of #138

Issue #138 ("worm physics body moves with drill projectile") is likely already resolved by PR #148 (drill no longer self-detonates on its firer). Manual playtest verification by Scott — close #138 if no longer reproduces.

## Files

- `worker/src/turnArbiter.ts` (#104)
- `worker/test/turnArbiter.test.ts` (#104 - new test)
- `worker/src/sim/simulation.ts` (#141)
- `worker/src/entities/worm.ts` (#144)

Closes #104
Closes #141
Closes #144