### PR TITLE
fix: weapons polish batch (#134 #135 #136 #139 #149)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -234,6 +234,23 @@ export interface WormDiedEvent {
   wormId: string;
 }
 
+/**
+ * Sent to the originating client (not broadcast) when a fire input is
+ * rejected. The client shows a brief toast above the active worm so the
+ * player knows why their shot did not fire.
+ */
+export type FireRejectedMessage = {
+  type: "fire_rejected";
+  weaponId: string;
+  reason:
+    | "no_ammo"
+    | "not_your_turn"
+    | "already_fired"
+    | "no_active_worm"
+    | "max_projectiles"
+    | "weapon_not_found";
+};
+
 // ---------------------------------------------------------------------------
 // Server -> client messages (discriminated by `type`)
 // ---------------------------------------------------------------------------
@@ -268,7 +285,8 @@ export type ServerMsg =
   | ({ type: "fire_event" } & FireEvent)
   | ({ type: "damage_event" } & DamageEvent)
   | ({ type: "worm_died" } & WormDiedEvent)
-  | { type: "error"; code: string; message: string };
+  | { type: "error"; code: string; message: string }
+  | FireRejectedMessage;
 
 // Note: Epic 9's per-input relay variants (input_walk/jump/etc as SERVER-SENT
 // messages) + turn_resolved have been removed. Server runs an authoritative

--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -6,7 +6,7 @@ export interface InputControllerInit {
   scene: Phaser.Scene;
   allWorms: Worm[]; // renamed from worms; all worms for cycleWithinTeam lookups
   onEndTurn: () => void; // called on Enter keydown
-  onSelectWeapon: (n: 1 | 2 | 3) => void; // called when 1/2/3 pressed in normal state
+  onSelectWeapon: (n: number) => void; // called when 1-7 pressed in normal state
   onFire: () => void; // called when F pressed in normal state
   onCycleMap: () => void; // called when M pressed; dev affordance to cycle maps
   // Epic 9: optional callbacks fired when local input mutates the active worm.
@@ -22,7 +22,7 @@ export interface InputControllerInit {
 export class InputController {
   private readonly scene: Phaser.Scene;
   private readonly onEndTurn: () => void;
-  private readonly onSelectWeapon: (n: 1 | 2 | 3) => void;
+  private readonly onSelectWeapon: (n: number) => void;
   private readonly onFire: () => void;
   private readonly onCycleMap: () => void;
   private readonly onWalk: (dir: -1 | 0 | 1) => void;
@@ -58,6 +58,10 @@ export class InputController {
   private readonly key1: Phaser.Input.Keyboard.Key;
   private readonly key2: Phaser.Input.Keyboard.Key;
   private readonly key3: Phaser.Input.Keyboard.Key;
+  private readonly key4: Phaser.Input.Keyboard.Key;
+  private readonly key5: Phaser.Input.Keyboard.Key;
+  private readonly key6: Phaser.Input.Keyboard.Key;
+  private readonly key7: Phaser.Input.Keyboard.Key;
   private readonly keyFire: Phaser.Input.Keyboard.Key; // F
   private readonly keyPowerDown: Phaser.Input.Keyboard.Key; // [
   private readonly keyPowerUp: Phaser.Input.Keyboard.Key; // ]
@@ -97,6 +101,10 @@ export class InputController {
     this.key1 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.ONE);
     this.key2 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.TWO);
     this.key3 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.THREE);
+    this.key4 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.FOUR);
+    this.key5 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.FIVE);
+    this.key6 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.SIX);
+    this.key7 = kb.addKey(Phaser.Input.Keyboard.KeyCodes.SEVEN);
     this.keyFire = kb.addKey(Phaser.Input.Keyboard.KeyCodes.F);
     this.keyPowerDown = kb.addKey(Phaser.Input.Keyboard.KeyCodes.OPEN_BRACKET);
     this.keyPowerUp = kb.addKey(Phaser.Input.Keyboard.KeyCodes.CLOSED_BRACKET);
