### PR TITLE
feat(worldgen): v1 pipeline foundation - types, runner, RNG, themes, tuning

### DIFF
--- a/src/maps/pass.ts
+++ b/src/maps/pass.ts
@@ -1,0 +1,28 @@
+import type { Tuning } from "../tuning";
+import type { Theme } from "./themes";
+import type { World } from "./world";
+
+/**
+ * Per-pass execution context. Passes receive this once and read from it.
+ * The shape is the load-bearing API of the pipeline: it deliberately
+ * includes resolveParam so passes can read theme.params with a tuning
+ * fallback in one call, instead of re-implementing the lookup pattern in
+ * every pass.
+ */
+export interface PassContext {
+  readonly world: World;
+  readonly rng: () => number;
+  readonly passIndex: number;
+  readonly tuning: Tuning;
+  /**
+   * Looks up `world.theme?.params[key]` and returns it if present (number),
+   * otherwise returns `fallback`. The standard pattern for "use theme
+   * override or fall back to global tuning default".
+   */
+  resolveParam(key: keyof Theme["params"], fallback: number): number;
+}
+
+export interface Pass {
+  readonly name: string;
+  run(ctx: PassContext): void;
+}

--- a/src/maps/pipeline.test.ts
+++ b/src/maps/pipeline.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Stub the cross-workstream module so tests can run before WS-B lands.
+// rngForPass(seed, passIndex) must return a deterministic () => number.
+// We implement the minimal contract: same (seed, passIndex) -> same sequence,
+// different passIndex -> different first value.
+vi.mock("./rng", () => ({
+  rngForPass: (seed: number, passIndex: number): (() => number) => {
+    // Simple deterministic sequence based on seed and passIndex.
+    let state = (seed ^ (passIndex * 2654435761)) >>> 0;
+    return () => {
+      state = Math.imul(state ^ (state >>> 16), 0x45d9f3b) >>> 0;
+      state = Math.imul(state ^ (state >>> 16), 0x45d9f3b) >>> 0;
+      state = (state ^ (state >>> 16)) >>> 0;
+      return state / 0x100000000;
+    };
+  },
+}));
+
+import type { Pass, PassContext } from "./pass";
+import { Pipeline } from "./pipeline";
+import { createWorld } from "./world";
+
+function makeWorld() {
+  return createWorld(42, 100, 100, "default");
+}
+
+/** Build a Pass whose run() calls the provided fn. */
+function makePass(name: string, fn: (ctx: PassContext) => void): Pass {
+  return { name, run: fn };
+}
+
+describe("Pipeline", () => {
+  describe("length", () => {
+    it("returns the pass count", () => {
+      const p = new Pipeline([makePass("a", () => {}), makePass("b", () => {})]);
+      expect(p.length).toBe(2);
+    });
+
+    it("returns 0 for empty pipeline", () => {
+      expect(new Pipeline([]).length).toBe(0);
+    });
+  });
+
+  describe("pass ordering and passIndex", () => {
+    it("executes passes in order with correct passIndex", () => {
+      const indices: number[] = [];
+      const passes: Pass[] = [
+        makePass("p0", (ctx) => {
+          indices.push(ctx.passIndex);
+        }),
+        makePass("p1", (ctx) => {
+          indices.push(ctx.passIndex);
+        }),
+        makePass("p2", (ctx) => {
+          indices.push(ctx.passIndex);
+        }),
+      ];
+      new Pipeline(passes).run(makeWorld());
+      expect(indices).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe("per-pass RNG", () => {
+    it("each pass receives a distinct RNG (distinct first values)", () => {
+      const firstValues: number[] = [];
+      const passes: Pass[] = [
+        makePass("p0", (ctx) => {
+          firstValues.push(ctx.rng());
+        }),
+        makePass("p1", (ctx) => {
+          firstValues.push(ctx.rng());
+        }),
+        makePass("p2", (ctx) => {
+          firstValues.push(ctx.rng());
+        }),
+      ];
+      new Pipeline(passes).run(makeWorld());
+      expect(firstValues.length).toBe(3);
+      const unique = new Set(firstValues);
+      expect(unique.size).toBe(3);
+    });
+  });
+
+  describe("determinism", () => {
+    it("same seed produces identical rng() sequences across two runs", () => {
+      const run1: number[] = [];
+      const run2: number[] = [];
+      const buildPasses = (out: number[]): Pass[] => [
+        makePass("p0", (ctx) => {
+          out.push(ctx.rng(), ctx.rng());
+        }),
+        makePass("p1", (ctx) => {
+          out.push(ctx.rng(), ctx.rng());
+        }),
+        makePass("p2", (ctx) => {
+          out.push(ctx.rng(), ctx.rng());
+        }),
+      ];
+      new Pipeline(buildPasses(run1)).run(makeWorld());
+      new Pipeline(buildPasses(run2)).run(makeWorld());
+      expect(run1).toEqual(run2);
+    });
+  });
+
+  describe("subseed isolation", () => {
+    it("a pass at index 0 gets the same rng regardless of total pipeline length", () => {
+      let valueA = -1;
+      let valueB = -1;
+      const p0a = makePass("p0", (ctx) => {
+        valueA = ctx.rng();
+      });
+      const p0b = makePass("p0", (ctx) => {
+        valueB = ctx.rng();
+      });
+      const noop = makePass("noop", () => {});
+      const world = makeWorld();
+      new Pipeline([p0a]).run(world);
+      new Pipeline([p0b, noop, noop]).run(world);
+      expect(valueA).toBe(valueB);
+    });
+  });
+
+  describe("error wrapping", () => {
+    it("wraps pass errors with pass name and index in message", () => {
+      const boom = makePass("explode", () => {
+        throw new Error("original error");
+      });
+      let caught: unknown;
+      try {
+        new Pipeline([boom]).run(makeWorld());
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const err = caught as Error;
+      expect(err.message).toContain("explode");
+      expect(err.message).toContain("0");
+    });
+
+    it("sets the original error as .cause", () => {
+      const original = new Error("original error");
+      const boom = makePass("explode", () => {
+        throw original;
+      });
+      let caught: unknown;
+      try {
+        new Pipeline([boom]).run(makeWorld());
+      } catch (e) {
+        caught = e;
+      }
+      expect((caught as Error & { cause?: unknown }).cause).toBe(original);
+    });
+
+    it("wraps non-Error throws by converting to Error first", () => {
+      const boom = makePass("strthrow", () => {
+        throw "raw string error";
+      });
+      let caught: unknown;
+      try {
+        new Pipeline([boom]).run(makeWorld());
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("strthrow");
+    });
+  });
+
+  describe("onPass observer", () => {
+    it("fires once per pass with index, name, and non-negative durationMs", () => {
+      const events: { index: number; name: string; durationMs: number }[] = [];
+      const passes: Pass[] = [makePass("alpha", () => {}), makePass("beta", () => {})];
+      new Pipeline(passes).run(makeWorld(), {
+        onPass: (info) => {
+          events.push(info);
+        },
+      });
+      expect(events.length).toBe(2);
+      expect(events[0]).toMatchObject({ index: 0, name: "alpha" });
+      expect(events[1]).toMatchObject({ index: 1, name: "beta" });
+      for (const ev of events) {
+        expect(ev.durationMs).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe("empty pipeline", () => {
+    it("runs without error", () => {
+      expect(() => new Pipeline([]).run(makeWorld())).not.toThrow();
+    });
+  });
+});

--- a/src/maps/pipeline.ts
+++ b/src/maps/pipeline.ts
@@ -1,0 +1,54 @@
+import { tuning } from "../tuning";
+import type { Pass, PassContext } from "./pass";
+import { rngForPass } from "./rng";
+import type { Theme } from "./themes";
+import type { World } from "./world";
+
+export interface PipelineRunOpts {
+  /** Optional observer fired once per pass. Useful for telemetry, profiling, debugging. */
+  onPass?: (info: { index: number; name: string; durationMs: number }) => void;
+}
+
+/**
+ * Executes an ordered list of named passes against a World.
+ *
+ * Each pass receives a PassContext with a per-pass RNG via rngForPass, the
+ * full Tuning object, the pass index, and a resolveParam helper. Passes
+ * that throw are wrapped in an Error that names the failing pass so
+ * stack traces are useful.
+ */
+export class Pipeline {
+  constructor(private readonly passes: readonly Pass[]) {}
+
+  get length(): number {
+    return this.passes.length;
+  }
+
+  run(world: World, opts?: PipelineRunOpts): void {
+    for (let i = 0; i < this.passes.length; i++) {
+      const pass = this.passes[i];
+      if (!pass) continue;
+      const rng = rngForPass(world.seed, i);
+      const ctx: PassContext = {
+        world,
+        rng,
+        passIndex: i,
+        tuning,
+        resolveParam: (key: keyof Theme["params"], fallback: number): number => {
+          const v = world.theme?.params[key];
+          return typeof v === "number" ? v : fallback;
+        },
+      };
+      const t0 = performance.now();
+      try {
+        pass.run(ctx);
+      } catch (e) {
+        const cause = e instanceof Error ? e : new Error(String(e));
+        const wrapped = new Error(`pass ${i} (${pass.name}) failed: ${cause.message}`, { cause });
+        throw wrapped;
+      }
+      const durationMs = performance.now() - t0;
+      opts?.onPass?.({ index: i, name: pass.name, durationMs });
+    }
+  }
+}

--- a/src/maps/rng.test.ts
+++ b/src/maps/rng.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { rngForPass, rngInt, rngRange } from "./rng";
+
+describe("rngForPass", () => {
+  it("determinism: same (worldSeed, passIndex) produces identical stream over 1000 values", () => {
+    const a = rngForPass(42, 3);
+    const b = rngForPass(42, 3);
+    for (let i = 0; i < 1000; i++) {
+      expect(a()).toBe(b());
+    }
+  });
+
+  it("collision resistance #1: (0, 0) differs from (0xdeadbeef, 0) over 1000 values", () => {
+    const a = rngForPass(0, 0);
+    const b = rngForPass(0xdeadbeef, 0);
+    const seqA = Array.from({ length: 1000 }, () => a());
+    const seqB = Array.from({ length: 1000 }, () => b());
+    // At least one value must differ
+    const anyDiff = seqA.some((v, i) => v !== seqB[i]);
+    expect(anyDiff).toBe(true);
+  });
+
+  it("collision resistance #2: (0, 0) differs from (0, 1)", () => {
+    const a = rngForPass(0, 0);
+    const b = rngForPass(0, 1);
+    const seqA = Array.from({ length: 1000 }, () => a());
+    const seqB = Array.from({ length: 1000 }, () => b());
+    const anyDiff = seqA.some((v, i) => v !== seqB[i]);
+    expect(anyDiff).toBe(true);
+  });
+
+  it("pass independence: 11 distinct pass streams for passIndex 0..10 (same worldSeed)", () => {
+    const SEED = 12345;
+    const streams = Array.from({ length: 11 }, (_, i) =>
+      Array.from({ length: 100 }, rngForPass(SEED, i)),
+    );
+    // Every pair of streams must differ in at least one value
+    for (let i = 0; i < streams.length; i++) {
+      for (let j = i + 1; j < streams.length; j++) {
+        const anyDiff = streams[i].some((v, k) => v !== streams[j][k]);
+        expect(anyDiff).toBe(true);
+      }
+    }
+  });
+});
+
+describe("rngInt", () => {
+  it("distribution sanity: 10000 samples of rngInt(rng, 10) fill all buckets [0..9] with 500..1500 hits", () => {
+    const rng = rngForPass(99, 0);
+    const counts = new Array<number>(10).fill(0);
+    for (let i = 0; i < 10000; i++) {
+      counts[rngInt(rng, 10)]++;
+    }
+    for (let bucket = 0; bucket < 10; bucket++) {
+      expect(counts[bucket]).toBeGreaterThanOrEqual(500);
+      expect(counts[bucket]).toBeLessThanOrEqual(1500);
+    }
+  });
+
+  it("throws when n is 0", () => {
+    const rng = rngForPass(1, 0);
+    expect(() => rngInt(rng, 0)).toThrow();
+  });
+
+  it("throws when n is negative", () => {
+    const rng = rngForPass(1, 0);
+    expect(() => rngInt(rng, -5)).toThrow();
+  });
+
+  it("throws when n is non-integer", () => {
+    const rng = rngForPass(1, 0);
+    expect(() => rngInt(rng, 2.5)).toThrow();
+  });
+});
+
+describe("rngRange", () => {
+  it("boundaries inclusive: 10000 samples of rngRange(rng, 5, 7) stay in {5, 6, 7} and hit each value", () => {
+    const rng = rngForPass(77, 2);
+    const seen = new Set<number>();
+    for (let i = 0; i < 10000; i++) {
+      const v = rngRange(rng, 5, 7);
+      expect(v).toBeGreaterThanOrEqual(5);
+      expect(v).toBeLessThanOrEqual(7);
+      seen.add(v);
+    }
+    expect(seen.has(5)).toBe(true);
+    expect(seen.has(6)).toBe(true);
+    expect(seen.has(7)).toBe(true);
+  });
+
+  it("throws when hi < lo", () => {
+    const rng = rngForPass(1, 0);
+    expect(() => rngRange(rng, 5, 3)).toThrow();
+  });
+});

--- a/src/maps/rng.ts
+++ b/src/maps/rng.ts
@@ -1,0 +1,49 @@
+import { xorshift } from "./xorshift";
+
+const PASS_MIX = 0x9e3779b9;
+const SEED_SALT = 0x85ebca6b;
+
+/**
+ * Returns a deterministic RNG instance for a given (worldSeed, passIndex) pair.
+ *
+ * Mixing constants chosen to avoid two collision classes:
+ * 1. `seed=0, passIndex=0` colliding with `seed=0xdeadbeef, passIndex=0` via
+ *    xorshift's zero-substitution.
+ * 2. Adjacent pass indices producing similar streams.
+ *
+ * Per `docs/guides/world-gen-passes-v1.md` cross-cutting conventions, this is
+ * the only blessed way to get an RNG inside a pass. Sharing a cursor across
+ * passes would mean reordering passes changes the RNG of unaffected passes,
+ * breaking same-seed-same-world for any future pipeline edit.
+ */
+export function rngForPass(worldSeed: number, passIndex: number): () => number {
+  const mixed = (worldSeed ^ SEED_SALT ^ Math.imul(passIndex + 1, PASS_MIX)) >>> 0;
+  // Ensure non-zero seed; xorshift's own zero-substitution would otherwise
+  // map our (0,0) and any other input that hashes to 0 onto the same stream.
+  const safe = mixed === 0 ? PASS_MIX : mixed;
+  return xorshift(safe);
+}
+
+/**
+ * Uniform integer in [0, n). The blessed integer-from-rng path; do not use
+ * `Math.floor(rng() * n)` directly in passes - this helper is a single-point
+ * audit surface for cross-engine determinism risks (V8 vs SpiderMonkey vs
+ * JavaScriptCore at the f64 boundary).
+ */
+export function rngInt(rng: () => number, n: number): number {
+  if (n <= 0 || !Number.isInteger(n)) {
+    throw new Error(`rngInt: n must be a positive integer, got ${n}`);
+  }
+  return Math.floor(rng() * n);
+}
+
+/** Uniform integer in [lo, hi] inclusive. */
+export function rngRange(rng: () => number, lo: number, hi: number): number {
+  if (!Number.isInteger(lo) || !Number.isInteger(hi)) {
+    throw new Error("rngRange: lo and hi must be integers");
+  }
+  if (hi < lo) {
+    throw new Error(`rngRange: hi (${hi}) must be >= lo (${lo})`);
+  }
+  return lo + rngInt(rng, hi - lo + 1);
+}

--- a/src/maps/themes.test.ts
+++ b/src/maps/themes.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { THEMES, getTheme } from "./themes";
+
+const EXPECTED_TAGS = ["default", "canyon", "snow", "jungle", "plateau", "volcanic"] as const;
+const FLAG_KEYS: (keyof import("./themes").ThemeFlags)[] = [
+  "wantsPeaks",
+  "wantsCaves",
+  "noFloor",
+  "wantsSurfaceCrust",
+  "wantsCaveAmbient",
+];
+
+describe("THEMES registry", () => {
+  it("has exactly 6 entries with the expected tags", () => {
+    const keys = Object.keys(THEMES);
+    expect(keys).toHaveLength(6);
+    for (const tag of EXPECTED_TAGS) {
+      expect(keys).toContain(tag);
+    }
+  });
+});
+
+describe("getTheme", () => {
+  it("resolves all 6 themes and returns a Theme with matching tag", () => {
+    for (const tag of EXPECTED_TAGS) {
+      const theme = getTheme(tag);
+      expect(theme.tag).toBe(tag);
+    }
+  });
+
+  it("every theme has all five ThemeFlags set as booleans (not undefined)", () => {
+    for (const tag of EXPECTED_TAGS) {
+      const theme = getTheme(tag);
+      for (const key of FLAG_KEYS) {
+        expect(typeof theme.flags[key], `${tag}.flags.${key} should be boolean`).toBe("boolean");
+      }
+    }
+  });
+
+  it("every theme palette has surface, mid, deep as numbers in valid RGB range (0-0xFFFFFF)", () => {
+    for (const tag of EXPECTED_TAGS) {
+      const { palette } = getTheme(tag);
+      for (const channel of ["surface", "mid", "deep"] as const) {
+        const val = palette[channel];
+        expect(typeof val, `${tag}.palette.${channel} should be number`).toBe("number");
+        expect(val, `${tag}.palette.${channel} should be >= 0`).toBeGreaterThanOrEqual(0);
+        expect(val, `${tag}.palette.${channel} should be <= 0xFFFFFF`).toBeLessThanOrEqual(
+          0xffffff,
+        );
+      }
+    }
+  });
+
+  it("throws for unknown tag and error message lists known themes", () => {
+    expect(() => getTheme("nonsense")).toThrowError(/Known themes:/);
+    expect(() => getTheme("nonsense")).toThrowError(/default/);
+    expect(() => getTheme("nonsense")).toThrowError(/canyon/);
+  });
+});

--- a/src/maps/themes.ts
+++ b/src/maps/themes.ts
@@ -1,0 +1,130 @@
+/**
+ * Theme registry for the world-gen v1 pipeline.
+ *
+ * Per the v1 pass list (`docs/guides/world-gen-passes-v1.md`), themes are
+ * read by passes via flag and param checks, never by string-matching the
+ * tag. The schema below is the contract every theme-conditional pass
+ * relies on.
+ */
+
+export interface ThemeFlags {
+  wantsPeaks: boolean;
+  wantsCaves: boolean;
+  noFloor: boolean;
+  wantsSurfaceCrust: boolean;
+  wantsCaveAmbient: boolean;
+}
+
+export interface ThemeParams {
+  cellSizePx?: number;
+  initialFillRatio?: number;
+  caveIterations?: number;
+  surfaceBufferPx?: number;
+  mountainAmplitude?: number;
+  crustDepthPx?: number;
+  maskHygieneThresholdPx?: number;
+  spawnDensity?: number;
+  minSpawnsPerTeam?: number;
+  bandDirtDepthPx?: number;
+  bandRockDepthPx?: number;
+}
+
+export interface ThemePalette {
+  /** Top crust color (RGB hex, e.g., 0x3a7a3c). */
+  surface: number;
+  /** Dirt band. */
+  mid: number;
+  /** Stone band. */
+  deep: number;
+}
+
+export interface Theme {
+  tag: string;
+  flags: ThemeFlags;
+  params: ThemeParams;
+  palette: ThemePalette;
+}
+
+export const THEMES: Record<string, Theme> = {
+  default: {
+    tag: "default",
+    flags: {
+      wantsPeaks: true,
+      wantsCaves: true,
+      noFloor: false,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: false,
+    },
+    params: {},
+    palette: { surface: 0x3a7a3c, mid: 0x7a4a2c, deep: 0x5a5a5a },
+  },
+  canyon: {
+    tag: "canyon",
+    flags: {
+      wantsPeaks: false,
+      wantsCaves: true,
+      noFloor: true,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: false,
+    },
+    params: {},
+    palette: { surface: 0xb05c3a, mid: 0x8a4523, deep: 0x6a3010 },
+  },
+  snow: {
+    tag: "snow",
+    flags: {
+      wantsPeaks: true,
+      wantsCaves: true,
+      noFloor: false,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: true,
+    },
+    params: {},
+    palette: { surface: 0xf5f7fa, mid: 0x6a7a8a, deep: 0x4a5a6a },
+  },
+  jungle: {
+    tag: "jungle",
+    flags: {
+      wantsPeaks: true,
+      wantsCaves: true,
+      noFloor: false,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: true,
+    },
+    params: {},
+    palette: { surface: 0x2a8a3a, mid: 0x4a3a1a, deep: 0x3a2a0a },
+  },
+  plateau: {
+    tag: "plateau",
+    flags: {
+      wantsPeaks: false,
+      wantsCaves: true,
+      noFloor: false,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: false,
+    },
+    params: {},
+    palette: { surface: 0x8a7a5a, mid: 0x6a5a3a, deep: 0x4a3a2a },
+  },
+  volcanic: {
+    tag: "volcanic",
+    flags: {
+      wantsPeaks: true,
+      wantsCaves: true,
+      noFloor: false,
+      wantsSurfaceCrust: true,
+      wantsCaveAmbient: true,
+    },
+    params: {},
+    palette: { surface: 0x3a1a0a, mid: 0x5a2a0a, deep: 0x2a0a00 },
+  },
+};
+
+export function getTheme(tag: string): Theme {
+  const theme = THEMES[tag];
+  if (!theme) {
+    const known = Object.keys(THEMES).join(", ");
+    throw new Error(`Unknown theme tag: "${tag}". Known themes: ${known}`);
+  }
+  return theme;
+}

--- a/src/maps/world.test.ts
+++ b/src/maps/world.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HEIGHTMAP_UNINIT, MASK_AIR, MATERIAL_AIR, createWorld } from "./world";
+import { HEIGHTMAP_UNINIT, MASK_AIR, MATERIAL_AIR, MAX_PIXEL_COUNT, createWorld } from "./world";
 
 describe("createWorld", () => {
   it("returns a World with correct dimensions, seed, and themeTag", () => {
@@ -65,5 +65,14 @@ describe("createWorld", () => {
 
   it("throws for invalid heightPx (negative)", () => {
     expect(() => createWorld(0, 100, -5, "x")).toThrow(/heightPx must be a positive integer/);
+  });
+
+  it("throws when widthPx * heightPx exceeds the allocation cap", () => {
+    expect(() => createWorld(0, 20000, 20000, "x")).toThrow(/exceeds the allocation cap/);
+  });
+
+  it("accepts widthPx * heightPx exactly at the allocation cap", () => {
+    const side = Math.floor(Math.sqrt(MAX_PIXEL_COUNT));
+    expect(() => createWorld(0, side, side, "default")).not.toThrow();
   });
 });

--- a/src/maps/world.test.ts
+++ b/src/maps/world.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { HEIGHTMAP_UNINIT, MASK_AIR, MATERIAL_AIR, createWorld } from "./world";
+
+describe("createWorld", () => {
+  it("returns a World with correct dimensions, seed, and themeTag", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.widthPx).toBe(100);
+    expect(w.heightPx).toBe(50);
+    expect(w.seed).toBe(42);
+    expect(w.themeTag).toBe("default");
+  });
+
+  it("heightmap is Int32Array of length widthPx filled with HEIGHTMAP_UNINIT", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.heightmap).toBeInstanceOf(Int32Array);
+    expect(w.heightmap.length).toBe(100);
+    for (let i = 0; i < w.heightmap.length; i++) {
+      expect(w.heightmap[i]).toBe(HEIGHTMAP_UNINIT);
+    }
+  });
+
+  it("mask is Uint8Array of length widthPx * heightPx zero-filled", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.mask).toBeInstanceOf(Uint8Array);
+    expect(w.mask.length).toBe(100 * 50);
+    for (let i = 0; i < w.mask.length; i++) {
+      expect(w.mask[i]).toBe(MASK_AIR);
+    }
+  });
+
+  it("materialMap is Uint8Array of length widthPx * heightPx zero-filled", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.materialMap).toBeInstanceOf(Uint8Array);
+    expect(w.materialMap.length).toBe(100 * 50);
+    for (let i = 0; i < w.materialMap.length; i++) {
+      expect(w.materialMap[i]).toBe(MATERIAL_AIR);
+    }
+  });
+
+  it("spawnList is { left: [], right: [] }", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.spawnList).toEqual({ left: [], right: [] });
+  });
+
+  it("theme is null initially", () => {
+    const w = createWorld(42, 100, 50, "default");
+    expect(w.theme).toBeNull();
+  });
+
+  it("throws for negative seed", () => {
+    expect(() => createWorld(-1, 100, 50, "x")).toThrow(/seed must be a non-negative integer/);
+  });
+
+  it("throws for seed >= 2^32", () => {
+    expect(() => createWorld(2 ** 32, 100, 50, "x")).toThrow(/seed must be a non-negative integer/);
+  });
+
+  it("throws for non-integer seed", () => {
+    expect(() => createWorld(1.5, 100, 50, "x")).toThrow(/seed must be a non-negative integer/);
+  });
+
+  it("throws for invalid widthPx (0)", () => {
+    expect(() => createWorld(0, 0, 50, "x")).toThrow(/widthPx must be a positive integer/);
+  });
+
+  it("throws for invalid heightPx (negative)", () => {
+    expect(() => createWorld(0, 100, -5, "x")).toThrow(/heightPx must be a positive integer/);
+  });
+});

--- a/src/maps/world.ts
+++ b/src/maps/world.ts
@@ -16,6 +16,11 @@ export const MASK_SOLID = 1;
  *  pass that should have written this column did not. */
 export const HEIGHTMAP_UNINIT = -2147483648; // INT32_MIN
 
+/** Maximum widthPx * heightPx for createWorld. ~100M pixels = 200MB across the
+ *  mask + materialMap pair. Anything larger is almost certainly a bug; the raw
+ *  Uint8Array allocation would either OOM or fail with a cryptic RangeError. */
+export const MAX_PIXEL_COUNT = 100_000_000;
+
 export interface SpawnPoint {
   xPx: number;
   yPx: number;
@@ -91,9 +96,14 @@ export function createWorld(
   if (!Number.isInteger(heightPx) || heightPx <= 0) {
     throw new Error(`createWorld: heightPx must be a positive integer, got ${heightPx}`);
   }
+  const pixelCount = widthPx * heightPx;
+  if (pixelCount > MAX_PIXEL_COUNT) {
+    throw new Error(
+      `createWorld: widthPx * heightPx (${pixelCount}) exceeds the allocation cap of ${MAX_PIXEL_COUNT}. Worlds beyond this size are likely a bug.`,
+    );
+  }
   const heightmap = new Int32Array(widthPx);
   heightmap.fill(HEIGHTMAP_UNINIT);
-  const pixelCount = widthPx * heightPx;
   return {
     widthPx,
     heightPx,

--- a/src/maps/world.ts
+++ b/src/maps/world.ts
@@ -1,0 +1,110 @@
+import type { Theme } from "./themes";
+
+/** Per-pixel material code in the World.materialMap. */
+export const MATERIAL_AIR = 0;
+export const MATERIAL_DIRT = 1;
+export const MATERIAL_ROCK = 2;
+export const MATERIAL_STONE = 3;
+
+/** Mask byte values. */
+export const MASK_AIR = 0;
+export const MASK_SOLID = 1;
+
+/** Sentinel value for an uninitialized heightmap column.
+ *  Distinguishable from "surface at top" (0) and "no surface" (>= worldHeight).
+ *  Passes that read the heightmap should never observe this; it indicates a
+ *  pass that should have written this column did not. */
+export const HEIGHTMAP_UNINIT = -2147483648; // INT32_MIN
+
+export interface SpawnPoint {
+  xPx: number;
+  yPx: number;
+}
+
+export interface SpawnList {
+  /** Left-side spawns, sorted by xPx ascending. */
+  left: SpawnPoint[];
+  /** Right-side spawns, sorted by xPx ascending. */
+  right: SpawnPoint[];
+}
+
+export interface AmbientFeature {
+  xPx: number;
+  yPx: number;
+  type: string;
+}
+
+export interface DressingFeature {
+  xPx: number;
+  yPx: number;
+  sprite: string;
+}
+
+/**
+ * The shared mutable state passed through the pipeline. Always-allocated;
+ * no nullables for buffers. Pre-populated by `createWorld` so passes never
+ * face "is this initialized" branching. The `theme` field is the single
+ * exception: it is populated by `DefineTheme` (typically pass 2). For
+ * convenience, callers can pre-set theme via `createWorld` to avoid that.
+ */
+export interface World {
+  readonly widthPx: number;
+  readonly heightPx: number;
+  readonly seed: number;
+  readonly themeTag: string;
+  theme: Theme | null;
+
+  /** Per-column surface Y. surfaceY >= heightPx means void column (no solid). */
+  heightmap: Int32Array;
+
+  /** Pixel mask, 1 byte per pixel. 0 = air, 1 = solid. Length = widthPx * heightPx. */
+  mask: Uint8Array;
+
+  /** Per-pixel material. 0 = air, 1 = dirt, 2 = rock, 3 = stone, etc. */
+  materialMap: Uint8Array;
+
+  spawnList: SpawnList;
+  caveAmbient: AmbientFeature[];
+  surfaceDressing: DressingFeature[];
+}
+
+/**
+ * Allocates a World ready for pipeline execution.
+ *
+ * - Validates seed range (must be a non-negative integer less than 2^32).
+ * - Heightmap filled with HEIGHTMAP_UNINIT sentinel.
+ * - Mask and materialMap zero-filled (all air).
+ * - Theme remains null; DefineTheme pass resolves it via getTheme(themeTag).
+ */
+export function createWorld(
+  seed: number,
+  widthPx: number,
+  heightPx: number,
+  themeTag: string,
+): World {
+  if (!Number.isInteger(seed) || seed < 0 || seed >= 2 ** 32) {
+    throw new Error(`createWorld: seed must be a non-negative integer < 2^32, got ${seed}`);
+  }
+  if (!Number.isInteger(widthPx) || widthPx <= 0) {
+    throw new Error(`createWorld: widthPx must be a positive integer, got ${widthPx}`);
+  }
+  if (!Number.isInteger(heightPx) || heightPx <= 0) {
+    throw new Error(`createWorld: heightPx must be a positive integer, got ${heightPx}`);
+  }
+  const heightmap = new Int32Array(widthPx);
+  heightmap.fill(HEIGHTMAP_UNINIT);
+  const pixelCount = widthPx * heightPx;
+  return {
+    widthPx,
+    heightPx,
+    seed,
+    themeTag,
+    theme: null,
+    heightmap,
+    mask: new Uint8Array(pixelCount),
+    materialMap: new Uint8Array(pixelCount),
+    spawnList: { left: [], right: [] },
+    caveAmbient: [],
+    surfaceDressing: [],
+  };
+}

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -97,6 +97,47 @@ interface Tuning {
   wind: {
     forceNewtonsPerUnit: number;
   };
+  worldgen: {
+    /** Surface heightmap baseline as fraction of world height. Matches existing terraworld baseY = height * 0.55. */
+    surfaceBaselineFrac: number;
+    heightmap: {
+      /** Octave 1 (base): broad rolling-hills stride in pixels. Matches existing terraworld baseStride = 256. */
+      baseStride: number;
+      /** Octave 1 amplitude as fraction of world height. Matches existing baseAmp = height * 0.08. */
+      baseAmpFrac: number;
+      /** Octave 2 (detail): fine-noise stride. Matches existing detailStride = 96. */
+      detailStride: number;
+      /** Octave 2 amplitude as fraction of world height. Matches existing detailAmp = height * 0.02. */
+      detailAmpFrac: number;
+      /** Octave 3 (mountains): low-frequency peak stride. New for v1; gated by theme.flags.wantsPeaks. */
+      mountainStride: number;
+      /** Octave 3 amplitude as fraction of world height. */
+      mountainAmpFrac: number;
+      /** Smoothstep range over which the mountain octave's contribution ramps from 0 to full. Tuple [lo, hi] in [0, 1]. */
+      mountainSmoothstepLo: number;
+      mountainSmoothstepHi: number;
+    };
+    materialBands: {
+      /** Pixels of dirt material below the surface crust before transitioning to rock. */
+      dirtDepthPx: number;
+      /** Pixels of rock below the dirt band before transitioning to stone. Beyond this is stone. */
+      rockDepthPx: number;
+    };
+    crust: {
+      /** Pixels of theme-specific surface crust material (snow, grass, sand, etc.) overwriting the top of the dirt band. */
+      depthPx: number;
+    };
+    hygiene: {
+      /** Minimum mask-island size (in pixels) to keep during FinalizeMask. Smaller than this is removed as orphan debris. */
+      thresholdPx: number;
+    };
+    spawn: {
+      /** Minimum spacing between spawn candidates in pixels. */
+      densityPx: number;
+      /** Minimum spawns per team. Below this, ValidateSpawnCoherence logs a warning. */
+      minPerTeam: number;
+    };
+  };
   camera: {
     turnZoomOutMs: number;
     turnHoldMinMs: number;
@@ -187,6 +228,33 @@ export const tuning: Tuning = {
   },
   // Mirror of worker/src/sim/simulation.ts WIND_FORCE - keep in sync.
   wind: { forceNewtonsPerUnit: 0.8 },
+  worldgen: {
+    surfaceBaselineFrac: 0.55,
+    heightmap: {
+      baseStride: 256,
+      baseAmpFrac: 0.08,
+      detailStride: 96,
+      detailAmpFrac: 0.02,
+      mountainStride: 512,
+      mountainAmpFrac: 0.18,
+      mountainSmoothstepLo: 0.3,
+      mountainSmoothstepHi: 0.7,
+    },
+    materialBands: {
+      dirtDepthPx: 6,
+      rockDepthPx: 60,
+    },
+    crust: {
+      depthPx: 3,
+    },
+    hygiene: {
+      thresholdPx: 16,
+    },
+    spawn: {
+      densityPx: 200,
+      minPerTeam: 2,
+    },
+  },
   camera: {
     turnZoomOutMs: 800,
     turnHoldMinMs: 700,

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -1,4 +1,4 @@
-interface Tuning {
+export interface Tuning {
   world: { gravityY: number };
   retreat: {
     windowMs: number;


### PR DESCRIPTION
## Summary

Foundation layer for the world-gen v1 pipeline. Adds the architectural primitives that subsequent PRs will fill in with passes. **No passes implemented yet. No new generator. No impact on existing maps.**

Closes worms#150 partially (epic; remaining work tracked as follow-up PRs per the multi-PR roadmap).

## Workstreams (4 parallel Sonnet agents in worktrees)

- **WS-A `feature/worldgen-themes`** - Theme registry with 6 v1 themes (default, canyon, snow, jungle, plateau, volcanic) per the pinned schema in `docs/guides/world-gen-passes-v1.md`. Themes carry tag, flags, params, palette. Conditional passes read flags/params, never tag string-match.
- **WS-B `feature/worldgen-rng`** - Per-pass RNG helper. `rngForPass(worldSeed, passIndex)` mixes seed and passIndex with collision-resistant constants before passing to the existing xorshift. Exports `rngInt` and `rngRange` as the blessed integer-from-rng helpers (single-point audit surface for cross-engine determinism).
- **WS-C `feature/worldgen-tuning`** - Adds `tuning.worldgen` section with heightmap octave params, material band depths, crust depth, mask hygiene threshold, spawn density and minPerTeam, surface baseline. Defaults match existing terraworld constants. Also exports `Tuning` interface (was internal-only).
- **WS-D `feature/worldgen-pipeline`** - World struct (Uint8Array mask + materialMap, Int32Array heightmap with HEIGHTMAP_UNINIT sentinel, no DOM dependencies per Section 11 of the design doc), `createWorld` factory with input validation, Pass + PassContext interfaces, Pipeline runner with per-pass RNG injection, error wrapping, and onPass observer hook.

## Integration commits

- Tuning export fix (WS-C didn't `export interface Tuning`; required by WS-D's PassContext)
- Allocation cap on createWorld (bugcheck finding; 100M pixel limit prevents cryptic OOM on bad inputs)

## Bugcheck (Phase 3, mandatory)

Five parallel Haiku lenses ran adversarial review on the integration branch. Synthesis:

**Critical:** None.

**High - addressed:**
- Allocation DoS in createWorld - **FIXED inline** (MAX_PIXEL_COUNT = 100M check)
- rngForPass collision clustering on PASS_MIX - **DOCUMENTED, not fixed.** ~100 (seed, passIndex) pairs hash to mixed=0 and route to xorshift(PASS_MIX). On analysis, this is intrinsic to a 32-bit hash: the substitution moves the natural xorshift 0→0xdeadbeef collision class to PASS_MIX without reducing its size. Practical impact: 2 hash values out of 2^32 share one stream. In one game with one seed, never observed.

**Medium / Low - known issues for future PRs:**
- `performance.now()` availability in Cloudflare Workers DO contexts. Pipeline.run uses it for `durationMs` in the optional `onPass` observer. If gen ever runs server-side in DO without a polyfill, this fails. Not relevant for v1 (gen runs client-side per recon).
- `resolveParam` silent fallback on key typos. TypeScript prevents this in normal use; only triggers if a caller bypasses with a type assertion.
- Multiplayer error-wrapping leaks (Pipeline.run preserves cause chain). Future concern when gen errors are logged in shared logs; sanitizer needed before broadcasting client-side.
- seed=-0 normalizes to 0 via xorshift's `>>> 0` coercion. Semantic curiosity, not a bug.
- PassContext does not expose `passCount` to passes. Telemetry/progress logging will be missing the denominator. Add if a pass needs it.
- Heightmap doc could clarify it's per-column-only (not 2D-indexed). The /// comment on the field already says so but a worked example helps future pass authors.

## Test plan

- [x] All 323 tests pass (was 321; +2 for new allocation cap)
- [x] tsc clean
- [x] biome clean
- [x] No regressions in existing terrain / map / generator tests
- [x] Bugcheck Phase 3 complete; critical and high findings addressed or documented
- [ ] Manual review

## What's next

This unblocks **PR 2: Substrate passes** (Reset, DefineTheme, GenerateHeightmap, ApplyThemeHeightmapMods, PaintSubstrateMask). Subsequent PRs land carving, materials, dressing, spawn refactor, validation tail, integration, and lobby seed UX per the roadmap in worms#150 and `docs/guides/world-gen-passes-v1.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)