### PR TITLE
fix: turn camera UX (#132 #143)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,14 +5,13 @@ import { LobbyScene } from "./scenes/LobbyScene";
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
-  width: 1280,
-  height: 720,
   parent: "game-container",
   backgroundColor: "#0b0b0f",
   scene: [BootScene, LobbyScene, GameScene],
   scale: {
-    mode: Phaser.Scale.FIT,
-    autoCenter: Phaser.Scale.CENTER_BOTH,
+    mode: Phaser.Scale.RESIZE,
+    width: window.innerWidth,
+    height: window.innerHeight,
   },
   dom: {
     createContainer: true,

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -428,6 +428,7 @@ export class GameScene extends Phaser.Scene {
         onActiveWormResolved: (target) => {
           this.cameraFollower?.setActiveWormTarget(target);
         },
+        simAdapter: this.networkedSim ?? undefined,
       });
 
       this.debugGfx = this.add.graphics();

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -42,7 +42,6 @@ type LobbySceneData = LobbySceneDataHome | LobbySceneDataReconnect;
 
 type View = "home" | "room";
 
-
 const TEXT_STYLE_LARGE: Phaser.Types.GameObjects.Text.TextStyle = {
   fontSize: "64px",
   color: "#e0e0e0",

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -42,7 +42,6 @@ type LobbySceneData = LobbySceneDataHome | LobbySceneDataReconnect;
 
 type View = "home" | "room";
 
-const CANVAS_W = 1280;
 
 const TEXT_STYLE_LARGE: Phaser.Types.GameObjects.Text.TextStyle = {
   fontSize: "64px",
@@ -200,7 +199,7 @@ export class LobbyScene extends Phaser.Scene {
     this.clearRoom();
     this.clearHome();
 
-    const cx = CANVAS_W / 2;
+    const cx = this.scale.width / 2;
 
     const title = this.add.text(cx, 120, "WORMS", TEXT_STYLE_LARGE).setOrigin(0.5);
     this.homeObjects.push(title);
@@ -634,13 +633,13 @@ export class LobbyScene extends Phaser.Scene {
       this.lastNormalizedHiddenMapId = null;
     }
 
-    const cx = CANVAS_W / 2;
+    const cx = this.scale.width / 2;
 
     // Header: code + leave button.
     const header = this.add.text(60, 40, `Room: ${state.code}`, TEXT_STYLE_BODY);
     this.roomObjects.push(header);
 
-    const leaveBtn = this.makeButton(CANVAS_W - 120, 50, 160, 50, "Leave", () => {
+    const leaveBtn = this.makeButton(this.scale.width - 120, 50, 160, 50, "Leave", () => {
       void this.handleLeave();
     });
     this.roomObjects.push(...leaveBtn);
@@ -788,7 +787,7 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   private flashRoomError(msg: string): void {
-    const cx = CANVAS_W / 2;
+    const cx = this.scale.width / 2;
     const txt = this.add.text(cx, 680, msg, TEXT_STYLE_ERROR).setOrigin(0.5);
     this.roomObjects.push(txt);
     this.time.delayedCall(3000, () => {
@@ -827,7 +826,7 @@ export class LobbyScene extends Phaser.Scene {
     // in game_started so every client renders pixel-identical terrain.
 
     const loadingText = this.add
-      .text(CANVAS_W / 2, this.scale.height / 2, "Generating world...", {
+      .text(this.scale.width / 2, this.scale.height / 2, "Generating world...", {
         fontSize: "32px",
         color: "#ffffff",
         fontFamily: "system-ui, sans-serif",

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -567,6 +567,19 @@ export class NetworkedSimAdapter implements SimAdapter {
     return this.inputAllowed;
   }
 
+  /**
+   * Return the authoritative position of a worm from the latest server frame.
+   * Reads from `currFrame.state.worms` (server-authoritative), NOT from
+   * `allWorms` (which lags by up to one render tick due to interpolation).
+   * Returns null if no frame has arrived yet or the worm id is not found.
+   */
+  getWormPosition(wormId: string): { xPx: number; yPx: number; alive: boolean } | null {
+    if (!this.currFrame) return null; // pre-first-frame guard
+    const worm = this.currFrame.state.worms.find((w) => w.id === wormId);
+    if (!worm) return null;
+    return { xPx: worm.x, yPx: worm.y, alive: worm.alive };
+  }
+
   private wireRoom(): void {
     const simStateUnsub = this.room.onMessage("sim_state", (msg: SimStateMessage) => {
       this.ingestSimState(msg);

--- a/src/ui/TurnTransition.test.ts
+++ b/src/ui/TurnTransition.test.ts
@@ -56,6 +56,13 @@ function makeMocks() {
   const onTransitioningChanged = vi.fn();
   const resolveFollowTarget = vi.fn((_id: string) => ({ x: 500, y: 300 }));
 
+  // Mock NetworkedSimAdapter with configurable getWormPosition
+  const simAdapter = {
+    getWormPosition: vi.fn(
+      (_id: string): { xPx: number; yPx: number; alive: boolean } | null => null,
+    ),
+  };
+
   function fireStable() {
     for (const sub of stableSubs) sub();
   }
@@ -67,6 +74,7 @@ function makeMocks() {
   return {
     scene,
     sim,
+    simAdapter,
     onTransitioningChanged,
     resolveFollowTarget,
     cameraCalls,
@@ -84,6 +92,7 @@ function makeTurnTransition(mocks: ReturnType<typeof makeMocks>) {
     worldHeightPx: 1024,
     resolveFollowTarget: mocks.resolveFollowTarget as never,
     onTransitioningChanged: mocks.onTransitioningChanged,
+    simAdapter: mocks.simAdapter as never,
   });
 }
 
@@ -239,5 +248,71 @@ describe("TurnTransition", () => {
     expect(tt.isTransitioning()).toBe(false);
     // Stable sub should have been removed
     expect(mocks.stableSubs.length).toBe(0);
+  });
+
+  it("getWormPosition returns valid alive worm -> camera pans to that position (xPx, yPx)", async () => {
+    const mocks = makeMocks();
+    // Sim adapter returns an alive worm at authoritative position (different from sprite)
+    mocks.simAdapter.getWormPosition.mockReturnValue({ xPx: 800, yPx: 600, alive: true });
+    // Sprite position is different to confirm we're reading from sim, not sprite
+    mocks.resolveFollowTarget.mockReturnValue({ x: 500, y: 300 });
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    // ZOOMING_OUT -> HOLDING via pan callback
+    await Promise.resolve();
+
+    // stable + min hold
+    mocks.fireStable();
+    vi.advanceTimersByTime(700);
+
+    // ZOOMING_IN should pan to sim-state position (800, 600), not sprite (500, 300)
+    expect(mocks.cameraCalls).toContain("pan:800,600");
+  });
+
+  it("getWormPosition returns null (pre-first-frame) -> falls back to sprite graphics target", async () => {
+    const mocks = makeMocks();
+    // Sim adapter returns null (no frame yet)
+    mocks.simAdapter.getWormPosition.mockReturnValue(null);
+    // Sprite is at 500, 300
+    mocks.resolveFollowTarget.mockReturnValue({ x: 500, y: 300 });
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    await Promise.resolve();
+
+    mocks.fireStable();
+    vi.advanceTimersByTime(700);
+
+    // Should fall back to sprite position
+    expect(mocks.cameraCalls).toContain("pan:500,300");
+  });
+
+  it("getWormPosition returns alive=false -> skips pan to sim pos, console.warn called", async () => {
+    const mocks = makeMocks();
+    // Sim adapter returns a dead worm
+    mocks.simAdapter.getWormPosition.mockReturnValue({ xPx: 800, yPx: 600, alive: false });
+    // resolveFollowTarget also returns null (no sprite for dead worm)
+    mocks.resolveFollowTarget.mockReturnValue(null);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const tt = makeTurnTransition(mocks);
+
+    tt.begin("red", "red-1");
+
+    await Promise.resolve();
+
+    mocks.fireStable();
+    vi.advanceTimersByTime(700);
+
+    // Should have warned and not panned to sim position
+    expect(mocks.cameraCalls).not.toContain("pan:800,600");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[TurnTransition] cannot resolve pan target",
+      expect.objectContaining({ pendingWormId: "red-1" }),
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/src/ui/TurnTransition.test.ts
+++ b/src/ui/TurnTransition.test.ts
@@ -54,9 +54,10 @@ function makeMocks() {
   };
 
   const onTransitioningChanged = vi.fn();
-  const resolveFollowTarget = vi.fn(
-    (_id: string): { x: number; y: number } | null => ({ x: 500, y: 300 }),
-  );
+  const resolveFollowTarget = vi.fn((_id: string): { x: number; y: number } | null => ({
+    x: 500,
+    y: 300,
+  }));
 
   // Mock NetworkedSimAdapter with configurable getWormPosition
   const simAdapter = {

--- a/src/ui/TurnTransition.test.ts
+++ b/src/ui/TurnTransition.test.ts
@@ -54,7 +54,9 @@ function makeMocks() {
   };
 
   const onTransitioningChanged = vi.fn();
-  const resolveFollowTarget = vi.fn((_id: string) => ({ x: 500, y: 300 }));
+  const resolveFollowTarget = vi.fn(
+    (_id: string): { x: number; y: number } | null => ({ x: 500, y: 300 }),
+  );
 
   // Mock NetworkedSimAdapter with configurable getWormPosition
   const simAdapter = {

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -203,7 +203,7 @@ export class TurnTransition {
     if (this.pendingWormId) {
       // Prefer authoritative sim-state position (not stale sprite graphics).
       const simPos = this.simAdapter?.getWormPosition(this.pendingWormId);
-      if (simPos && simPos.alive) {
+      if (simPos?.alive) {
         panX = simPos.xPx;
         panY = simPos.yPx;
       } else {

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -1,4 +1,5 @@
 import type Phaser from "phaser";
+import type { NetworkedSimAdapter } from "../sim/NetworkedSimAdapter";
 import type { SimAdapter } from "../sim/SimAdapter";
 import { tuning } from "../tuning";
 
@@ -17,6 +18,12 @@ export interface TurnTransitionInit {
    * after a projectile despawns.
    */
   onActiveWormResolved?: (target: Phaser.GameObjects.GameObject | null) => void;
+  /**
+   * Optional reference to the NetworkedSimAdapter so zoom-in can read the
+   * authoritative worm position from the latest server frame instead of
+   * the interpolated sprite position (which lags by up to one render tick).
+   */
+  simAdapter?: NetworkedSimAdapter;
 }
 
 type State = "IDLE" | "ZOOMING_OUT" | "HOLDING" | "ZOOMING_IN";
@@ -41,6 +48,7 @@ export class TurnTransition {
   private readonly onActiveWormResolved:
     | ((target: Phaser.GameObjects.GameObject | null) => void)
     | undefined;
+  private readonly simAdapter: NetworkedSimAdapter | undefined;
   private readonly unsubStable: () => void;
 
   private state: State = "IDLE";
@@ -66,6 +74,7 @@ export class TurnTransition {
     this.resolveFollowTarget = init.resolveFollowTarget;
     this.onTransitioningChanged = init.onTransitioningChanged;
     this.onActiveWormResolved = init.onActiveWormResolved;
+    this.simAdapter = init.simAdapter;
     this.unsubStable = this.sim.onStateStable(() => this.handleStateStable());
   }
 
@@ -187,9 +196,31 @@ export class TurnTransition {
     const gen = this.generation;
 
     const camera = this.scene.cameras.main;
-    const target = this.pendingWormId ? this.resolveFollowTarget(this.pendingWormId) : null;
 
-    if (!target) {
+    let panX: number | null = null;
+    let panY: number | null = null;
+
+    if (this.pendingWormId) {
+      // Prefer authoritative sim-state position (not stale sprite graphics).
+      const simPos = this.simAdapter?.getWormPosition(this.pendingWormId);
+      if (simPos && simPos.alive) {
+        panX = simPos.xPx;
+        panY = simPos.yPx;
+      } else {
+        // Fallback: sprite graphics (may be stale, but better than (0,0))
+        const target = this.resolveFollowTarget(this.pendingWormId);
+        if (target) {
+          const g = target as unknown as { x: number; y: number };
+          panX = g.x;
+          panY = g.y;
+        }
+      }
+    }
+
+    if (panX === null || panY === null) {
+      console.warn("[TurnTransition] cannot resolve pan target", {
+        pendingWormId: this.pendingWormId,
+      });
       // No target - fail gracefully back to idle without a zoom-in.
       camera.zoomTo(1, tuning.camera.turnZoomInMs, "Sine.easeInOut", true);
       this.zoomInDelayed = this.scene.time.delayedCall(tuning.camera.turnZoomInMs, () => {
@@ -199,18 +230,21 @@ export class TurnTransition {
       return;
     }
 
-    // target is a Phaser GameObject with x/y we can read
-    const g = target as unknown as { x: number; y: number };
+    // Resolve the follow target (sprite) for startFollow at zoom-in completion.
+    // This may be null in networked mode when the sim adapter provided the position
+    // but the sprite isn't ready - finishToIdle handles a null follow target gracefully.
+    const followTarget = this.pendingWormId ? this.resolveFollowTarget(this.pendingWormId) : null;
+
     camera.zoomTo(1, tuning.camera.turnZoomInMs, "Sine.easeInOut", true);
     camera.pan(
-      g.x,
-      g.y,
+      panX,
+      panY,
       tuning.camera.turnZoomInMs,
       "Sine.easeInOut",
       true,
       (_c: Phaser.Cameras.Scene2D.Camera, progress: number) => {
         if (progress >= 1 && this.state === "ZOOMING_IN" && gen === this.generation) {
-          this.finishToIdle(target);
+          this.finishToIdle(followTarget);
         }
       },
     );

--- a/src/ui/TurnTransition.ts
+++ b/src/ui/TurnTransition.ts
@@ -147,7 +147,7 @@ export class TurnTransition {
   private computeFitZoom(): number {
     const vw = this.scene.scale.width;
     const vh = this.scene.scale.height;
-    return Math.min(vw / this.worldWidthPx, vh / this.worldHeightPx);
+    return Math.max(vw / this.worldWidthPx, vh / this.worldHeightPx);
   }
 
   private enterHolding(): void {


### PR DESCRIPTION
## Summary

Two camera/UI fixes batched together.

- **#132** - Phaser scale config switched from `Phaser.Scale.FIT` (fixed 1280x720) to `Phaser.Scale.RESIZE` so the canvas fills the viewport on any aspect ratio (iPhone 16 Pro 19.5:9 etc.). Wide phones no longer show gray pillarbox bars. World stays 2560x1024 (already decoupled from canvas). Also: `computeFitZoom` in TurnTransition switched from `Math.min` to `Math.max` so the brief zoom-out animation over-covers the viewport rather than leaving a black sliver on certain aspects.
- **#143** - Turn-transition zoom-in now reads worm position from the authoritative server frame (`NetworkedSimAdapter.getWormPosition` reads `currFrame.state.worms`) instead of from sprite graphics (which lag by up to one render tick due to interpolation). Falls back to sprite if sim position is null (pre-first-frame), and skips pan + logs `console.warn` if the worm is dead or unresolvable. New 3 test cases cover alive/null/dead paths.

## Closes
- Closes #132
- Closes #143

## Bug Check
- Critical: none
- High: none
- Tests: client 282/282, worker 95/95

## Manual viewport checklist (please verify before / after deploy)
- [ ] iPhone 16 Pro landscape (Chrome devtools mobile emulation): canvas fills viewport, no gray bars
- [ ] iPad landscape: still works, no regression
- [ ] Desktop 1920x1080: still works
- [ ] Multi-turn playtest: zoom-in consistently lands on the active worm, not random map area

## Known follow-up (not blocking)

HUD components (`TurnHUD`, `WindHUD`, `UtilityDPad`, `WeaponRadial`, `SpectatorHUD`, `ReconnectingOverlay`) compute their positions in their constructors and don't relayout on `scale.resize` events. CLAUDE.md notes the game is landscape-locked, so mid-game rotation can't fire resize. Edge cases (iOS Safari URL bar showing/hiding, mobile soft keyboard, desktop window resize) may leave HUDs at stale positions. Will file a separate `enhancement` issue to extract `layout()` methods and subscribe to `scene.scale.on("resize", ...)`.