### PR TITLE
docs: world-gen philosophy + worms design consensus

### DIFF
--- a/docs/guides/world-gen-design.md
+++ b/docs/guides/world-gen-design.md
@@ -1,0 +1,188 @@
+# World Generation Design
+
+This document is the worms-specific translation of `world-gen-philosophy.md`. Read it side by side with the bible. The bible describes what Terraria does and why. This doc describes what we believe and what we will build, derived from the bible but adapted for our domain.
+
+Sections are keyed one-to-one with the bible's sections. We work through them in order, building consensus per section, before any technical implementation begins.
+
+---
+
+## 1. World as history
+
+**Consensus:** we accept the bible's framing wholesale. A generated world is a history played forward, not a snapshot. The seed is a starting condition. The pass list is the rules. The output is the present moment of a world that has lived through every pass. Every artifact has a cause in an earlier pass; nothing is magic.
+
+**Scope clarification.** This concern ends at t=0. What is done with the generated world - terraforming via weapons, mid-match terrain mutation, player-driven changes - is explicitly out of scope here. That belongs to the object-world interaction philosophy, deferred to worms#161. The bible never talks about post-gen behavior because post-gen behavior is a different bible. We hold that line.
+
+**The mental model we are committing to: "isolated but highly dependent."** Each pass is single-responsibility. It owns one rule about one thing and does not call other passes. But every pass after the first reads what previous passes wrote into shared world state. A weird world is the result of one wonky pass corrupting the substrate that subsequent passes built on. Both properties must hold simultaneously - isolation alone gives you incoherent worlds, dependency alone gives you tangled spaghetti. The discipline is to enforce both.
+
+**Provisional on technical feasibility.** If implementation reveals some aspect of this framing is too heavy for our performance budget (mobile-web 60fps, ~400KB bundle) or impossible on our stack (Phaser + planck + Colyseus), we revisit. Until then this is the foundation.
+
+---
+
+## 2. Shape: a flat ordered named list
+
+**Consensus:** the world-gen pipeline is a flat ordered list of named passes. Not a tree, not a graph, not a declarative rule config. Same shape Terraria ships, for the same reasons:
+
+- Easy logic for coding. A pipeline is a `for` loop over an array.
+- Easy logic for debugging. You read top to bottom and know exactly what happens, in what order.
+- Clear path. The order itself is the design surface; nothing is hidden in nested structure.
+
+**Length is honest, not target.** Terraria's ~107 passes is honest for Terraria's scope. Ours will likely be shorter (one-screen-ish maps, fewer biomes, no civilization layer) - probably in the 15-30 range to start. We do not artificially compress passes to hit a low number, and we do not pad to hit a high one. If a job deserves its own pass, it gets its own pass.
+
+**Naming discipline.** Each pass name answers "what does this pass do" in a few words. Vague names ("GenerateStuff", "DoTerrainPhase") are a smell that should trigger splitting the pass into named sub-passes. Terraria's "Mount Caves" / "Spreading Grass" / "Final Cleanup" set the bar.
+
+**Additive growth model.** When we want to expand the world - add a new biome, a new feature, a new theme - we add another pass to the flat list. We do not refactor the architecture, we do not introduce nesting, we do not touch other passes. The pipeline is open to extension by appending. This is the long-term win of flat-list shape over any hierarchical alternative.
+
+> **Note for technical implementation.** When this is built, the codebase must include clear, discoverable instructions for how to add a new pass: where the file lives, what the contract is, where it gets registered, how to test it in isolation. The additive growth model only pays off if adding a pass is genuinely easy. A `docs/guides/adding-a-pass.md` (paralleling the existing `adding-a-weapon.md`, `adding-a-map.md`) is the right shape.
+
+---
+
+## 3. Categories of pass
+
+**Consensus: categories are a teaching tool, not an architectural feature.** They are how humans group adjacent passes when explaining or designing. They are not enforced in code. The actual data structure is the flat list from Section 2; categories live in documentation and in our heads. This matches Terraria's approach exactly.
+
+**Categories adopted for v1:**
+
+- **Substrate.** Establish the canvas. The terrain mask, the sky/ground silhouette, the gross shape of the world.
+- **Carving.** Subtract from substrate. Tunnels, caves, overhangs.
+- **Material differentiation.** Inject heterogeneity into the substrate. For us this is horizontal bands (dirt / rock / sand layers feeding the existing stratum painter), not Terraria's interleaved "Rocks In Dirt + Dirt In Rocks" pattern. Smaller scale, same idea.
+- **Theme.** Per-map flavor (snow map, jungle map, canyon map). One theme per generated world. This replaces Terraria's per-region biome category for v1.
+- **Dressing.** Decorate without affecting physics. Surface details, ambient flora, parallax hints, color variation.
+- **Spawn-point distribution.** Late-stage passes that read the settled world and place worm spawns where they will be safe and reachable. Gameplay-critical, must run after every other gen pass has settled.
+- **Validation / cleanup.** Final passes that enforce structural invariants. No orphaned floating mask islands, no spawn buried under a wall, no weapon cache in the void.
+
+**Categories dropped from Terraria:**
+
+- **Civilization.** No NPCs, no quest-bearing chests, no dungeons. Spawn-point placement (above) is the one civilization-flavored thing that survives, and it gets its own category because of how late it has to run.
+- **Hydrology.** Our water is a runtime concern - global rising waterline (sudden death), projectile-borne water effects. Not a gen-time concern.
+- **Structures (Terraria-style).** No multi-tile bounded rectangles like dungeons or floating-island houses in v1.
+
+**Deferred to future enhancements (added later via append, per Section 2 growth model):**
+
+- **Biomes.** Per-region differentiation inside a single map. Out of scope until our maps grow large enough that "the whole map is one theme" stops feeling rich enough.
+- **Structural drops.** Spelunky-style template carves (bunkers, fortifications, ruined buildings). Out for v1; can be added as a category later when we want recognizable geometry inside procgen terrain.
+
+---
+
+## 4. Why the order is what it is
+
+**Consensus: order encodes a hand-tuned causal graph.** The pass list is not arbitrary; each pass's prerequisites live as substrate that earlier passes wrote. We do not compute a topological sort from declared dependencies. We hand-order passes, find bugs, reorder, and arrive at a sequence that works. The order itself is institutional knowledge captured in the list.
+
+**No spray/place cutoff for us.** Terraria designates an explicit boundary ("after Gems, every operation must respect existing structures") because they have ore-runners that corrupt multi-tile structures. We do not have ore-runners or multi-tile structures. World-gen is one piece of what we are building and we are not going to import discipline that does not protect against problems we have. If we ever add structural drops (deferred), we revisit.
+
+**Late-pass-invalidates-earlier-pass is a pattern to watch for.** Terraria runs Settle Liquids twice because late passes punch holes that re-trigger flow. We do not have flowing liquids in gen, but the underlying pattern - "if a late pass invalidates an earlier pass's output, the earlier pass may need to re-run" - could still apply (example: dressing punches through the mask in a way that breaks a connectivity check earlier passes assumed). We do not pre-design for this; we let it emerge during implementation if it does.
+
+**Final Cleanup is mandatory and runs last.** It is the only pass licensed to read the entire world and patch inconsistencies. Specifics of what it checks are deferred to Section 8 (validation).
+
+---
+
+## 5. The shared world state
+
+**Consensus: a single shared mutable structure during gen, and passes communicate only through it.** Whatever data the pipeline needs to read or write lives in one place. Passes get to it through that structure; they do not call each other, raise events, or return values to a coordinator. If pass N wants to influence pass N+5, the only mechanism is to leave a mark on the world that pass N+5 will notice. This discipline keeps the pipeline simple and matches our world's scope.
+
+**No version control, no rollback.** If a pass writes the wrong thing, every later pass sees the wrong thing. The implication is that pass-authoring discipline matters - a pass should be small enough to reason about and test in isolation, because once it runs, its output is the truth.
+
+**Cooperative coordination registry deferred.** Terraria's StructureMap exists to prevent multi-tile structures from overlapping. We have no multi-tile structures in v1, so we have no placement-collision problem to solve. When structural drops are added (deferred per Section 3), we introduce the registry then.
+
+**No premature shape commitment.** We are not enumerating the fields of the v1 world state in this doc. The exact fields fall out of which passes we write. The conceptual contract is: one shared structure, accessed only via that structure, no out-of-band communication.
+
+---
+
+## 6. Conditional vs unconditional passes
+
+**Consensus: every pass always runs; conditionality is internal to the pass.** There is no orchestrator-level pass-skipping. The pipeline is uniform - the same flat list executes for every seed. A pass whose substrate is missing does nothing on its own; the "is my substrate present?" check is the pass's responsibility.
+
+**Risk acceptance.** This pattern is elegant *and* brittle, and we are choosing to accept that tradeoff. Elegant because there is no conditional logic in the orchestrator, no graph of declared dependencies, no skip-registration mechanism. Brittle because pass authors must implement the substrate check correctly, and a pass that misbehaves on missing substrate can quietly mangle the world. The alternative (a graph-based skip system) would be more code and less debuggable, and inconsistent with the flat-list shape from Section 2. We accept the brittleness because the elegance pays back every time we add a new pass.
+
+**Theme-variant passes follow this pattern.** The canonical worms example: a "place snow piles" pass and a "place jungle vines" pass both exist in the flat list, and both run on every world. Each one reads the theme metadata an earlier pass wrote, and if the theme does not match, it does nothing. We get themed worlds without ever introducing a pass-skipping mechanism.
+
+**Most v1 passes are unconditional.** Substrate, carving, validation always have work to do. Conditional passes are the theme-variant decoration and dressing slots. Conditionality is invisible from outside the pass.
+
+---
+
+## 7. Determinism and seeding
+
+**Consensus: the same seed produces the same world. Always. Operationally this is three rules:**
+
+1. **One RNG, seeded once, used by every pass.** We already have `xorshift` and it is platform-independent. Every random decision in every pass goes through it. No second RNG, no Math.random, no system entropy.
+2. **Fixed pass order.** Reordering changes RNG consumption order and the world downstream diverges. The flat list from Section 2 is the order. Adding a pass means appending; mid-list inserts are a determinism event.
+3. **No input from outside the seed.** No wall-clock time, no Date.now, no platform-specific math, no iteration order over an unsorted collection. The seed is the only input.
+
+**Multiplayer is not a special case at the philosophy level.** World generation is singular: a seed maps to a world. Whether the server runs the pipeline and broadcasts the artifact, or the server broadcasts the seed and every client re-runs the pipeline locally, is a transport decision that does not change the philosophy. If the three rules hold, the output is identical regardless of who computed it. The transport choice is an implementation concern (bandwidth vs CPU, trust model) and is deferred.
+
+**Seeds are a product surface, not just an internal mechanism.** Players should be able to see the seed of a generated world and input one in the lobby when readying up. "Save a good seed, share it with your friend, play that exact world next time" is a feature worth shipping. Terraria does this and it is one of the things people love about the game. The philosophy of one-seed-one-world is what makes that feature trivial: if determinism holds, the seed is a complete description of the world.
+
+---
+
+## 8. Validation, soft-locks, playability
+
+**Consensus: structural playability is the standard. Not goal-oriented playability.** A world is playable if it has terrain, spawn points, and the metadata gameplay needs - not if a path can be proved between any two points. Worms players have jetpack, drill, rope, jumping, walking, and weapons; between those tools, traversal is a player problem, not a generator problem. We do not run a Spelunky-style traversal validator and we do not check "can a worm physically reach this other worm." Same call Terraria made for the same reason.
+
+**The cleanup tail enforces local invariants.** Final passes scan the settled world and patch inconsistencies. The categories of invariant we will care about (exact checks emerge from implementation):
+
+- **Spawn coherence.** Every spawn point has open air above and solid ground below. No spawn buried under a late-placed wall, no spawn floating in void.
+- **Mask hygiene.** No orphaned 1-pixel (or sub-threshold) mask islands. The threshold for "too small to physically matter" is implementation-tunable.
+- **Material coherence.** Every solid pixel has a material assigned. No pixels of solid-but-unspecified.
+- **Per-theme invariants.** Each theme can declare what it requires of the final world. Examples: a canyon-theme map needs its central gap intact (the bottomless void is gameplay-load-bearing, not a defect to fix). The cleanup tail respects per-theme constraints, which means the tail is theme-aware.
+
+**Important non-invariant: "world is fully bounded by solid."** This is NOT universal. The canyon theme intentionally has a no-floor void, and worms that fall in are killed by the off-map system. The cleanup tail must not "fix" this. Per-theme invariants override global expectations.
+
+**Cleanup is conservative janitorial, not gameplay verification.** It fixes states that are wrong, not states that are sub-optimal. A world with one boring spawn placement is not broken; a world with a spawn point inside a rock is broken.
+
+---
+
+## 9. What is Terraria-specific vs universal
+
+This section is mostly a recap of decisions already made in Sections 1-8. Capturing it explicitly so future readers see the line clearly.
+
+**Universal, adopted:**
+
+- The named pass model (Section 2).
+- Deterministic single-RNG seeding (Section 7).
+- Shared mutable world state during generation (Section 5).
+- Conditionality via substrate, not via pass-skipping (Section 6).
+- Hand-tuned topological ordering, documented as "this before that and here is why" (Section 4).
+- Structural-playability validation tail (Section 8).
+
+**Terraria-specific, rejected:**
+
+- The tile grid. Our substrate is a pixel mask plus metadata (heightmap, material map, theme, spawn candidates). The pass model still applies; the data shape is different.
+- The five-layer system (Space / Surface / Underground / Cavern / Underworld). Our maps are one-screen-ish; we don't have layers, we have a single substrate band.
+- The civilization category (NPCs, quest chests, dungeons).
+- The hydrology category. Water is a runtime concern.
+- The StructureMap, for now. Deferred until we add structural drops.
+
+**Adapted, not adopted wholesale:**
+
+- Categories: theme (per-map) instead of biome (per-region); simpler material differentiation (horizontal bands, not interleaved spray); spawn-point distribution promoted to its own category because it has to run after everything else has settled.
+- No spray-before-place cutoff. We have no ore-runners or multi-tile structures, so the cutoff Terraria designates at "Gems" has no analog for us.
+
+**The substrate model in concrete form.** For a 2D destructible-mask physics game, the substrate is a rasterized mask plus metadata layered on top: heightmap, material assignments, theme tag, spawn-point candidates, exclusion zones (when we have them). Substrate passes lay the mask. Carving passes erase from it. Material passes paint stratum. Theme passes write theme metadata. Decoration passes read theme and place ambient features. Spawn passes read the settled world and place spawns where they will be safe. Validation passes scan and patch. The abstract pipeline maps onto this concrete substrate cleanly.
+
+---
+
+## 10. Status of the bible's open questions
+
+The bible enumerated seven open questions for translation. Walking through Sections 1-9 resolved or deferred six of them.
+
+**Resolved or deferred:**
+
+- *Is mid-match destruction a constraint that changes our pass model?* Sibling concern. Out of scope for gen. Tracked in worms#161.
+- *Do we want biomes at our scale?* No for v1. Theme (per-map) instead; biomes as future enhancement. (Section 3)
+- *How does multiplayer determinism interact with seeded gen?* Not a philosophy-level issue. Determinism is determinism; transport is implementation. (Section 7)
+- *What is our equivalent of the StructureMap?* Deferred until we add structural drops. (Section 5)
+- *What does the validation tail look like for us?* Structural-playability, conservative janitorial, named invariant categories. (Section 8)
+- *Does the pass system extend into match time?* Sibling concern. Out of scope for gen. Tracked in worms#161.
+
+**Genuinely still open after this doc:**
+
+- *What are worms's analogous phases?* We have categories (Section 3); we do not have a specific pass list. This is the next conversation - the bridge from philosophy to specification. The output is a draft v1 pass list, ordered, named, and slotted into the categories above.
+
+When that draft is written, this section gets updated to point at it.
+
+---
+
+## Done
+
+This document captures consensus on world-gen philosophy as of the conversation that produced it. The bible at `world-gen-philosophy.md` remains the unmodified extraction of Terraria's model. This doc is what we believe and what we are building. They are read together.
+
+Next: draft the v1 pass list. Then we move technical.