@@ -277,10 +285,14 @@ export class InputController {
         return;
       }
 
-      // Weapon select (1/2/3)
+      // Weapon select (1-7)
       if (Phaser.Input.Keyboard.JustDown(this.key1)) this.onSelectWeapon(1);
       else if (Phaser.Input.Keyboard.JustDown(this.key2)) this.onSelectWeapon(2);
       else if (Phaser.Input.Keyboard.JustDown(this.key3)) this.onSelectWeapon(3);
+      else if (Phaser.Input.Keyboard.JustDown(this.key4)) this.onSelectWeapon(4);
+      else if (Phaser.Input.Keyboard.JustDown(this.key5)) this.onSelectWeapon(5);
+      else if (Phaser.Input.Keyboard.JustDown(this.key6)) this.onSelectWeapon(6);
+      else if (Phaser.Input.Keyboard.JustDown(this.key7)) this.onSelectWeapon(7);
 
       // Fire (F)
       if (Phaser.Input.Keyboard.JustDown(this.keyFire)) {

--- a/src/net/types.ts
+++ b/src/net/types.ts
@@ -15,6 +15,7 @@ export {
   type ClientMsg,
   type DamageEvent,
   type FireEvent,
+  type FireRejectedMessage,
   type LobbyPlayer,
   type LobbyState,
   type ProjectileRenderState,
@@ -49,3 +50,4 @@ export type TerrainCutMessage = Extract<ServerMsg, { type: "terrain_cut" }>;
 export type FireEventMessage = Extract<ServerMsg, { type: "fire_event" }>;
 export type DamageEventMessage = Extract<ServerMsg, { type: "damage_event" }>;
 export type WormDiedMessage = Extract<ServerMsg, { type: "worm_died" }>;
+export type FireRejectedMsg = Extract<ServerMsg, { type: "fire_rejected" }>;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -596,7 +596,54 @@ export class GameScene extends Phaser.Scene {
         this.cameras.main.shake(80, 0.002);
         return;
       }
+      case "fire_rejected": {
+        // Show a brief toast above the active worm so the player sees why
+        // the shot was rejected. Skip toasting for no_active_worm - it
+        // usually means the worm just died and the message is stale.
+        if (ev.reason === "no_active_worm") return;
+        const reasonText: Record<string, string> = {
+          no_ammo: "OUT OF AMMO",
+          not_your_turn: "NOT YOUR TURN",
+          already_fired: "ALREADY FIRED",
+          max_projectiles: "TOO MANY IN FLIGHT",
+          weapon_not_found: "WEAPON UNAVAILABLE",
+        };
+        const label = reasonText[ev.reason];
+        if (!label) return;
+        const activeId = this.sim.getActiveWormId();
+        const activeWorm = this.sim.allWorms.find((w) => w.id === activeId);
+        const xPx = activeWorm?.xPx ?? this.scale.width / 2;
+        const yPx = activeWorm ? activeWorm.yPx - 20 : this.scale.height / 2;
+        this.spawnFireRejectedToast(xPx, yPx, label);
+        return;
+      }
     }
+  }
+
+  /**
+   * Floating toast label shown when a fire input is rejected by the server.
+   * Styled similarly to spawnDamageNumber but in orange/yellow. Auto-destroys
+   * after the tween completes.
+   */
+  private spawnFireRejectedToast(xPx: number, yPx: number, label: string): void {
+    const txt = this.add
+      .text(xPx, yPx, label, {
+        fontSize: "16px",
+        fontFamily: "monospace",
+        color: "#ffaa00",
+        stroke: "#000000",
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5, 1)
+      .setDepth(50);
+    this.tweens.add({
+      targets: txt,
+      y: yPx - 24,
+      alpha: { from: 1, to: 0 },
+      duration: 1200,
+      ease: "Quad.easeOut",
+      onComplete: () => txt.destroy(),
+    });
   }
 
   /**

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -553,9 +553,31 @@ export class GameScene extends Phaser.Scene {
         // Visual mask cut (networked mode only; offline mode cuts the
         // bodies-aware Terrain directly inside OfflineSimAdapter).
         this.terrainRenderer?.cutCircle(ev.x, ev.y, ev.r, ev.seq);
-        // Small camera shake on large cuts. Radius 20+ counts as "big".
-        if (ev.r >= 20) {
-          this.cameras.main.shake(120, 0.003);
+        // Radius-scaled camera shake + screen flash. Bigger weapons feel bigger.
+        if (ev.r >= tuning.juice.shakeMinRadiusPx) {
+          const durMs = Math.min(280, 80 + ev.r * 2);
+          const intensity = Math.min(tuning.juice.shakeMaxIntensity, 0.0015 + ev.r * 0.0001);
+          this.cameras.main.shake(durMs, intensity);
+
+          // Brief screen flash overlay scaled by radius for big-explosion punch.
+          const cam = this.cameras.main;
+          const flashAlpha = Math.min(tuning.juice.flashMaxAlpha, 0.04 + ev.r * 0.002);
+          const flash = this.add.rectangle(
+            cam.midPoint.x,
+            cam.midPoint.y,
+            cam.width,
+            cam.height,
+            0xffffff,
+            flashAlpha,
+          );
+          flash.setScrollFactor(0);  // CRITICAL: pin to camera viewport
+          flash.setDepth(10000);
+          this.tweens.add({
+            targets: flash,
+            alpha: 0,
+            duration: 80,
+            onComplete: () => flash.destroy(),
+          });
         }
         return;
       case "fire_event":

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -570,7 +570,7 @@ export class GameScene extends Phaser.Scene {
             0xffffff,
             flashAlpha,
           );
-          flash.setScrollFactor(0);  // CRITICAL: pin to camera viewport
+          flash.setScrollFactor(0); // CRITICAL: pin to camera viewport
           flash.setDepth(10000);
           this.tweens.add({
             targets: flash,

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -20,6 +20,7 @@ import type {
   ClientMsg,
   DamageEventMessage,
   FireEventMessage,
+  FireRejectedMsg,
   SimStateMessage,
   TeamInit,
   TerrainCutMessage,
@@ -617,6 +618,13 @@ export class NetworkedSimAdapter implements SimAdapter {
       for (const sub of this.gameOverSubs) sub(msg.winnerTeamId);
     });
     this.unsubs.push(gameOverUnsub);
+
+    const fireRejectedUnsub = this.room.onMessage("fire_rejected", (msg: FireRejectedMsg) => {
+      for (const sub of this.eventSubs) {
+        sub({ type: "fire_rejected", weaponId: msg.weaponId, reason: msg.reason });
+      }
+    });
+    this.unsubs.push(fireRejectedUnsub);
   }
 }
 

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -17,7 +17,13 @@
  * applies the input immediately to the local world; networked mode forwards
  * the input to the server and waits for the next `sim_state`.
  */
-import type { DamageEvent, FireEvent, TerrainCutEvent, WormDiedEvent } from "../../shared/protocol";
+import type {
+  DamageEvent,
+  FireEvent,
+  FireRejectedMessage,
+  TerrainCutEvent,
+  WormDiedEvent,
+} from "../../shared/protocol";
 import type { Team } from "../worm/Team";
 
 /** Union of event types an adapter can emit upstream to the renderer. */
@@ -25,7 +31,8 @@ export type SimEvent =
   | ({ type: "terrain_cut" } & TerrainCutEvent)
   | ({ type: "fire_event" } & FireEvent)
   | ({ type: "damage_event" } & DamageEvent)
-  | ({ type: "worm_died" } & WormDiedEvent);
+  | ({ type: "worm_died" } & WormDiedEvent)
+  | FireRejectedMessage;
 
 /**
  * Renderer's view of a worm. Pixel-space coords so the renderer never

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -102,6 +102,11 @@ interface Tuning {
     projectileLerp: number;
     postImpactLingerMs: number;
   };
+  juice: {
+    shakeMaxIntensity: number;  // accessibility cap; bigger explosions clamp here
+    shakeMinRadiusPx: number;   // below this radius, no shake
+    flashMaxAlpha: number;
+  };
 }
 
 export const tuning: Tuning = {
@@ -184,5 +189,10 @@ export const tuning: Tuning = {
     wormLerp: 0.08,
     projectileLerp: 0.05,
     postImpactLingerMs: 1200,
+  },
+  juice: {
+    shakeMaxIntensity: 0.012,  // accessibility cap; bigger explosions clamp here
+    shakeMinRadiusPx: 15,       // below this radius, no shake
+    flashMaxAlpha: 0.20,
   },
 };

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -174,7 +174,8 @@ export const tuning: Tuning = {
     iterations: 4,
     surfaceBufferPx: 80,
   },
-  wind: { forceNewtonsPerUnit: 2 },
+  // Mirror of worker/src/sim/simulation.ts WIND_FORCE - keep in sync.
+  wind: { forceNewtonsPerUnit: 0.8 },
   camera: {
     turnZoomOutMs: 800,
     turnHoldMinMs: 700,

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -103,8 +103,8 @@ interface Tuning {
     postImpactLingerMs: number;
   };
   juice: {
-    shakeMaxIntensity: number;  // accessibility cap; bigger explosions clamp here
-    shakeMinRadiusPx: number;   // below this radius, no shake
+    shakeMaxIntensity: number; // accessibility cap; bigger explosions clamp here
+    shakeMinRadiusPx: number; // below this radius, no shake
     flashMaxAlpha: number;
   };
 }
@@ -192,8 +192,8 @@ export const tuning: Tuning = {
     postImpactLingerMs: 1200,
   },
   juice: {
-    shakeMaxIntensity: 0.012,  // accessibility cap; bigger explosions clamp here
-    shakeMinRadiusPx: 15,       // below this radius, no shake
-    flashMaxAlpha: 0.20,
+    shakeMaxIntensity: 0.012, // accessibility cap; bigger explosions clamp here
+    shakeMinRadiusPx: 15, // below this radius, no shake
+    flashMaxAlpha: 0.2,
   },
 };

--- a/src/weapons/fire.ts
+++ b/src/weapons/fire.ts
@@ -41,7 +41,12 @@ function fireHitscan(weapon: WeaponConfig, ctx: FireContext, shotsFiredBefore: n
 
   // Apply per-shot angle jitter if weapon has hitscanSpreadRad set (e.g. Minigun).
   const spread = weapon.hitscanSpreadRad ?? 0;
-  const jitter = spread > 0 ? (Math.random() * 2 - 1) * spread : 0;
+  // Bates-2 (triangular) distribution biases toward center, removing visible
+  // outliers. Sum of two uniforms peaks at 0; ~50% of pellets within +/-0.29*spread
+  // vs uniform's +/-0.5*spread.
+  const jitter = spread > 0
+    ? ((Math.random() - 0.5) + (Math.random() - 0.5)) * spread
+    : 0;
   const shotAngle = aimRadians + jitter;
 
   // Compute ray endpoints

--- a/src/weapons/fire.ts
+++ b/src/weapons/fire.ts
@@ -44,9 +44,7 @@ function fireHitscan(weapon: WeaponConfig, ctx: FireContext, shotsFiredBefore: n
   // Bates-2 (triangular) distribution biases toward center, removing visible
   // outliers. Sum of two uniforms peaks at 0; ~50% of pellets within +/-0.29*spread
   // vs uniform's +/-0.5*spread.
-  const jitter = spread > 0
-    ? ((Math.random() - 0.5) + (Math.random() - 0.5)) * spread
-    : 0;
+  const jitter = spread > 0 ? (Math.random() - 0.5 + (Math.random() - 0.5)) * spread : 0;
   const shotAngle = aimRadians + jitter;
 
   // Compute ray endpoints

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -1053,7 +1053,10 @@ export class Room implements DurableObject {
       if (player.ownerOfTeamId !== lobby.currentTeamId) continue;
       const activeWormId = lobby.currentWormId;
       if (!activeWormId) continue;
-      if (inputsLocked) continue;
+      // walk-stop (dir 0) bypasses the input-lock so a worm halts when the timer
+      // expires post-fire. Without this, walk-stop messages arriving after the
+      // retreat window expires are dropped and the worm keeps walking until turn end.
+      if (inputsLocked && !(input.kind === "walk" && input.dir === 0)) continue;
       switch (input.kind) {
         case "walk":
           this.sim.applyWalkInput(activeWormId, input.dir);

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -36,7 +36,12 @@ import {
   type TeamInit,
 } from "./messages.js";
 import { isValidNickname, normaliseNickname } from "./sanitize.js";
-import { type SerializedSim, type SimEvent, type SimFireResult, Simulation } from "./sim/simulation.js";
+import {
+  type SerializedSim,
+  type SimEvent,
+  type SimFireResult,
+  Simulation,
+} from "./sim/simulation.js";
 import {
   type AliveCountsProvider,
   type ArbiterPersistedState,

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -28,6 +28,7 @@ import {
 import { type LogContext, dlog } from "./debug/logger.js";
 import {
   ALLOWED_COLORS,
+  type FireRejectedMessage,
   type LobbyPlayer,
   type LobbyState,
   type ServerMsg,
@@ -35,7 +36,7 @@ import {
   type TeamInit,
 } from "./messages.js";
 import { isValidNickname, normaliseNickname } from "./sanitize.js";
-import { type SerializedSim, type SimEvent, Simulation } from "./sim/simulation.js";
+import { type SerializedSim, type SimEvent, type SimFireResult, Simulation } from "./sim/simulation.js";
 import {
   type AliveCountsProvider,
   type ArbiterPersistedState,
@@ -1076,13 +1077,34 @@ export class Room implements DurableObject {
         case "select_weapon":
           this.sim.applySelectWeapon(activeWormId, input.weaponId);
           break;
-        case "fire":
-          // Reject if arbiter says no: already fired, paused, past timer, or
-          // game over. Prevents double-fire within a turn and post-timer sneaks.
-          if (!this.arbiter?.canFire()) break;
-          this.sim.applyFire(activeWormId);
+        case "fire": {
+          // Resolve the weapon id now so rejection messages can include it.
+          const activeWeapon = this.sim.getWorm(activeWormId)?.activeWeapon ?? "";
+          // Reject if arbiter says no: already fired, paused, past timer, or game over.
+          if (!this.arbiter?.canFire()) {
+            // Determine the most specific arbiter rejection reason.
+            const arbiterReason: FireRejectedMessage["reason"] = this.arbiter?.getHasFiredThisTurn()
+              ? "already_fired"
+              : "not_your_turn";
+            this.sendToSession(input.sessionId, {
+              type: "fire_rejected",
+              weaponId: activeWeapon,
+              reason: arbiterReason,
+            });
+            break;
+          }
+          const fireResult: SimFireResult = this.sim.applyFire(activeWormId);
+          if (!fireResult.ok) {
+            this.sendToSession(input.sessionId, {
+              type: "fire_rejected",
+              weaponId: activeWeapon,
+              reason: fireResult.reason,
+            });
+            break;
+          }
           this.arbiter.onFireCommitted();
           break;
+        }
         case "jetpack_toggle":
           this.sim.applyJetPackToggle(activeWormId);
           break;
@@ -1134,6 +1156,22 @@ export class Room implements DurableObject {
       ws.send(JSON.stringify({ type: "error", code, message }));
     } catch {
       // ignore
+    }
+  }
+
+  /** Send a message to the single WebSocket belonging to the given sessionId. */
+  private sendToSession(sessionId: string, msg: ServerMsg): void {
+    const serialised = JSON.stringify(msg);
+    for (const ws of this.state.getWebSockets()) {
+      const att = ws.deserializeAttachment() as WsAttachment | undefined;
+      if (att?.sessionId === sessionId) {
+        try {
+          ws.send(serialised);
+        } catch {
+          // ignore
+        }
+        return;
+      }
     }
   }
 

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -39,7 +39,8 @@ import { toMeters, toPixels } from "../physics/scale.js";
 import { createPhysicsWorld } from "../physics/world.js";
 import type { PlanckWorld } from "../physics/world.js";
 import { type ExplodeResult, explode } from "../weapons/explode.js";
-import { type FireResult, fire } from "../weapons/fire.js";
+import { fire } from "../weapons/fire.js";
+import type { FireResult as WeaponFireResult } from "../weapons/fire.js";
 import { defaultAmmoForMatch, getById } from "../weapons/registry.js";
 
 const OFF_MAP_MARGIN_PX = 200;
@@ -146,6 +147,22 @@ export interface SerializedSim {
   wind: number;
   waterLevelPx: number;
 }
+
+/**
+ * Structured result from applyFire. On success, `ok: true` and the underlying
+ * WeaponFireResult is included for the arbiter (shotsRemaining / turnEndsImmediately).
+ * On failure, `ok: false` with a reason the caller can forward to the client.
+ */
+export type SimFireResult =
+  | { ok: true; weaponResult: WeaponFireResult }
+  | {
+      ok: false;
+      reason:
+        | "no_ammo"
+        | "no_active_worm"
+        | "max_projectiles"
+        | "weapon_not_found";
+    };
 
 export class Simulation {
   readonly world: PlanckWorld;
@@ -316,22 +333,22 @@ export class Simulation {
   }
 
   /**
-   * Fire the worm's active weapon. Returns the FireResult so the
-   * caller can inspect shotsRemaining / turnEndsImmediately for the
-   * turn arbiter. Also emits a fire_event SimEvent on success, and
-   * any explode events for hitscan hits.
+   * Fire the worm's active weapon. Returns a SimFireResult so the caller can
+   * inspect shotsRemaining / turnEndsImmediately (on success) or forward a
+   * rejection reason to the originating client (on failure). Also emits a
+   * fire_event SimEvent on success, and any explode events for hitscan hits.
    */
-  applyFire(wormId: string, weaponId?: string): FireResult | null {
+  applyFire(wormId: string, weaponId?: string): SimFireResult {
     const worm = this.worms.get(wormId);
-    if (!worm || !worm.alive) return null;
-    if (this.projectiles.length >= MAX_PROJECTILES) return null;
+    if (!worm || !worm.alive) return { ok: false, reason: "no_active_worm" };
+    if (this.projectiles.length >= MAX_PROJECTILES) return { ok: false, reason: "max_projectiles" };
     const weapon = weaponId ? getById(weaponId) : getById(worm.activeWeapon);
-    if (!weapon) return null;
+    if (!weapon) return { ok: false, reason: "weapon_not_found" };
 
-    // Enforce per-team ammo. Reject silently if the team has run out.
+    // Enforce per-team ammo. Reject if the team has run out.
     const teamPool = this.teamAmmo.get(worm.teamId);
     const remaining = teamPool?.[weapon.id] ?? -1;
-    if (remaining !== -1 && remaining <= 0) return null;
+    if (remaining !== -1 && remaining <= 0) return { ok: false, reason: "no_ammo" };
 
     const result = fire({
       world: this.world,
@@ -379,7 +396,7 @@ export class Simulation {
       this.projectiles.push(proj);
     }
 
-    return result;
+    return { ok: true, weaponResult: result };
   }
 
   // ---- Main tick ----

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -442,7 +442,10 @@ export class Simulation {
       // Wind: apply horizontal force per tick to in-flight projectiles.
       // WIND_FORCE is Newtons per unit wind; tunable in src/tuning.ts.
       if (this.wind !== 0) {
-        const WIND_FORCE = 2; // Mirror of tuning.wind.forceNewtonsPerUnit.
+        // Mirror of src/tuning.ts wind.forceNewtonsPerUnit - keep in sync.
+        // 0.8 N/unit gives ~9 m/s^2 lateral accel at wind=0.8 on a 0.07kg projectile,
+        // approximately gravity strength - meaningful but not trajectory-breaking.
+        const WIND_FORCE = 0.8;
         proj.body.applyForce(
           { x: this.wind * WIND_FORCE, y: 0 },
           proj.body.getWorldCenter(),

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -157,11 +157,7 @@ export type SimFireResult =
   | { ok: true; weaponResult: WeaponFireResult }
   | {
       ok: false;
-      reason:
-        | "no_ammo"
-        | "no_active_worm"
-        | "max_projectiles"
-        | "weapon_not_found";
+      reason: "no_ammo" | "no_active_worm" | "max_projectiles" | "weapon_not_found";
     };
 
 export class Simulation {

--- a/worker/src/turnArbiter.ts
+++ b/worker/src/turnArbiter.ts
@@ -209,6 +209,11 @@ export class TurnArbiter {
     return this.gameOver;
   }
 
+  /** True if the active worm has already fired this turn (one-shot gate). */
+  getHasFiredThisTurn(): boolean {
+    return this.hasFiredThisTurn;
+  }
+
   /**
    * Called by the Room immediately after a fire input is processed.
    * Shortens turnEndsAt to +5s so players can reposition (retreat window)

--- a/worker/src/weapons/fire.ts
+++ b/worker/src/weapons/fire.ts
@@ -80,9 +80,7 @@ function fireHitscan(ctx: FireContext): FireResult {
     // Bates-2 (triangular) distribution biases toward center, removing visible
     // outliers. Sum of two uniforms peaks at 0; ~50% of pellets within +/-0.29*spread
     // vs uniform's +/-0.5*spread.
-    const jitter = spread > 0
-      ? ((Math.random() - 0.5) + (Math.random() - 0.5)) * spread
-      : 0;
+    const jitter = spread > 0 ? (Math.random() - 0.5 + (Math.random() - 0.5)) * spread : 0;
     const shotAngle = aimRadians + jitter;
 
     const originPx = {

--- a/worker/src/weapons/fire.ts
+++ b/worker/src/weapons/fire.ts
@@ -77,7 +77,12 @@ function fireHitscan(ctx: FireContext): FireResult {
 
   for (let i = 0; i < shotsAllowed; i++) {
     // Re-jitter angle for each pellet independently.
-    const jitter = spread > 0 ? (Math.random() * 2 - 1) * spread : 0;
+    // Bates-2 (triangular) distribution biases toward center, removing visible
+    // outliers. Sum of two uniforms peaks at 0; ~50% of pellets within +/-0.29*spread
+    // vs uniform's +/-0.5*spread.
+    const jitter = spread > 0
+      ? ((Math.random() - 0.5) + (Math.random() - 0.5)) * spread
+      : 0;
     const shotAngle = aimRadians + jitter;
 
     const originPx = {

--- a/worker/test/fireHitscan.test.ts
+++ b/worker/test/fireHitscan.test.ts
@@ -207,8 +207,9 @@ describe("fireHitscan - minigun (12 pellets, with spread)", () => {
 
     const result = fire(ctx);
 
-    // Math.random must have been called once per pellet (spread > 0).
-    expect(callCount).toBe(12);
+    // Math.random must have been called twice per pellet (Bates-2 triangular
+    // distribution: jitter = (rand - 0.5) + (rand - 0.5)) so 24 calls for 12 pellets.
+    expect(callCount).toBe(24);
     // All 12 hits should be present.
     expect(result.explodeResults).toHaveLength(12);
   });

--- a/worker/test/sim.test.ts
+++ b/worker/test/sim.test.ts
@@ -586,9 +586,10 @@ describe("Simulation - Holy Grenade ammo enforcement", () => {
     expect(r2).not.toBeNull();
     expect(sim.getTeamAmmo("red", "holygrenade")).toBe(0);
 
-    // Third fire: should be rejected (returns null).
+    // Third fire: should be rejected (no ammo remaining).
     const r3 = sim.applyFire("Red-1");
-    expect(r3).toBeNull();
+    expect(r3.ok).toBe(false);
+    expect((r3 as { ok: false; reason: string }).reason).toBe("no_ammo");
     expect(sim.getTeamAmmo("red", "holygrenade")).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

Five weapon-feel fixes batched together.

- **#134** - walk-stop (dir=0) input bypasses the input-lock gate. Worm now halts on button release even after the post-fire retreat window expires (was causing server worm to keep walking after client released).
- **#135 part 1** - keyboard hotkeys 4-7 added in `InputController`. Holy grenade (5), dynamite (4), minigun (6), drill (7) are now selectable via keyboard (radial menu was the only path before).
- **#135 part 2** - server emits `fire_rejected` messages with a reason; client shows a brief floating toast above the active worm ("OUT OF AMMO", "ALREADY FIRED", "NOT YOUR TURN", etc.). Both fixes silent-fail UX and serves as the diagnostic signal for #135 (if "OUT OF AMMO" appears, ammo was the cause).
- **#136** - explosion camera shake duration + intensity now scale with terrain cut radius; added a brief screen-flash overlay (camera-pinned, alpha tween). New `tuning.juice` block exposes `shakeMaxIntensity`, `shakeMinRadiusPx`, `flashMaxAlpha` for tuning. Audio + particles remain out of scope.
- **#139** - minigun pellet jitter switched from uniform `(rand*2-1)*spread` to triangular `((rand-0.5)+(rand-0.5))*spread` (Bates-2). Pellets bias toward center of cone; visible outliers gone. Both server (authoritative) and client (preview) updated.
- **#149** - wind force tuned from 2.0 to 0.8 N/unit. At wind=0.8 lateral acceleration is now ~9 m/s^2 (gravity strength) instead of 23 m/s^2; trajectories curve meaningfully instead of being redirected 180 degrees. Worker keeps the value mirrored inline (worker is intentionally isolated from `src/tuning.ts`).

## Bug Check

Three lenses run (fire-reject integration trace, regression, edge cases).

- Critical: none
- High: none
- Tests: client 278/278, worker 95/95

## Known Issues (non-blocking)

- **[L1] Toast spam stacking** - rapid fire-presses against a locked turn stack floating-text objects. No leak (each destroys via tween) but visually messy. Follow-up if observed in playtest (300ms debounce per reason).
- **[L2] Shake replace-only on chain reactions** - Phaser's `cameras.main.shake` is replace-only; chain explosions in the same frame use the second call's params. Minor cosmetic.

## Files

- `worker/src/room.ts` (#134, #135 toast plumbing)
- `worker/src/sim/simulation.ts` (#135 SimFireResult, #149 wind force)
- `worker/src/turnArbiter.ts` (#135 getHasFiredThisTurn accessor)
- `worker/src/weapons/fire.ts` (#139 Bates-2)
- `worker/test/fireHitscan.test.ts` (#139 test update)
- `worker/test/sim.test.ts` (#135 SimFireResult shape)
- `shared/protocol.ts` (#135 FireRejectedMessage)
- `src/input/InputController.ts` (#135 hotkeys 4-7)
- `src/sim/NetworkedSimAdapter.ts` (#135 fire_rejected listener)
- `src/sim/SimAdapter.ts` (#135 SimEvent union)
- `src/net/types.ts` (#135 type re-export)
- `src/scenes/GameScene.ts` (#135 toast UI, #136 shake/flash)
- `src/tuning.ts` (#136 juice block, #149 wind)
- `src/weapons/fire.ts` (#139 Bates-2 client preview)

Closes #134
Closes #135
Closes #136
Closes #139
Closes #149