### PR TITLE
feat: jetpack radial vector-thrust input (#91)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -328,5 +328,6 @@ export type ClientMsg =
   | { type: "input_jetpack_toggle"; seq: number }
   | { type: "input_jetpack_thrust"; active: boolean; seq: number }
   | { type: "input_jetpack_horizontal"; dir: -1 | 0 | 1; seq: number }
+  | { type: "input_jetpack_vector"; vx: number; vy: number }
   | { type: "leave" }
   | { type: "client_log"; scope: string; event: string; data?: unknown; ts: number };

--- a/src/input/touchGestures.test.ts
+++ b/src/input/touchGestures.test.ts
@@ -16,6 +16,7 @@ function mkInput(overrides: Partial<GestureInput> = {}): GestureInput {
     myTurn: true,
     utilityActive: false,
     wormHitRadiusPx: 40,
+    jetpackRadialDeadZonePx: 50,
     doubleTapMaxMs: 250,
     longPressMs: 400,
     ...overrides,
@@ -120,10 +121,35 @@ describe("touchGestures state machine", () => {
     expect(up).toEqual([]);
   });
 
-  it("utility active off-worm returns ignored", () => {
+  it("utility active off-worm outside dead zone emits utility_thrust_start", () => {
     const t = createGestureTracker();
-    const down = t.processDown(mkInput({ downXPx: 200, utilityActive: true }));
+    // downXPx=200, wormXPx=640, wormYPx=400, downYPx=360 -> dx=440, dy=40 -> len~441
+    // len > jetpackRadialDeadZonePx (50), so thrust fires.
+    const down = t.processDown(
+      mkInput({ downXPx: 200, utilityActive: true, jetpackRadialDeadZonePx: 50 }),
+    );
+    expect(down).toHaveLength(1);
+    expect(down[0].kind).toBe("utility_thrust_start");
+    const o = down[0] as { kind: "utility_thrust_start"; nx: number; ny: number };
+    // nx/ny should be a unit vector; magnitude must be ~1.
+    expect(Math.hypot(o.nx, o.ny)).toBeCloseTo(1, 5);
+  });
+
+  it("utility active off-worm inside dead zone returns ignored", () => {
+    const t = createGestureTracker();
+    // downXPx=650, wormXPx=640, wormYPx=400, downYPx=360 -> dx=10,dy=40 -> len~41
+    // 41 < jetpackRadialDeadZonePx (50), so ignored.
+    const down = t.processDown(
+      mkInput({ downXPx: 650, downYPx: 356, utilityActive: true, jetpackRadialDeadZonePx: 50 }),
+    );
     expect(down).toEqual([{ kind: "ignored" }]);
+  });
+
+  it("utility_thrust_end emitted on pointerup after thrust start", () => {
+    const t = createGestureTracker();
+    t.processDown(mkInput({ downXPx: 200, utilityActive: true, jetpackRadialDeadZonePx: 50 }));
+    const up = t.processUp(1100);
+    expect(up).toEqual([{ kind: "utility_thrust_end" }]);
   });
 
   it("utility active ON worm still enters aim mode", () => {

--- a/src/input/touchGestures.ts
+++ b/src/input/touchGestures.ts
@@ -30,6 +30,9 @@ export type GestureOutcome =
   | { kind: "aim_start"; xPx: number; yPx: number }
   | { kind: "aim_move"; xPx: number; yPx: number }
   | { kind: "aim_end" }
+  | { kind: "utility_thrust_start"; nx: number; ny: number }
+  | { kind: "utility_thrust_move"; nx: number; ny: number }
+  | { kind: "utility_thrust_end" }
   | { kind: "ignored" };
 
 /**
@@ -47,12 +50,13 @@ export interface GestureInput {
   myTurn: boolean;
   utilityActive: boolean;
   wormHitRadiusPx: number;
+  jetpackRadialDeadZonePx: number;
   doubleTapMaxMs: number;
   longPressMs: number;
 }
 
-/** Internal gesture modes. Mirrors the plan: idle / aim / walk. */
-type Mode = "idle" | "aim" | "walk";
+/** Internal gesture modes. Mirrors the plan: idle / aim / walk / utility_thrust. */
+type Mode = "idle" | "aim" | "walk" | "utility_thrust";
 
 /**
  * Factory for a fresh tracker. Holds state across gestures (for double-tap
@@ -71,6 +75,10 @@ export function createGestureTracker(): {
   // Set on processDown when this gesture is the 2nd half of a double-tap so
   // processUp knows to emit "jump" instead of "walk_release".
   let pendingDoubleTap = false;
+  // Worm position captured on processDown for utility_thrust recomputation
+  // in processMove (pointer coords change but worm position stays stable).
+  let thrustWormXPx = 0;
+  let thrustWormYPx = 0;
 
   return {
     processDown(input: GestureInput): GestureOutcome[] {
@@ -96,9 +104,19 @@ export function createGestureTracker(): {
         return [{ kind: "aim_start", xPx: input.downXPx, yPx: input.downYPx }];
       }
 
-      // Utility active + not on worm -> ignore (the d-pad takes over walking).
+      // Utility active + not on worm -> radial thrust gesture.
+      // Vector from click to worm = thrust direction (inverted: "aim away
+      // from click" so tapping left of worm thrusts right, like aiming).
       if (input.utilityActive) {
-        return [{ kind: "ignored" }];
+        if (input.wormXPx === null || input.wormYPx === null) return [{ kind: "ignored" }];
+        const dx = input.wormXPx - input.downXPx;
+        const dy = input.wormYPx - input.downYPx;
+        const len = Math.hypot(dx, dy);
+        if (len < input.jetpackRadialDeadZonePx) return [{ kind: "ignored" }];
+        mode = "utility_thrust";
+        thrustWormXPx = input.wormXPx;
+        thrustWormYPx = input.wormYPx;
+        return [{ kind: "utility_thrust_start", nx: dx / len, ny: dy / len }];
       }
 
       // Off-worm, my turn, no utility -> WALK mode.
@@ -122,6 +140,16 @@ export function createGestureTracker(): {
       if (mode === "aim") {
         return [{ kind: "aim_move", xPx, yPx }];
       }
+      if (mode === "utility_thrust") {
+        // Recompute thrust vector from current pointer position.
+        // We need the worm position but processMove doesn't carry it -
+        // store it from the processDown call via closure.
+        const dx = thrustWormXPx - xPx;
+        const dy = thrustWormYPx - yPx;
+        const len = Math.hypot(dx, dy);
+        if (len < 1) return [];
+        return [{ kind: "utility_thrust_move", nx: dx / len, ny: dy / len }];
+      }
       // WALK mode ignores movement: the walk continues held until release.
       // IDLE mode shouldn't receive moves (caller gates on activeGesture).
       return [];
@@ -139,6 +167,10 @@ export function createGestureTracker(): {
 
       if (currentMode === "aim") {
         return [{ kind: "aim_end" }];
+      }
+
+      if (currentMode === "utility_thrust") {
+        return [{ kind: "utility_thrust_end" }];
       }
 
       if (currentMode === "walk" && (side === -1 || side === 1)) {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -97,7 +97,7 @@ export class GameScene extends Phaser.Scene {
    * - "walk": tap-hold on a screen half, walking left/right
    * - null: no pointer is being tracked
    */
-  private activeGestureKind: "aim" | "walk" | null = null;
+  private activeGestureKind: "aim" | "walk" | "utility_thrust" | null = null;
   /** Pointer id that opened the active gesture. Only this id's move/up events
    * are honored; other pointers (multi-touch) are routed to their own buttons. */
   private activePointerId: number | null = null;
@@ -1039,6 +1039,7 @@ export class GameScene extends Phaser.Scene {
       if (this.turnHUD.hitsButton(p)) return;
       if (this.touchControls.hitsButton(p)) return;
       if (this.weaponRadial?.hitsRadial(p)) return;
+      if (this.utilityDPad?.hitsButton(p)) return;
       // Already tracking a gesture on a different pointer: ignore. Multi-touch
       // secondary fingers should route to buttons (above), not the gesture layer.
       if (this.activePointerId !== null) return;
@@ -1060,6 +1061,7 @@ export class GameScene extends Phaser.Scene {
         myTurn,
         utilityActive,
         wormHitRadiusPx: tuning.touch.wormHitRadiusPx,
+        jetpackRadialDeadZonePx: tuning.touch.jetpackRadialDeadZonePx,
         doubleTapMaxMs: tuning.touch.doubleTapMaxMs,
         longPressMs: tuning.touch.longPressMs,
       };
@@ -1077,6 +1079,10 @@ export class GameScene extends Phaser.Scene {
           // walk message directly.
           this.sim.setFacing(o.dir);
           this.sim.walk(o.dir);
+        } else if (o.kind === "utility_thrust_start") {
+          this.activeGestureKind = "utility_thrust";
+          this.activePointerId = p.id;
+          this.sim.setJetPackThrustVector(o.nx, o.ny);
         }
         // "ignored": no-op. pointermove / pointerup for this pointer won't
         // match activePointerId (null), so they short-circuit.
@@ -1085,6 +1091,15 @@ export class GameScene extends Phaser.Scene {
 
     this.input.on("pointermove", (p: Phaser.Input.Pointer) => {
       if (p.id !== this.activePointerId) return;
+      if (this.activeGestureKind === "utility_thrust") {
+        const moves = this.gestureTracker.processMove(p.worldX, p.worldY);
+        for (const m of moves) {
+          if (m.kind === "utility_thrust_move") {
+            this.sim.setJetPackThrustVector(m.nx, m.ny);
+          }
+        }
+        return;
+      }
       if (this.activeGestureKind !== "aim") return;
       const worm = this.getActiveWormAdapter();
       if (!worm || !this.isInputAllowed()) return;
@@ -1134,6 +1149,8 @@ export class GameScene extends Phaser.Scene {
           this.sim.jump();
         } else if (o.kind === "backflip") {
           this.sim.backflip();
+        } else if (o.kind === "utility_thrust_end") {
+          this.sim.setJetPackThrustVector(0, 0);
         }
       }
       void gestureKind; // retained for future metrics / debug.

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -119,6 +119,9 @@ export class NetworkedSimAdapter implements SimAdapter {
   private lastJetThrustV: boolean | null = null;
   /** Cache last jetpack horizontal dir for the same reason. */
   private lastJetThrustH: -1 | 0 | 1 | null = null;
+  /** Cache last jetpack vector for dedup. */
+  private lastJetVx: number | null = null;
+  private lastJetVy: number | null = null;
 
   constructor(init: NetworkedSimAdapterInit) {
     dlogUnthrottled("sim", "NetworkedSimAdapter.constructing", {
@@ -298,6 +301,13 @@ export class NetworkedSimAdapter implements SimAdapter {
     if (dir === this.lastJetThrustH) return;
     this.lastJetThrustH = dir;
     this.send({ type: "input_jetpack_horizontal", dir, seq: this.nextSeq() });
+  }
+
+  setJetPackThrustVector(vx: number, vy: number): void {
+    if (vx === this.lastJetVx && vy === this.lastJetVy) return;
+    this.lastJetVx = vx;
+    this.lastJetVy = vy;
+    this.send({ type: "input_jetpack_vector", vx, vy });
   }
 
   isJetPacking(): boolean {

--- a/src/sim/OfflineSimAdapter.test.ts
+++ b/src/sim/OfflineSimAdapter.test.ts
@@ -46,6 +46,7 @@ describe("OfflineSimAdapter (type contract)", () => {
       "endTurn",
       "toggleRope",
       "toggleJetPack",
+      "setJetPackThrustVector",
       "update",
       "destroy",
       "onEvent",

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -347,6 +347,10 @@ export class OfflineSimAdapter implements SimAdapter {
     this.turnManager.getActiveWorm()?.jetPackUtility?.setHorizontalInput(dir);
   }
 
+  setJetPackThrustVector(vx: number, vy: number): void {
+    this.turnManager.getActiveWorm()?.jetPackUtility?.setThrustVector(vx, vy);
+  }
+
   isJetPacking(): boolean {
     return this.turnManager.getActiveWorm()?.isJetPacking() ?? false;
   }

--- a/src/sim/SimAdapter.ts
+++ b/src/sim/SimAdapter.ts
@@ -96,6 +96,8 @@ export interface SimAdapter {
   toggleJetPack(): void;
   setJetPackThrust(active: boolean): void;
   setJetPackHorizontal(dir: -1 | 0 | 1): void;
+  /** Continuous 2D thrust vector API. vx: -1=left, +1=right. vy: -1=up, +1=down (Y-down). */
+  setJetPackThrustVector(vx: number, vy: number): void;
   isJetPacking(): boolean;
   /** Current jetpack fuel level, 0..100. */
   getJetPackFuel(): number;

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -68,6 +68,11 @@ interface Tuning {
     /** Radius around the active worm (in pixels) where a pointerdown is
      * treated as aim-intent instead of walk-intent. */
     wormHitRadiusPx: number;
+    /** Min distance from the click point to the worm (in pixels) required
+     * for a utility-active off-worm drag to register as a jetpack thrust.
+     * Must be > wormHitRadiusPx (40) so the on-worm zone resolves to AIM,
+     * not thrust. */
+    jetpackRadialDeadZonePx: number;
     /** Max ms between two walk-side taps for the second to count as a
      * double-tap (-> jump). */
     doubleTapMaxMs: number;
@@ -160,6 +165,7 @@ export const tuning: Tuning = {
     buttonIdleAlpha: 0.55,
     buttonPressedAlpha: 1.0,
     wormHitRadiusPx: 40,
+    jetpackRadialDeadZonePx: 50,
     doubleTapMaxMs: 250,
     longPressMs: 400,
   },

--- a/src/ui/UtilityDPad.ts
+++ b/src/ui/UtilityDPad.ts
@@ -83,6 +83,21 @@ export class UtilityDPad {
     }
   }
 
+  /** Returns true if the pointer is over any of the d-pad buttons.
+   * GameScene uses this to gate the gesture layer so d-pad taps don't
+   * double-fire as utility_thrust gestures. */
+  hitsButton(pointer: Phaser.Input.Pointer): boolean {
+    if (!this.container.visible) return false;
+    const hits = this.scene.input.hitTestPointer(pointer);
+    return hits.some(
+      (obj) =>
+        obj === this.leftBtn ||
+        obj === this.rightBtn ||
+        obj === this.upBtn ||
+        obj === this.downBtn,
+    );
+  }
+
   show(): void {
     this.container.setVisible(true);
     // Re-enable hit-testing on each button; setInteractive() is a no-op

--- a/src/ui/UtilityDPad.ts
+++ b/src/ui/UtilityDPad.ts
@@ -91,10 +91,7 @@ export class UtilityDPad {
     const hits = this.scene.input.hitTestPointer(pointer);
     return hits.some(
       (obj) =>
-        obj === this.leftBtn ||
-        obj === this.rightBtn ||
-        obj === this.upBtn ||
-        obj === this.downBtn,
+        obj === this.leftBtn || obj === this.rightBtn || obj === this.upBtn || obj === this.downBtn,
     );
   }
 

--- a/src/utilities/JetPack.ts
+++ b/src/utilities/JetPack.ts
@@ -110,12 +110,9 @@ export class JetPack implements Utility {
    */
   setThrustVector(nx: number, ny: number): void {
     const len = Math.hypot(nx, ny);
-    if (len > 1) {
-      nx /= len;
-      ny /= len;
-    }
-    this.thrustVx = nx;
-    this.thrustVy = ny;
+    const scale = len > 1 ? 1 / len : 1;
+    this.thrustVx = nx * scale;
+    this.thrustVy = ny * scale;
   }
 
   /**

--- a/src/utilities/JetPack.ts
+++ b/src/utilities/JetPack.ts
@@ -14,8 +14,8 @@ export class JetPack implements Utility {
   private _active = false;
   private _fuel: number;
   private readonly flameGfx: Phaser.GameObjects.Graphics;
-  private thrustH: -1 | 0 | 1 = 0; // horizontal from InputController
-  private thrustUp = false; // vertical from InputController
+  thrustVx = 0; // continuous horizontal thrust: -1=left, +1=right
+  thrustVy = 0; // continuous vertical thrust: -1=up, +1=down (Phaser Y-down)
 
   constructor(init: JetPackInit) {
     this.worm = init.worm;
@@ -79,9 +79,9 @@ export class JetPack implements Utility {
 
     // Build force vector - use applyForce (continuous acceleration, dt-integrated by solver)
     // not applyLinearImpulse (instant velocity kick that stacks every frame at 60fps).
-    // Negative Y = upward in planck (y-down coordinate system)
-    const fx = this.thrustH * tuning.jetpack.sideForce;
-    const fy = this.thrustUp ? -tuning.jetpack.upwardForce : 0;
+    // Negative vy = thrust up in planck (y-down coordinate system).
+    const fx = this.thrustVx * tuning.jetpack.sideForce;
+    const fy = this.thrustVy * tuning.jetpack.upwardForce;
 
     if (fx !== 0 || fy !== 0) {
       this.worm.body.applyForce({ x: fx, y: fy }, this.worm.body.getPosition(), true);
@@ -95,8 +95,8 @@ export class JetPack implements Utility {
     }
 
     // Update facing direction when thrusting sideways
-    if (this.thrustH !== 0) {
-      this.worm.setFacing(this.thrustH as -1 | 1);
+    if (this.thrustVx !== 0) {
+      this.worm.setFacing(this.thrustVx > 0 ? 1 : -1);
     }
 
     // Draw flame (small orange triangle below worm)
@@ -104,18 +104,34 @@ export class JetPack implements Utility {
   }
 
   /**
-   * Called by InputController: horizontal thrust direction.
-   * -1 = left, 0 = none, 1 = right.
+   * Set continuous 2D thrust vector. Magnitude is clamped to <= 1 so
+   * diagonal presses (e.g. W+D) don't exceed full-power thrust.
+   * vx: -1=left, +1=right. vy: -1=up, +1=down (Phaser Y-down).
    */
-  setHorizontalInput(direction: -1 | 0 | 1): void {
-    this.thrustH = direction;
+  setThrustVector(nx: number, ny: number): void {
+    const len = Math.hypot(nx, ny);
+    if (len > 1) {
+      nx /= len;
+      ny /= len;
+    }
+    this.thrustVx = nx;
+    this.thrustVy = ny;
   }
 
   /**
-   * Called by InputController: whether upward thrust is pressed.
+   * Back-compat wrapper for InputController keyboard path.
+   * Preserves the current vy so W (up) + D (right) both work simultaneously.
+   */
+  setHorizontalInput(h: -1 | 0 | 1): void {
+    this.setThrustVector(h, this.thrustVy);
+  }
+
+  /**
+   * Back-compat wrapper for InputController keyboard path.
+   * Preserves the current vx so W (up) + D (right) both work simultaneously.
    */
   setVerticalInput(up: boolean): void {
-    this.thrustUp = up;
+    this.setThrustVector(this.thrustVx, up ? -1 : 0);
   }
 
   /** Clean up graphics. Called when worm is destroyed. */
@@ -138,15 +154,15 @@ export class JetPack implements Utility {
 
     this.flameGfx.clear();
 
-    // Bottom flame when thrusting up
-    if (this.thrustUp) {
+    // Bottom flame when thrusting up (vy < 0 in Y-down)
+    if (this.thrustVy < 0) {
       this.flameGfx.fillStyle(0xff6600, 0.85);
       this.flameGfx.fillTriangle(cx - 5, cy + r + 2, cx + 5, cy + r + 2, cx, cy + r + 14);
     }
 
     // Side flame when thrusting horizontally
-    if (this.thrustH !== 0) {
-      const sx = this.thrustH * -1; // flame points opposite to movement
+    if (this.thrustVx !== 0) {
+      const sx = this.thrustVx > 0 ? -1 : 1; // flame points opposite to movement
       this.flameGfx.fillStyle(0xff8800, 0.75);
       this.flameGfx.fillTriangle(cx + sx * r, cy - 4, cx + sx * r, cy + 4, cx + sx * (r + 10), cy);
     }

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -99,6 +99,11 @@ export class Worm {
   jetPackFuel = 100;
   jetPackThrustV = false;
   jetPackThrustH: -1 | 0 | 1 = 0;
+  // Continuous 2D vector thrust (new API). vx: -1=left, +1=right; vy: -1=up, +1=down.
+  // When setJetPackThrustVector is called these override the discrete fields in applyJetPackForce.
+  jetPackThrustVx = 0;
+  jetPackThrustVy = 0;
+  private _useVectorThrust = false;
 
   constructor(init: WormInit) {
     this.id = init.id;
@@ -210,6 +215,9 @@ export class Worm {
       this.jetPackActive = false;
       this.jetPackThrustV = false;
       this.jetPackThrustH = 0;
+      this.jetPackThrustVx = 0;
+      this.jetPackThrustVy = 0;
+      this._useVectorThrust = false;
     } else {
       if (this.jetPackFuel <= 0) return;
       this.jetPackActive = true;
@@ -222,6 +230,22 @@ export class Worm {
 
   setJetPackHorizontal(dir: -1 | 0 | 1): void {
     this.jetPackThrustH = dir;
+    this._useVectorThrust = false;
+  }
+
+  /**
+   * Continuous 2D thrust vector. vx: -1=left, +1=right; vy: -1=up, +1=down.
+   * Magnitude clamped to <= 1 on the client before sending; server also clamps defensively.
+   */
+  setJetPackThrustVector(vx: number, vy: number): void {
+    const len = Math.hypot(vx, vy);
+    if (len > 1) {
+      vx /= len;
+      vy /= len;
+    }
+    this.jetPackThrustVx = vx;
+    this.jetPackThrustVy = vy;
+    this._useVectorThrust = true;
   }
 
   /**
@@ -235,6 +259,9 @@ export class Worm {
       this.jetPackActive = false;
       this.jetPackThrustV = false;
       this.jetPackThrustH = 0;
+      this.jetPackThrustVx = 0;
+      this.jetPackThrustVy = 0;
+      this._useVectorThrust = false;
       return;
     }
 
@@ -243,8 +270,15 @@ export class Worm {
     const SIDE_FORCE = 8;
     const FUEL_PER_SECOND = 30; // percent per second
 
-    const fx = this.jetPackThrustH * SIDE_FORCE;
-    const fy = this.jetPackThrustV ? -UP_FORCE : 0;
+    let fx: number;
+    let fy: number;
+    if (this._useVectorThrust) {
+      fx = this.jetPackThrustVx * SIDE_FORCE;
+      fy = this.jetPackThrustVy * UP_FORCE;
+    } else {
+      fx = this.jetPackThrustH * SIDE_FORCE;
+      fy = this.jetPackThrustV ? -UP_FORCE : 0;
+    }
 
     if (fx !== 0 || fy !== 0) {
       this.body.applyForce({ x: fx, y: fy }, this.body.getPosition(), true);
@@ -256,6 +290,9 @@ export class Worm {
       this.jetPackActive = false;
       this.jetPackThrustV = false;
       this.jetPackThrustH = 0;
+      this.jetPackThrustVx = 0;
+      this.jetPackThrustVy = 0;
+      this._useVectorThrust = false;
     }
   }
 
@@ -265,6 +302,9 @@ export class Worm {
     this.jetPackFuel = 100;
     this.jetPackThrustV = false;
     this.jetPackThrustH = 0;
+    this.jetPackThrustVx = 0;
+    this.jetPackThrustVy = 0;
+    this._useVectorThrust = false;
   }
 
   // ---- Health ----
@@ -290,6 +330,9 @@ export class Worm {
     this.jetPackActive = false;
     this.jetPackThrustV = false;
     this.jetPackThrustH = 0;
+    this.jetPackThrustVx = 0;
+    this.jetPackThrustVy = 0;
+    this._useVectorThrust = false;
   }
 
   // ---- Foot contact ----

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -239,12 +239,9 @@ export class Worm {
    */
   setJetPackThrustVector(vx: number, vy: number): void {
     const len = Math.hypot(vx, vy);
-    if (len > 1) {
-      vx /= len;
-      vy /= len;
-    }
-    this.jetPackThrustVx = vx;
-    this.jetPackThrustVy = vy;
+    const scale = len > 1 ? 1 / len : 1;
+    this.jetPackThrustVx = vx * scale;
+    this.jetPackThrustVy = vy * scale;
     this._useVectorThrust = true;
   }
 

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -107,7 +107,8 @@ type PendingInput =
   | { kind: "fire"; sessionId: string }
   | { kind: "jetpack_toggle"; sessionId: string }
   | { kind: "jetpack_thrust"; sessionId: string; active: boolean }
-  | { kind: "jetpack_horizontal"; sessionId: string; dir: -1 | 0 | 1 };
+  | { kind: "jetpack_horizontal"; sessionId: string; dir: -1 | 0 | 1 }
+  | { kind: "jetpack_vector"; sessionId: string; vx: number; vy: number };
 
 /** Sim-kickoff metadata persisted so hibernation can rebuild. */
 interface SimBootstrap {
@@ -480,6 +481,7 @@ export class Room implements DurableObject {
       case "input_jetpack_toggle":
       case "input_jetpack_thrust":
       case "input_jetpack_horizontal":
+      case "input_jetpack_vector":
         this.queueInput(attachment.sessionId, type, msg);
         break;
       case "client_log":
@@ -1037,6 +1039,14 @@ export class Room implements DurableObject {
         this.pendingInputs.push({ kind: "jetpack_horizontal", sessionId: senderSessionId, dir });
         return;
       }
+      case "input_jetpack_vector": {
+        const vx = raw.vx;
+        const vy = raw.vy;
+        if (typeof vx !== "number" || typeof vy !== "number") return;
+        if (vx < -1 || vx > 1 || vy < -1 || vy > 1) return;
+        this.pendingInputs.push({ kind: "jetpack_vector", sessionId: senderSessionId, vx, vy });
+        return;
+      }
       case "input_end_turn":
         // Explicit end-turn press from the active player. Force-advance
         // via the arbiter (validates ownership + pause state). Without
@@ -1129,6 +1139,9 @@ export class Room implements DurableObject {
           break;
         case "jetpack_horizontal":
           this.sim.applyJetPackHorizontal(activeWormId, input.dir);
+          break;
+        case "jetpack_vector":
+          this.sim.applyJetPackVector(activeWormId, input.vx, input.vy);
           break;
       }
     }

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -315,6 +315,10 @@ export class Simulation {
     this.worms.get(wormId)?.setJetPackHorizontal(dir);
   }
 
+  applyJetPackVector(wormId: string, vx: number, vy: number): void {
+    this.worms.get(wormId)?.setJetPackThrustVector(vx, vy);
+  }
+
   /** Reset utility state when a new turn starts for the given worm. */
   resetUtilitiesForTurnStart(wormId: string): void {
     this.worms.get(wormId)?.resetUtilitiesForTurnStart();


### PR DESCRIPTION
## Summary

Adds a vector-thrust touch input model for jetpack, replacing the discrete-direction touch input. Press 'J' to activate jetpack; touch/click anywhere off the worm; vector from CLICK to WORM is the thrust direction (worm goes opposite of click - "inverted like aiming"). Continuous-hold: while pointer is down, the thrust vector recomputes on each move. Release stops thrust immediately.

Two layers of changes:

### Vector API + network protocol
- `src/utilities/JetPack.ts` (client offline) and `worker/src/entities/worm.ts` (server) now have a `setThrustVector(vx, vy)` method that takes a 2D vector clamped to magnitude ≤ 1
- Existing keyboard `setHorizontalInput(-1|0|1)` and `setVerticalInput(boolean)` are preserved as thin wrappers that call `setThrustVector` internally - keyboard W/A/D feels effectively unchanged (slight diagonal nerf when pressing W+D simultaneously: vector clamps to mag 1 instead of sqrt(2), intentional for consistency with touch)
- New wire message `input_jetpack_vector { vx, vy }` in `shared/protocol.ts` with server-side validation (range + type check)
- `SimAdapter.setJetPackThrustVector` plumbed through both `OfflineSimAdapter` and `NetworkedSimAdapter`

### Touch radial gesture
- New `utility_thrust` mode in `src/input/touchGestures.ts`. When jetpack is active, off-worm touches enter this mode (replacing the previous "ignored" gate)
- Vector is `worm - pointer` (so worm thrusts AWAY from where you click - opposite of click position, like aim drag)
- Dead zone: `tuning.touch.jetpackRadialDeadZonePx = 50` (just outside `wormHitRadiusPx = 40`) so the worm-tap zone goes to AIM mode, not feeble thrust
- Stable thrust direction during hold: worm position is captured at touchdown so as the worm moves, thrust direction stays anchored to the original frame instead of chasing/oscillating
- `UtilityDPad.hitsButton(p)` added to `GameScene` hit-test guard chain so legacy d-pad button taps don't double-fire as `utility_thrust` (resolves a BLOCKING input fight flagged in adversarial review)

### L/R touch movement (no change)
Discovered during recon that L/R touch movement was already worm-centric (`touchGestures.ts:127`). No code change needed there - but worth confirming in playtest that it feels right.

## Closes
- Closes #91

## Bug Check
- Critical: none (one false-positive flag was investigated and dismissed - the "inverted" sign convention is intentional, matching the user's "like aiming" requirement)
- High: none
- Tests: client 284/284, worker 95/95

## Manual playtest checklist

- [ ] Press J to activate jetpack. Tap below worm → worm thrusts UP. Tap right of worm → worm thrusts LEFT. Tap above-left → worm thrusts down-right.
- [ ] Hold finger down → continuous thrust. Drag finger to a new position → thrust direction updates live (relative to original worm position at touchdown).
- [ ] Release pointer → thrust stops immediately.
- [ ] Tap the legacy UtilityDPad d-pad buttons → discrete control still works (alternate input).
- [ ] Keyboard W/A/D in jetpack mode → effectively unchanged feel (slight nerf on diagonals is acceptable).
- [ ] Multiplayer: same behavior on a hosted match (`mccarrison.me/worms`). Server validates vector ranges.