--- a/docs/guides/world-gen-philosophy.md
+++ b/docs/guides/world-gen-philosophy.md
@@ -1,0 +1,137 @@
+# World Generation Philosophy
+
+This document is the bible. We are rebuilding our procedural world system on top of a stronger conceptual model than the directory of one-off mask drawers we have today. The model we are adopting is the one Re-Logic shipped in Terraria: world generation as a deterministic, ordered pipeline of named passes, each pass an event in a played-forward history of the world.
+
+This doc lays the philosophy down so we can re-derive the system from scratch in any engine, in any language, ten years from now. It contains no code. It is meant to be read in one sitting.
+
+## 1. What world generation actually is
+
+A generated world is not a snapshot. It is a *history*. The seed is a starting condition. The pass list is the laws of physics and biology applied in order. The output is the present moment of a world that has lived through every pass. You should be able to point at any tile in the final world and answer "which pass put this here, and what came before it."
+
+This reframing matters because it tells us what the artifacts of generation actually are. They are not "a heightmap and some caves." They are "the result of caves carved through stone that was first laid down as a substrate, then ore was injected, then water settled, then chests were placed in cavities the previous passes already created." Every late artifact is parasitic on an earlier one. The pipeline is causal.
+
+The Terraria community wiki says the same thing in fewer words: "World Generation is composed of Passes, and Passes are composed of Steps." (https://hackmd.io/@tModLoader/HJUiVKXzu) The hierarchy matters less than the ordering. The ordering is the whole game.
+
+## 2. The Terraria pass list, enumerated
+
+The complete vanilla Terraria pass list, in the order Re-Logic ships it, taken from the tModLoader wiki's Vanilla World Generation Steps page (https://github.com/tModLoader/tModLoader/wiki/Vanilla-World-Generation-Steps):
+
+Reset, Terrain, Dunes, Ocean Sand, Sand Patches, Tunnels, Mount Caves, Dirt Wall Backgrounds, Rocks In Dirt, Dirt In Rocks, Clay, Small Holes, Dirt Layer Caves, Rock Layer Caves, Surface Caves, Wavy Caves, Generate Ice Biome, Grass, Jungle, Mud Caves To Grass, Full Desert, Floating Islands, Mushroom Patches, Marble, Granite, Dirt To Mud, Silt, Shinies, Webs, Underworld, Corruption, Lakes, Dungeon, Slush, Mountain Caves, Beaches, Gems, Gravitating Sand, Create Ocean Caves, Shimmer, Clean Up Dirt, Pyramids, Dirt Rock Wall Runner, Living Trees, Wood Tree Walls, Altars, Wet Jungle, Jungle Temple, Hives, Jungle Chests, Settle Liquids, Remove Water From Sand, Oasis, Shell Piles, Smooth World, Waterfalls, Ice, Wall Variety, Life Crystals, Statues, Buried Chests, Surface Chests, Jungle Chests Placement, Water Chests, Spider Caves, Gem Caves, Moss, Temple, Cave Walls, Jungle Trees, Floating Island Houses, Quick Cleanup, Pots, Hellforge, Spreading Grass, Surface Ore and Stone, Place Fallen Log, Traps, Piles, Spawn Point, Grass Wall, Guide, Sunflowers, Planting Trees, Herbs, Dye Plants, Webs And Honey, Weeds, Glowing Mushrooms and Jungle Plants, Jungle Plants, Vines, Flowers, Mushrooms, Gems In Ice Biome, Random Gems, Moss Grass, Muds Walls In Jungle, Larva, Settle Liquids Again, Cactus Palm Trees & Coral, Tile Cleanup, Lihzahrd Altars, Micro Biomes, Water Plants, Stalac, Remove Broken Traps, Final Cleanup.
+
+That is roughly 107 named passes. Don't memorize them. Look at the shape.
+
+## 3. Categories of pass, derived from the list
+
+Six categories emerge if you read the list with squinted eyes. These are not Re-Logic's labels; they are ours, inferred from the list.
+
+**Substrate.** The earliest passes establish the canvas the rest will paint on. Reset wipes state. Terrain lays the surface heightmap. Dunes, Ocean Sand, and Sand Patches lay the lateral biomes that exist as substrate, not as decoration. Underworld establishes the bottom band of the world. The Terraria layer model itself (Space, Surface, Underground, Cavern, Underworld) is set up here (https://terraria.wiki.gg/wiki/Layers).
+
+**Carving.** Tunnels, Mount Caves, Dirt Layer Caves, Rock Layer Caves, Surface Caves, Wavy Caves, Spider Caves, Gem Caves, Mountain Caves, Create Ocean Caves. These passes *subtract*. They cut into substrate. They cannot run before substrate exists. They are also the source of nearly all the cavities later passes will fill.
+
+**Material differentiation.** Rocks In Dirt, Dirt In Rocks, Clay, Marble, Granite, Dirt To Mud, Silt. These take the homogenous early substrate and inject heterogeneity. Stone is no longer just stone. The world starts to feel geological. This is *before* ore because ore wants something interesting to be embedded in.
+
+**Biome / regional differentiation.** Generate Ice Biome, Jungle, Full Desert, Floating Islands, Mushroom Patches, Mud Caves To Grass, Wet Jungle, Corruption. These take large subregions and apply rule sets that overwrite or transmute the underlying substrate. A biome is not decoration; it is a region under different physical law.
+
+**Dressing.** Shinies (vanilla ore), Webs, Gems, Random Gems, Moss, Cave Walls, Wall Variety, Stalac, Webs And Honey, Vegetation passes. The world is now varied; we sprinkle the things that decorate it.
+
+**Structures.** Pyramids, Living Trees, Altars, Jungle Temple, Hives, Dungeon, Floating Island Houses, Lihzahrd Altars, Buried Chests, Surface Chests, Water Chests, Hellforge, Statues, Life Crystals. Discrete, mostly multi-tile features that occupy a bounded rectangle. They cannot be drawn earlier because they need empty space (cavities), they need the right substrate, and they cannot have ore-runner code spraying through them after they are placed.
+
+**Civilization and finishing.** Spawn Point, Guide, Settle Liquids, Settle Liquids Again, Tile Cleanup, Quick Cleanup, Final Cleanup, Remove Broken Traps, Smooth World, Waterfalls. These passes either give the world a player (the Guide NPC, the spawn point) or sweep up after everything else. They run last because they read the entire prior world state.
+
+The categories are ordered like a stratigraphy. Substrate at the bottom, structures and life at the top. The pass list is the playthrough of that stratigraphy in fast-forward.
+
+## 4. Why the order is what it is
+
+Read the list as a causal graph and the order stops looking arbitrary.
+
+Dunes runs before Ocean Sand because the desert is a band of substrate; ocean sand needs to know where the desert ends. Tunnels runs before the layered cave passes because tunnels are the long-distance veins; the layered passes carve the local pockets that connect to them. Shinies (ore) runs before Dungeon and before Buried Chests because ore is a "spray" operation that uses a tile-runner with override behavior; if it ran after a chest was placed, it would mangle the multi-tile chest. The tModLoader docs are explicit: "TileRunner is NOT SAFE to use when multitiles are in the world with the override parameter as true, as it will corrupt them" (https://github.com/tModLoader/tModLoader/wiki/World-Generation). The latest pass that safely uses spray semantics is Gems. After Gems, every operation must respect existing structures.
+
+Settle Liquids runs after the lakes, the dungeon, and the major carving passes because liquids flow and we only want to compute that flow once everything that could redirect water is in place. Then Settle Liquids Again runs near the end because later passes (vegetation, structures) sometimes punch new holes, and we want a final, stable hydrology.
+
+Final Cleanup is last because it is the only pass licensed to read the entire world and patch any inconsistency. By that point, every other pass has had its turn.
+
+If you reorder the list, things break in mechanical ways: you get chests with ore growing through them, water that hangs in mid-air over a cave that was carved later, vegetation rooted in tiles that were converted to mud after the plants were placed. The pass list is not an arbitrary sequence. It is a topological sort of a dependency graph, hand-tuned by Re-Logic over a decade of ship-and-fix.
+
+## 5. The shared world state
+
+During generation, the world is one mutable structure. In Terraria's case it is a 2D tile array plus a small set of side tables (the StructureMap, the random number generator, the world configuration). Every pass reads and writes the same array.
+
+This is a hard contract. Passes communicate only through the world. There is no message bus, no event system, no per-pass return value the next pass consumes. If pass N wants pass N+5 to behave differently, the only way is to leave a mark on the world that pass N+5 will notice. That mark might be "this region is now the Jungle biome" expressed as a particular tile type, or it might be "this rectangle is occupied by the Dungeon" expressed as an entry in the StructureMap.
+
+The StructureMap deserves a special call-out. It is the one piece of metadata Re-Logic exposed to coordinate non-overlapping placement. Before placing a structure, a pass can ask "is this rectangle free?" and if yes, occupy it. The tModLoader documentation describes it as "cooperative" (https://github.com/tModLoader/tModLoader/wiki/World-Generation): nothing forces a pass to consult it, but if a pass doesn't, it risks colliding with previously placed structures. The cooperative model is fragile but it works because the pass list itself is curated. New passes added to the curated list are required to play nicely.
+
+The conceptual takeaway is that the world during generation is a single shared mutable canvas, and every pass is both a reader and a writer of that canvas. There is no version control. There is no rollback. If a pass writes the wrong thing, every later pass sees the wrong thing.
+
+## 6. Conditional vs unconditional passes
+
+Most Terraria passes always run. A few are conditional in interesting ways. The "Corruption" pass exists in two flavors (Crimson is a Corruption variant) and only one runs per world. Special seeds like "Drunk World" enable both. The "For the Worthy", "Not the Bees", and "Zenith" seeds change which passes run and how they parameterize themselves (https://terraria.wiki.gg/wiki/World_Seed). Floating Island Houses only runs if Floating Islands ran. Jungle Chests Placement only runs if Jungle Chests located cavities to fill.
+
+Re-Logic does not express conditionality with a pass-skipping graph. It expresses it with substrate. If pass N never wrote anything, then pass N+5 looks at the world, finds nothing to act on, and quietly does nothing. The conditional dependency graph is implicit in the world state. This is elegant and it is also the source of subtle bugs: a pass that "should have skipped" because its substrate is missing can still misbehave if it doesn't check carefully. Pass authors are responsible for asking the world what state it is in.
+
+## 7. Determinism and seeding
+
+The contract is "the same seed always produces the same world." Operationally this requires three things.
+
+One: a single world-generation random number generator, seeded once at the start, used by every pass. Terraria calls this `WorldGen.genRand`. Every random decision in every pass goes through it. The tModLoader guide is emphatic: "It is important that you use WorldGen.genRand for all random decisions, as it facilitates the world seed feature" (https://github.com/tModLoader/tModLoader/wiki/World-Generation). If a pass uses a different RNG, even one seeded from genRand, you get a world that is reproducible only if all the other RNGs are also reproducible, and the cone of fragility expands.
+
+Two: a fixed pass order. If pass order changes between runs, the consumption order of the RNG changes, and the same seed produces different output. This is why mod authors are warned never to insert passes by hard-coded index (https://github.com/tModLoader/tModLoader/wiki/World-Generation): if any other mod inserts a pass before yours, your hard-coded index points at the wrong slot, and the entire world downstream diverges.
+
+Three: no input from outside the seed. No wall-clock time, no system entropy, no per-machine integer width. Terraria 1.4.0.1 explicitly fixed "an issue where different operating systems would see slightly different world seed results" (https://terraria.wiki.gg/wiki/World_Seed). The seed must be the *only* input. Any other input is a leak.
+
+Determinism is brittle. It is also free if you are disciplined. The discipline is: one RNG, fixed order, no external inputs.
+
+## 8. Validation, soft-locks, playability
+
+Terraria does not run a Spelunky-style solution-path validator. There is no "can the player reach the end" check. What it has instead is a tail of cleanup passes that enforce local invariants: Tile Cleanup, Quick Cleanup, Smooth World, Remove Broken Traps, Final Cleanup. These passes scan the world and fix tiles that are in inconsistent states (a half-placed multi-tile, a trap with a missing trigger, a wall pattern that doesn't match its neighbors). They are conservative janitors, not gameplay verifiers.
+
+The deeper point is that Terraria's notion of "playable" is structural rather than goal-oriented. The world is playable if its tiles are coherent. The player is presumed to be capable of digging, climbing, and exploring; the generator does not need to guarantee a path. This is a luxury we share, because a worms world is similarly forgiving: if it has terrain and spawn points and weapons, it is playable.
+
+What Terraria *does* guard against is corruption-of-state: ore through chests, water hanging in air, multi-tile structures cut in half. The cleanup tail exists for that.
+
+## 9. What is Terraria-specific vs universal
+
+Terraria-specific: the tile grid, the layer system (Space/Surface/Underground/Cavern/Underworld), the specific category list (no biomes for us, probably no dungeons), the specific structures, the multi-tile concept itself.
+
+Universal and worth keeping: the named pass model. Deterministic single-RNG seeding. The shared mutable world state during generation. The cooperative structure registry. The convention that destructive spray operations come before placement of fragile features. The validation tail. The explicit topological ordering documented as "this comes before that, and here is why."
+
+For a 2D destructible-mask physics game, the substrate is not tiles, it is a rasterized mask plus whatever metadata we layer on top (spawn zones, weapon caches, surface normals, biome tints). The pass model still applies. Substrate passes lay the mask. Carving passes erase from it. Decoration passes write biome metadata or spawn-zone hints. Structural passes register exclusion rectangles in the worms equivalent of a StructureMap. Validation passes ensure no spawn point is buried under a wall and no weapon cache is in the void.
+
+## 10. Open questions for translation
+
+These are the conversations Scott and I need to have before any types or code exist.
+
+What are worms's analogous phases? Do we have a "substrate" pass that produces the gross silhouette of an island? Do we have "carving" for the worm-traversable tunnels and overhangs? Do we have "dressing" for visual flavor that does not affect physics? The category list above is a hypothesis; we should pressure-test it against actual worms map-making instincts.
+
+Is mid-match destruction a constraint that changes our pass model? Terraria assumes the world is generated once and then mutated by the player. We mutate the world every time a bazooka hits. Does our pass system need to be re-runnable on a sub-region after destruction? Or is destruction a separate concern entirely, operating on the post-gen artifact?
+
+Do we want biomes at our scale? A worms map is small (one screen-ish). Terraria's biome system exists because the map is huge. We might want "themes" instead of biomes, applied per-map rather than per-region.
+
+How does multiplayer determinism interact with seeded gen? If the server generates and broadcasts the world, do clients need the RNG at all? If clients re-run gen from the seed, what is the bandwidth-vs-CPU tradeoff? What happens if a client and server disagree on the post-gen world by one pixel?
+
+What is our equivalent of the StructureMap? A list of reserved rectangles? A signed distance field of "do not place here"? Both? Where does it live, who owns it, and what is its lifetime relative to the match?
+
+What does the validation tail look like for us? Spawn-point reachability? Weapon-cache visibility? Mask connectivity (no orphaned floating islands of pixels)? We should enumerate the "broken world" failure modes we care about before we write the validators.
+
+Does the pass system extend into match time, or does it stop at match start? Terraria stops, then opens a hardmode tasks list. We may want a "during-match passes" concept for spawning weapon crates, dropping airdrops, mutating terrain on a timer. Those would share the same conceptual machinery: ordered, deterministic, reading shared state.
+
+We answer these next. The point of this doc is that we now have a vocabulary to answer them in.
+
+---
+
+## Sibling concern: object-world interaction
+
+This document covers world generation only - the substrate that exists at t=0. How dynamic entities (worms, projectiles, weapons) interact with that substrate at runtime is a distinct concern with a different lineage of references (Worms-the-game, Cortex Command, Noita), and is documented separately. Deferred until the gen philosophy is settled and translated. Tracked in worms#161.
+
+---
+
+## Sources
+
+- tModLoader Vanilla World Generation Steps (the canonical pass list): https://github.com/tModLoader/tModLoader/wiki/Vanilla-World-Generation-Steps
+- tModLoader World Generation guide (StructureMap, GenShape/GenAction, multitile safety): https://github.com/tModLoader/tModLoader/wiki/World-Generation
+- tModLoader "What is World Generation": https://hackmd.io/@tModLoader/HJUiVKXzu
+- GenPass class reference: https://docs.tmodloader.net/docs/1.4-stable/class_terraria_1_1_world_building_1_1_gen_pass.html
+- Terraria Wiki, World Generation: https://terraria.wiki.gg/wiki/World_generation
+- Terraria Wiki, Layers: https://terraria.wiki.gg/wiki/Layers
+- Terraria Wiki, World Seed (determinism, special seeds, OS-level seed bugs): https://terraria.wiki.gg/wiki/World_Seed
+- tModLoader issue 2260 (modernization commentary on the GenPass model): https://github.com/tModLoader/tModLoader/issues/2260
+- Minecraft Wiki, World generation (corroborating evidence on pipeline-based gen): https://minecraft.wiki/w/World_generation


### PR DESCRIPTION
## Summary

- Adds `docs/guides/world-gen-philosophy.md` - extraction of Terraria's GenPass model as canonical prior art ("the bible")
- Adds `docs/guides/world-gen-design.md` - worms-specific consensus translation, keyed 1:1 to the bible
- Forward-points to worms#161 (object-world interaction sibling concern, deferred)

## Why

We were heading toward iterating on Plan #150 (world-gen v1) without a strong conceptual foundation. Existing generators are a mix of procgen-first scaffolding and hardcoded handcrafted scripts; adding mountains meant editing one generator, adding caves meant editing another. The pipeline shape was implicit and fickle. Stepping back to extract the philosophy from Terraria first, then committing to a worms-specific translation, gives us a solid foundation to build on rather than fork-and-edit.

## What's in the design doc

Section-by-section consensus mirroring the bible:

1. World-as-history framing
2. Flat ordered named list, additive growth
3. Categories (substrate, carving, material differentiation, theme, dressing, spawn-point distribution, validation/cleanup)
4. Order encodes hand-tuned causal graph
5. Single shared mutable canvas, communication via state only
6. Conditionality via substrate (not pass-skipping)
7. Three-rule determinism (one RNG, fixed order, no external inputs); player-visible seeds
8. Structural playability, no Spelunky-style traversal validator
9. Recap of what's universal vs Terraria-specific
10. Status of bible's open questions; identifies next deliverable

## What's deferred

- Object-world interaction philosophy (worms#161)
- Per-region biomes (future enhancement)
- Multi-tile structures + StructureMap analog (future enhancement)
- v1 pass list itself (next doc, in-progress conversationally)

## Test plan

- [x] No em dashes in either doc
- [x] Both docs read end-to-end without referring to implementation specifics
- [x] worms#161 referenced from philosophy doc
- [ ] Manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)