### PR TITLE
feat(worldgen): PR 3 - carving passes (CarveCaves, FinalizeMask) + terraworldV1 generator

### DIFF
--- a/src/maps/generators/paintMaskToContext.test.ts
+++ b/src/maps/generators/paintMaskToContext.test.ts
@@ -1,0 +1,68 @@
+import { createCanvas } from "canvas";
+import { describe, expect, it } from "vitest";
+import { paintMaskToContext } from "./paintMaskToContext";
+
+function makeCtx(w: number, h: number): CanvasRenderingContext2D {
+  const c = createCanvas(w, h);
+  return c.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+describe("paintMaskToContext", () => {
+  it("paints solid bytes as opaque white pixels and air bytes as transparent", () => {
+    const ctx = makeCtx(2, 2);
+    // mask layout (row-major): [solid, air, air, solid]
+    const mask = new Uint8Array([1, 0, 0, 1]);
+    paintMaskToContext(ctx, mask, 2, 2);
+    const data = ctx.getImageData(0, 0, 2, 2).data;
+    // pixel 0 (top-left): solid -> RGB=255, alpha=255
+    expect(data[0]).toBe(255);
+    expect(data[1]).toBe(255);
+    expect(data[2]).toBe(255);
+    expect(data[3]).toBe(255);
+    // pixel 1 (top-right): air -> alpha=0
+    expect(data[7]).toBe(0);
+    // pixel 2 (bottom-left): air -> alpha=0
+    expect(data[11]).toBe(0);
+    // pixel 3 (bottom-right): solid -> alpha=255
+    expect(data[15]).toBe(255);
+  });
+
+  it("all-zero mask produces fully transparent canvas", () => {
+    const ctx = makeCtx(4, 3);
+    const mask = new Uint8Array(4 * 3); // zero-filled
+    paintMaskToContext(ctx, mask, 4, 3);
+    const data = ctx.getImageData(0, 0, 4, 3).data;
+    for (let i = 3; i < data.length; i += 4) {
+      expect(data[i]).toBe(0);
+    }
+  });
+
+  it("all-one mask produces fully opaque white canvas", () => {
+    const ctx = makeCtx(4, 3);
+    const mask = new Uint8Array(4 * 3);
+    mask.fill(1);
+    paintMaskToContext(ctx, mask, 4, 3);
+    const data = ctx.getImageData(0, 0, 4, 3).data;
+    for (let i = 0; i < data.length; i += 4) {
+      expect(data[i]).toBe(255);
+      expect(data[i + 1]).toBe(255);
+      expect(data[i + 2]).toBe(255);
+      expect(data[i + 3]).toBe(255);
+    }
+  });
+
+  it("throws when mask length does not match widthPx * heightPx", () => {
+    const ctx = makeCtx(4, 3);
+    const wrong = new Uint8Array(10); // 10 != 12
+    expect(() => paintMaskToContext(ctx, wrong, 4, 3)).toThrow(/mask.length/);
+  });
+
+  it("treats non-1 non-0 byte values as air (only mask[i] === 1 is solid)", () => {
+    const ctx = makeCtx(2, 1);
+    const mask = new Uint8Array([1, 2]); // 1 = solid; 2 = anything else (treated as air)
+    paintMaskToContext(ctx, mask, 2, 1);
+    const data = ctx.getImageData(0, 0, 2, 1).data;
+    expect(data[3]).toBe(255); // solid
+    expect(data[7]).toBe(0); // not strictly === 1, so treated as air
+  });
+});

--- a/src/maps/generators/paintMaskToContext.ts
+++ b/src/maps/generators/paintMaskToContext.ts
@@ -1,0 +1,39 @@
+/**
+ * Materializes a 1-byte-per-pixel solid/air mask into a canvas context.
+ *
+ * Writes RGB=255 + alpha=255 for solid pixels (matches the
+ * fillStyle="#ffffff" convention used by existing canvas-based generators;
+ * applyStratumPaint overwrites RGB later but preserves alpha). Air pixels
+ * stay at the default 0/0/0/0 from createImageData.
+ *
+ * Used by the v1 pipeline's terraworldV1 generator (and any future pipeline-
+ * based generator) to convert a Uint8Array mask into the HTMLCanvasElement
+ * shape that LoadedMap and TerrainRenderer consume.
+ */
+export function paintMaskToContext(
+  ctx: CanvasRenderingContext2D,
+  mask: Uint8Array,
+  widthPx: number,
+  heightPx: number,
+): void {
+  if (mask.length !== widthPx * heightPx) {
+    throw new Error(
+      `paintMaskToContext: mask.length (${mask.length}) !== widthPx * heightPx (${widthPx * heightPx})`,
+    );
+  }
+  const imageData = ctx.createImageData(widthPx, heightPx);
+  const data = imageData.data;
+  // mask[i] is one byte per pixel; data is RGBA (4 bytes per pixel).
+  // Solid byte (1) -> opaque white pixel; air byte (0) -> transparent
+  // (default zero from createImageData).
+  for (let i = 0; i < mask.length; i++) {
+    if (mask[i] === 1) {
+      const dataIdx = i * 4;
+      data[dataIdx] = 255;
+      data[dataIdx + 1] = 255;
+      data[dataIdx + 2] = 255;
+      data[dataIdx + 3] = 255;
+    }
+  }
+  ctx.putImageData(imageData, 0, 0);
+}

--- a/src/maps/generators/terraworldV1.integration.test.ts
+++ b/src/maps/generators/terraworldV1.integration.test.ts
@@ -1,0 +1,95 @@
+import { createCanvas } from "canvas";
+import { describe, expect, it } from "vitest";
+import { terraworldV1Generator } from "./terraworldV1";
+
+function makeCtx(w: number, h: number) {
+  const c = createCanvas(w, h);
+  return c.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+describe("terraworldV1 integration", () => {
+  it("default theme: produces a canvas with both opaque and transparent pixels (caves carved)", () => {
+    const W = 400;
+    const H = 300;
+    const ctx = makeCtx(W, H);
+    terraworldV1Generator(ctx, W, H, { seed: 42 });
+    const data = ctx.getImageData(0, 0, W, H).data;
+    let opaque = 0;
+    let transparent = 0;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] === 255) opaque++;
+      else if (data[i] === 0) transparent++;
+    }
+    expect(opaque).toBeGreaterThan(0);
+    expect(transparent).toBeGreaterThan(0);
+  });
+
+  it("canyon theme: middle column has at least one transparent pixel (gap exists)", () => {
+    const W = 400;
+    const H = 300;
+    const ctx = makeCtx(W, H);
+    terraworldV1Generator(ctx, W, H, { seed: 42, themeTag: "canyon" });
+    const data = ctx.getImageData(0, 0, W, H).data;
+    let middleHasTransparent = false;
+    for (let y = 0; y < H; y++) {
+      const idx = (y * W + Math.floor(W / 2)) * 4 + 3;
+      if (data[idx] === 0) {
+        middleHasTransparent = true;
+        break;
+      }
+    }
+    expect(middleHasTransparent).toBe(true);
+  });
+
+  it("determinism: same seed produces byte-identical canvas alpha channel", () => {
+    const W = 200;
+    const H = 200;
+    const c1 = makeCtx(W, H);
+    const c2 = makeCtx(W, H);
+    terraworldV1Generator(c1, W, H, { seed: 1234 });
+    terraworldV1Generator(c2, W, H, { seed: 1234 });
+    const d1 = c1.getImageData(0, 0, W, H).data;
+    const d2 = c2.getImageData(0, 0, W, H).data;
+    for (let i = 3; i < d1.length; i += 4) {
+      expect(d1[i]).toBe(d2[i]);
+    }
+  });
+
+  it("different seeds produce different canvases", () => {
+    const W = 200;
+    const H = 200;
+    const c1 = makeCtx(W, H);
+    const c2 = makeCtx(W, H);
+    terraworldV1Generator(c1, W, H, { seed: 1 });
+    terraworldV1Generator(c2, W, H, { seed: 2 });
+    const d1 = c1.getImageData(0, 0, W, H).data;
+    const d2 = c2.getImageData(0, 0, W, H).data;
+    let differs = false;
+    for (let i = 3; i < d1.length; i += 4) {
+      if (d1[i] !== d2[i]) {
+        differs = true;
+        break;
+      }
+    }
+    expect(differs).toBe(true);
+  });
+
+  it("different themes at same seed produce different canvases", () => {
+    const W = 200;
+    const H = 200;
+    const cDefault = makeCtx(W, H);
+    const cCanyon = makeCtx(W, H);
+    terraworldV1Generator(cDefault, W, H, { seed: 99 });
+    terraworldV1Generator(cCanyon, W, H, { seed: 99, themeTag: "canyon" });
+    const d1 = cDefault.getImageData(0, 0, W, H).data;
+    const d2 = cCanyon.getImageData(0, 0, W, H).data;
+    let differs = false;
+    for (let i = 3; i < d1.length; i += 4) {
+      if (d1[i] !== d2[i]) {
+        differs = true;
+        break;
+      }
+    }
+    expect(differs).toBe(true);
+  });
+});

--- a/src/maps/generators/terraworldV1.ts
+++ b/src/maps/generators/terraworldV1.ts
@@ -1,0 +1,41 @@
+import { applyThemeHeightmapModsPass } from "../passes/applyThemeHeightmapMods";
+import { carveCavesPass } from "../passes/carveCaves";
+import { defineThemePass } from "../passes/defineTheme";
+import { finalizeMaskPass } from "../passes/finalizeMask";
+import { generateHeightmapPass } from "../passes/generateHeightmap";
+import { paintSubstrateMaskPass } from "../passes/paintSubstrateMask";
+import { resetPass } from "../passes/reset";
+import { Pipeline } from "../pipeline";
+import type { MapGenerator } from "../types";
+import { createWorld } from "../world";
+import { paintMaskToContext } from "./paintMaskToContext";
+
+const PASSES = [
+  resetPass,
+  defineThemePass,
+  generateHeightmapPass,
+  applyThemeHeightmapModsPass,
+  paintSubstrateMaskPass,
+  carveCavesPass,
+  finalizeMaskPass,
+];
+
+/**
+ * Pipeline-based world generator. Wires the v1 substrate + carving passes
+ * (7 of 14 total per docs/guides/world-gen-passes-v1.md). Materializes the
+ * resulting Uint8Array mask onto the canvas at the boundary.
+ *
+ * opts.themeTag selects the theme; defaults to "default" if absent. Accepts
+ * any tag registered in src/maps/themes.ts (default, canyon, snow, jungle,
+ * plateau, volcanic).
+ *
+ * Goal is architecture demonstration, not byte-parity with the legacy
+ * terraworld map. Same seed produces a different mask because the pipeline
+ * uses rngForPass per pass instead of a single shared cursor.
+ */
+export const terraworldV1Generator: MapGenerator = (ctx, widthPx, heightPx, opts) => {
+  const themeTag = (opts.themeTag as string | undefined) ?? "default";
+  const world = createWorld(opts.seed, widthPx, heightPx, themeTag);
+  new Pipeline(PASSES).run(world);
+  paintMaskToContext(ctx, world.mask, widthPx, heightPx);
+};

--- a/src/maps/passes/carveCaves.test.ts
+++ b/src/maps/passes/carveCaves.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { MASK_AIR, MASK_SOLID, createWorld } from "../world";
+import type { World } from "../world";
+import { carveCavesPass } from "./carveCaves";
+
+function setupWorld(seed: number, w: number, h: number, themeTag: string): World {
+  const world = createWorld(seed, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  // Pre-populate heightmap and mask as if substrate passes had run.
+  // For testing CarveCaves in isolation, set surface at midline and fill solid below.
+  const surfaceY = Math.floor(h * 0.55);
+  for (let x = 0; x < w; x++) world.heightmap[x] = surfaceY;
+  for (let y = surfaceY; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      world.mask[y * w + x] = MASK_SOLID;
+    }
+  }
+  return world;
+}
+
+function makeCtx(world: World, passIndex: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+describe("carveCavesPass", () => {
+  it("is deterministic: same seed produces same mask", () => {
+    const w1 = setupWorld(42, 400, 300, "default");
+    const w2 = setupWorld(42, 400, 300, "default");
+    carveCavesPass.run(makeCtx(w1, 5));
+    carveCavesPass.run(makeCtx(w2, 5));
+    expect(Array.from(w1.mask)).toEqual(Array.from(w2.mask));
+  });
+
+  it("wantsCaves=false produces no mask changes", () => {
+    const world = setupWorld(42, 400, 300, "default");
+    // Override theme flag for this test. theme is non-null because setupWorld sets it.
+    const theme = world.theme;
+    if (!theme) throw new Error("setupWorld must set world.theme");
+    world.theme = { ...theme, flags: { ...theme.flags, wantsCaves: false } };
+    const before = Array.from(world.mask);
+    carveCavesPass.run(makeCtx(world, 5));
+    expect(Array.from(world.mask)).toEqual(before);
+  });
+
+  it("preserves the surface-buffer crust on non-void columns", () => {
+    // Use a world tall enough that surfaceY (h*0.55) + surfaceBufferPx (80) < heightPx.
+    // 400x300: surfaceY=165, 165+80=245 < 300.
+    const world = setupWorld(42, 400, 300, "default");
+    carveCavesPass.run(makeCtx(world, 5));
+    // Sample column 50; the top surfaceBufferPx pixels of solid should remain solid.
+    const surfY = world.heightmap[50] ?? 0;
+    const buffer = tuning.caves.surfaceBufferPx;
+    for (let y = surfY; y < surfY + buffer; y++) {
+      expect(world.mask[y * 400 + 50]).toBe(MASK_SOLID);
+    }
+  });
+
+  it("void columns (surfaceY === heightPx) leave the mask unchanged", () => {
+    const world = setupWorld(42, 400, 300, "canyon");
+    // Manually mark some columns as void after substrate setup
+    for (let x = 80; x < 120; x++) {
+      world.heightmap[x] = world.heightPx;
+      // Clear the mask in those columns (as PaintSubstrateMask would)
+      for (let y = 0; y < world.heightPx; y++) {
+        world.mask[y * world.widthPx + x] = MASK_AIR;
+      }
+    }
+    carveCavesPass.run(makeCtx(world, 5));
+    // Void columns should remain entirely air after CarveCaves.
+    for (let x = 80; x < 120; x++) {
+      for (let y = 0; y < world.heightPx; y++) {
+        expect(world.mask[y * world.widthPx + x]).toBe(MASK_AIR);
+      }
+    }
+  });
+
+  it("default theme on 600x500: at least some pixels become air below the surface buffer (caves carved)", () => {
+    // World must have enough depth below the surface buffer for CA to carve caves.
+    // 600x500: surfaceY = floor(500*0.55) = 275, buffer = 80, carveable = 500-355 = 145px ~= 6 cell rows.
+    // With 6 rows of carveable cells insulated from the boundary, B5/S4 at fill=0.5 reliably carves chambers.
+    const world = setupWorld(42, 600, 500, "default");
+    carveCavesPass.run(makeCtx(world, 5));
+    let airBelowBuffer = 0;
+    for (let x = 0; x < 600; x++) {
+      const surfY = world.heightmap[x] ?? 0;
+      const bufferEnd = surfY + tuning.caves.surfaceBufferPx;
+      for (let y = bufferEnd; y < 500; y++) {
+        if (world.mask[y * 600 + x] === MASK_AIR) airBelowBuffer++;
+      }
+    }
+    expect(airBelowBuffer).toBeGreaterThan(0);
+  });
+
+  it("throws on null theme", () => {
+    const world = createWorld(42, 100, 100, "default");
+    // Don't set world.theme - leave it null
+    expect(() => carveCavesPass.run(makeCtx(world, 5))).toThrow(/DefineTheme must run first/);
+  });
+});

--- a/src/maps/passes/carveCaves.ts
+++ b/src/maps/passes/carveCaves.ts
@@ -1,0 +1,112 @@
+import type { Pass } from "../pass";
+import { MASK_AIR } from "../world";
+
+/**
+ * Cellular-automata cave carver, byte-mask edition. Replicates the algorithm
+ * in src/maps/caves/cellularAutomata.ts but operates on world.mask: Uint8Array
+ * directly instead of CanvasRenderingContext2D. The CA cell grid (cols * rows
+ * of 1=solid/0=void) is a temporary internal Uint8Array; only the final
+ * void-cell pixel writes touch world.mask.
+ *
+ * Theme params:
+ * - cellSizePx (default tuning.caves.cellSizePx = 24): cell granularity
+ * - initialFillRatio (default tuning.caves.initialFillRatio = 0.5): probability solid
+ * - caveIterations (default tuning.caves.iterations = 4): CA iteration count.
+ *   Note: theme key is `caveIterations`; tuning key is `iterations`.
+ * - surfaceBufferPx (default tuning.caves.surfaceBufferPx = 80): pixels of crust
+ *
+ * Surface source: world.heightmap[x] (Int32Array populated by GenerateHeightmap).
+ * Void columns (heightmap[x] === heightPx) naturally have surfY+bufferPx > heightPx,
+ * so all cells in those columns force-solid; no carving applied; mask unchanged
+ * (was already all-air from PaintSubstrateMask).
+ *
+ * Per-pass RNG count is deterministic for given (widthPx, heightPx, cellSizePx,
+ * initialFillRatio, surfaceBuffer state): exactly one rng() call per non-buffer
+ * cell during initial fill. CA iterations consume zero rng.
+ */
+export const carveCavesPass: Pass = {
+  name: "CarveCaves",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("CarveCaves: world.theme is null; DefineTheme must run first");
+    }
+    if (!world.theme.flags.wantsCaves) return;
+
+    const { widthPx, heightPx, mask, heightmap } = world;
+    const cellSizePx = resolveParam("cellSizePx", tuning.caves.cellSizePx);
+    const initialFillRatio = resolveParam("initialFillRatio", tuning.caves.initialFillRatio);
+    const iterations = resolveParam("caveIterations", tuning.caves.iterations);
+    const surfaceBufferPx = resolveParam("surfaceBufferPx", tuning.caves.surfaceBufferPx);
+
+    const cols = Math.ceil(widthPx / cellSizePx);
+    const rows = Math.ceil(heightPx / cellSizePx);
+    const total = cols * rows;
+
+    const isCellAboveSurfaceBuffer = (cx: number, cy: number): boolean => {
+      const cellCenterX = Math.min(Math.floor(cx * cellSizePx + cellSizePx / 2), widthPx - 1);
+      const cellCenterY = Math.floor(cy * cellSizePx + cellSizePx / 2);
+      const surfY = heightmap[cellCenterX] ?? 0;
+      return cellCenterY < surfY + surfaceBufferPx;
+    };
+
+    let cells = new Uint8Array(total);
+    for (let cy = 0; cy < rows; cy++) {
+      for (let cx = 0; cx < cols; cx++) {
+        const idx = cy * cols + cx;
+        if (isCellAboveSurfaceBuffer(cx, cy)) {
+          cells[idx] = 1;
+        } else {
+          cells[idx] = rng() < initialFillRatio ? 1 : 0;
+        }
+      }
+    }
+
+    for (let iter = 0; iter < iterations; iter++) {
+      const next = new Uint8Array(total);
+      for (let cy = 0; cy < rows; cy++) {
+        for (let cx = 0; cx < cols; cx++) {
+          const idx = cy * cols + cx;
+          if (isCellAboveSurfaceBuffer(cx, cy)) {
+            next[idx] = 1;
+            continue;
+          }
+          let solidCount = 0;
+          for (let dy = -1; dy <= 1; dy++) {
+            for (let dx = -1; dx <= 1; dx++) {
+              if (dx === 0 && dy === 0) continue;
+              const nx = cx + dx;
+              const ny = cy + dy;
+              if (nx < 0 || nx >= cols || ny < 0 || ny >= rows) {
+                solidCount++;
+              } else {
+                solidCount += cells[ny * cols + nx] ?? 0;
+              }
+            }
+          }
+          const wasSolid = cells[idx] === 1;
+          next[idx] = solidCount >= 5 || (wasSolid && solidCount >= 4) ? 1 : 0;
+        }
+      }
+      cells = next;
+    }
+
+    for (let cy = 0; cy < rows; cy++) {
+      for (let cx = 0; cx < cols; cx++) {
+        const idx = cy * cols + cx;
+        if ((cells[idx] ?? 1) !== 0) continue;
+        const pixelX0 = cx * cellSizePx;
+        const pixelY0 = cy * cellSizePx;
+        const pixelX1 = Math.min(pixelX0 + cellSizePx, widthPx);
+        const pixelY1 = Math.min(pixelY0 + cellSizePx, heightPx);
+        for (let py = pixelY0; py < pixelY1; py++) {
+          for (let px = pixelX0; px < pixelX1; px++) {
+            const surfY = heightmap[px] ?? 0;
+            if (py >= surfY + surfaceBufferPx) {
+              mask[py * widthPx + px] = MASK_AIR;
+            }
+          }
+        }
+      }
+    }
+  },
+};

--- a/src/maps/passes/finalizeMask.test.ts
+++ b/src/maps/passes/finalizeMask.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import type { Theme } from "../themes";
+import { MASK_AIR, MASK_SOLID, createWorld } from "../world";
+import type { World } from "../world";
+import { finalizeMaskPass } from "./finalizeMask";
+
+function makeCtx(world: World, passIndex: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag: string): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+/** Return a copy of a theme with maskHygieneThresholdPx overridden. */
+function withThreshold(base: Theme, px: number): Theme {
+  return { ...base, params: { ...base.params, maskHygieneThresholdPx: px } };
+}
+
+describe("finalizeMaskPass", () => {
+  it("removes a small orphan island below threshold while preserving large main", () => {
+    // 100x100 world. Big main component on the right half (50*100=5000 px).
+    // Small island at top-left (5x5 = 25 px).
+    const world = setupWorld(100, 100, "default");
+    // Override threshold via theme param for predictable test
+    world.theme = withThreshold(getTheme("default"), 50);
+    // Big main: x in [50, 100), y in [0, 100)
+    for (let y = 0; y < 100; y++) {
+      for (let x = 50; x < 100; x++) world.mask[y * 100 + x] = MASK_SOLID;
+    }
+    // Small island: x in [10, 15), y in [10, 15)
+    for (let y = 10; y < 15; y++) {
+      for (let x = 10; x < 15; x++) world.mask[y * 100 + x] = MASK_SOLID;
+    }
+    finalizeMaskPass.run(makeCtx(world, 7));
+    // Small island removed
+    for (let y = 10; y < 15; y++) {
+      for (let x = 10; x < 15; x++) {
+        expect(world.mask[y * 100 + x]).toBe(MASK_AIR);
+      }
+    }
+    // Main intact (sample a few)
+    expect(world.mask[0 * 100 + 50]).toBe(MASK_SOLID);
+    expect(world.mask[50 * 100 + 75]).toBe(MASK_SOLID);
+    expect(world.mask[99 * 100 + 99]).toBe(MASK_SOLID);
+  });
+
+  it("is deterministic: identical mask in produces identical mask out", () => {
+    const w1 = setupWorld(50, 50, "default");
+    const w2 = setupWorld(50, 50, "default");
+    // Pre-populate identical patterns
+    for (let i = 0; i < 50 * 50; i++) {
+      const v: 0 | 1 = i % 7 === 0 ? 1 : 0;
+      w1.mask[i] = v;
+      w2.mask[i] = v;
+    }
+    finalizeMaskPass.run(makeCtx(w1, 7));
+    finalizeMaskPass.run(makeCtx(w2, 7));
+    expect(Array.from(w1.mask)).toEqual(Array.from(w2.mask));
+  });
+
+  it("threshold = 0 is a no-op (early return)", () => {
+    const world = setupWorld(20, 20, "default");
+    world.theme = withThreshold(getTheme("default"), 0);
+    // Single isolated solid pixel
+    world.mask[10 * 20 + 10] = MASK_SOLID;
+    finalizeMaskPass.run(makeCtx(world, 7));
+    expect(world.mask[10 * 20 + 10]).toBe(MASK_SOLID);
+  });
+
+  it("theme threshold override beats tuning default", () => {
+    const world = setupWorld(20, 20, "default");
+    // Solid component of size 10
+    for (let i = 0; i < 10; i++) world.mask[i] = MASK_SOLID;
+    // tuning.worldgen.hygiene.thresholdPx default after this PR is 1024;
+    // but we override via theme param to 100. Component (10) < threshold (100): removed.
+    world.theme = withThreshold(getTheme("default"), 100);
+    finalizeMaskPass.run(makeCtx(world, 7));
+    for (let i = 0; i < 10; i++) expect(world.mask[i]).toBe(MASK_AIR);
+  });
+
+  it("preserves a component exactly at the threshold", () => {
+    const world = setupWorld(20, 20, "default");
+    // Solid component of size 100
+    for (let i = 0; i < 100; i++) world.mask[i] = MASK_SOLID;
+    world.theme = withThreshold(getTheme("default"), 100);
+    finalizeMaskPass.run(makeCtx(world, 7));
+    // 100 >= threshold 100, so component is preserved
+    for (let i = 0; i < 100; i++) expect(world.mask[i]).toBe(MASK_SOLID);
+  });
+
+  it("uses 4-connectivity (diagonal pixels are not connected)", () => {
+    const world = setupWorld(20, 20, "default");
+    world.theme = withThreshold(getTheme("default"), 5);
+    // Two solid pixels at (5,5) and (6,6) - diagonal neighbors only
+    world.mask[5 * 20 + 5] = MASK_SOLID;
+    world.mask[6 * 20 + 6] = MASK_SOLID;
+    finalizeMaskPass.run(makeCtx(world, 7));
+    // Both should be removed: each is its own 1-pixel component, 1 < 5
+    expect(world.mask[5 * 20 + 5]).toBe(MASK_AIR);
+    expect(world.mask[6 * 20 + 6]).toBe(MASK_AIR);
+  });
+
+  it("throws on null theme", () => {
+    const world = createWorld(0, 20, 20, "default");
+    // Leave world.theme null
+    expect(() => finalizeMaskPass.run(makeCtx(world, 7))).toThrow(/DefineTheme must run first/);
+  });
+});

--- a/src/maps/passes/finalizeMask.ts
+++ b/src/maps/passes/finalizeMask.ts
@@ -1,0 +1,108 @@
+import type { Pass } from "../pass";
+import { MASK_AIR, MASK_SOLID } from "../world";
+
+/**
+ * Connected-components scan that removes orphaned solid components below a
+ * pixel-count threshold. The post-CarveCaves cleanup pass.
+ *
+ * Algorithm: BFS with a number[] queue + head pointer (queue[qHead++] for O(1)
+ * "shift"; queue.shift() is O(n) in JS). 4-connectivity per the convergent
+ * shipped pattern (Sebastian Lague's cave-gen reference + scikit-image's
+ * remove_small_objects default).
+ *
+ * Threshold: theme.params.maskHygieneThresholdPx ?? tuning.worldgen.hygiene.thresholdPx.
+ * Default 1024 px is approximately 1.8 CA cells at default cellSizePx=24,
+ * sized to remove single-cell orphans while preserving any 2+ cell features.
+ *
+ * Memory profile: visited Uint8Array (1 byte per pixel, capped at world size).
+ * The BFS queue is a number[] that grows to peak frontier (~O(perimeter), not
+ * O(area)). Per-component componentPixels[] is bounded at threshold entries
+ * (early-aborts when component is large enough to keep, freeing the array).
+ *
+ * Determinism: top-left to bottom-right scan order, fixed neighbor ordering.
+ * No RNG used.
+ *
+ * Throws if world.theme is null (FinalizeMask depends on theme.params resolution).
+ */
+export const finalizeMaskPass: Pass = {
+  name: "FinalizeMask",
+  run: ({ world, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("FinalizeMask: world.theme is null; DefineTheme must run first");
+    }
+
+    const { widthPx, heightPx, mask } = world;
+    const threshold = resolveParam("maskHygieneThresholdPx", tuning.worldgen.hygiene.thresholdPx);
+    if (threshold <= 0) return;
+
+    const visited = new Uint8Array(widthPx * heightPx);
+
+    for (let startY = 0; startY < heightPx; startY++) {
+      for (let startX = 0; startX < widthPx; startX++) {
+        const startIdx = startY * widthPx + startX;
+        if (visited[startIdx]) continue;
+        if (mask[startIdx] !== MASK_SOLID) {
+          visited[startIdx] = 1;
+          continue;
+        }
+
+        // BFS for the connected solid component starting at (startX, startY).
+        // Mark visited at push time (standard BFS optimization to avoid
+        // duplicate work). 4-connectivity.
+        const queue: number[] = [startIdx];
+        let qHead = 0;
+        const componentPixels: number[] = [];
+        let aborted = false;
+        visited[startIdx] = 1;
+
+        while (qHead < queue.length) {
+          const idx = queue[qHead++] as number;
+
+          if (!aborted) {
+            componentPixels.push(idx);
+            if (componentPixels.length >= threshold) {
+              aborted = true;
+              componentPixels.length = 0;
+            }
+          }
+
+          const cx = idx % widthPx;
+          const cy = (idx - cx) / widthPx;
+
+          if (cx > 0) {
+            const n = idx - 1;
+            if (!visited[n] && mask[n] === MASK_SOLID) {
+              visited[n] = 1;
+              queue.push(n);
+            }
+          }
+          if (cx < widthPx - 1) {
+            const n = idx + 1;
+            if (!visited[n] && mask[n] === MASK_SOLID) {
+              visited[n] = 1;
+              queue.push(n);
+            }
+          }
+          if (cy > 0) {
+            const n = idx - widthPx;
+            if (!visited[n] && mask[n] === MASK_SOLID) {
+              visited[n] = 1;
+              queue.push(n);
+            }
+          }
+          if (cy < heightPx - 1) {
+            const n = idx + widthPx;
+            if (!visited[n] && mask[n] === MASK_SOLID) {
+              visited[n] = 1;
+              queue.push(n);
+            }
+          }
+        }
+
+        if (!aborted) {
+          for (const p of componentPixels) mask[p] = MASK_AIR;
+        }
+      }
+    }
+  },
+};

--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -8,6 +8,7 @@ import { islandGenerator } from "./generators/island";
 import { plateauGenerator } from "./generators/plateau";
 import { spireGenerator } from "./generators/spire";
 import { terraworldGenerator } from "./generators/terraworld";
+import { terraworldV1Generator } from "./generators/terraworldV1";
 import type { MapConfig, MapGenerator } from "./types";
 
 type RegistryEntry = { config: MapConfig; generator: MapGenerator };
@@ -127,6 +128,27 @@ export const MAPS: Record<string, RegistryEntry> = {
       generator: { id: "terraworld", seed: 0 },
     },
     generator: terraworldGenerator,
+  },
+  terraworld_v1: {
+    config: {
+      id: "terraworld_v1",
+      name: "Terraworld v1",
+      description: "Pipeline-based terraworld using the v1 substrate + carving passes.",
+      maxWorms: 4,
+      generator: { id: "terraworld_v1", seed: 0 },
+    },
+    generator: terraworldV1Generator,
+  },
+  canyon_v1: {
+    config: {
+      id: "canyon_v1",
+      name: "Canyon v1",
+      description: "Pipeline-based canyon (theme=canyon) for offline testing.",
+      maxWorms: 4,
+      generator: { id: "canyon_v1", seed: 0, options: { themeTag: "canyon" } },
+      visibleInLobby: false,
+    },
+    generator: terraworldV1Generator,
   },
 };
 

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -128,7 +128,10 @@ export interface Tuning {
       depthPx: number;
     };
     hygiene: {
-      /** Minimum mask-island size (in pixels) to keep during FinalizeMask. Smaller than this is removed as orphan debris. */
+      /** Minimum mask-island size in pixels. Components smaller than this are
+       *  removed as orphan debris by FinalizeMask. Default 1024 is approximately
+       *  1.8 CA cells at default cellSizePx=24, calibrated to remove single-cell
+       *  orphans while preserving 2+ cell features. Adjust if cellSizePx changes. */
       thresholdPx: number;
     };
     spawn: {
@@ -248,7 +251,7 @@ export const tuning: Tuning = {
       depthPx: 3,
     },
     hygiene: {
-      thresholdPx: 16,
+      thresholdPx: 1024,
     },
     spawn: {
       densityPx: 200,

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -64,6 +64,8 @@ const MAP_WHITELIST = [
   "canyon_legacy",
   "plateau",
   "terraworld",
+  "terraworld_v1",
+  "canyon_v1",
 ] as const;
 const MIN_PLAYERS_TO_START = 2;
 const MAX_CLIENTS = 8;


### PR DESCRIPTION
## Summary

PR 3 of the world-gen v1 pipeline. Adds the 2 carving passes (CarveCaves, FinalizeMask) and wires all 7 substrate+carving passes through a new \`terraworldV1\` MapGenerator registered side-by-side with the legacy terraworld.

Tracks worms#150.

## Workstreams (3 parallel Sonnet agents)

- **WS-A \`feature/worldgen-pass-carve-caves\`** - CarveCaves pass. Byte-mask edition of cellularAutomata.ts: same B5/S4 cellular automaton, same surface-buffer protection, same out-of-bounds-as-solid behavior, same RNG-call count, but operates on \`world.mask: Uint8Array\` and reads \`world.heightmap[x]\` as the surface source. Gated by \`theme.flags.wantsCaves\`. Resolves cellSizePx/initialFillRatio/caveIterations/surfaceBufferPx via \`resolveParam\`.
- **WS-B \`feature/worldgen-pass-finalize-mask\`** - FinalizeMask pass + tuning bump. BFS connected-components scan with \`number[]\` queue + head pointer (O(1) "shift") and 4-connectivity, per the convergent shipped pattern (Sebastian Lague's cave-gen reference + scikit-image's \`remove_small_objects\` default). Marks visited at push time. Component pixels capped at threshold via early abort. Bumps \`tuning.worldgen.hygiene.thresholdPx\` from placeholder 16 to 1024 (~1.8 CA cells at default cellSizePx=24).
- **WS-C \`feature/worldgen-paint-mask-helper\`** - \`paintMaskToContext\` helper. Materializes a Uint8Array mask onto a CanvasRenderingContext2D via getImageData/putImageData. Writes RGB=255 + alpha=255 for solid (matches existing \`fillStyle="#ffffff"\` convention).

## Integration phase

- New \`src/maps/generators/terraworldV1.ts\` wires all 7 passes (Reset, DefineTheme, GenerateHeightmap, ApplyThemeHeightmapMods, PaintSubstrateMask, CarveCaves, FinalizeMask) through Pipeline. Materializes byte mask via paintMaskToContext.
- Registry adds 2 entries: \`terraworld_v1\` (visible in lobby) and \`canyon_v1\` (hidden, accessible via \`?map=canyon_v1\` for offline testing).
- Worker \`MAP_WHITELIST\` updated to admit the new ids; without this the lobby would reject them with \`invalid_map\`.
- Integration test asserts caves carved (mixed opaque/transparent), canyon gap exists in middle column, same-seed determinism, different-seed and different-theme divergence.

## Goal: architecture demonstration, NOT byte-parity

The pipeline uses \`rngForPass(seed, passIndex)\` per pass; the legacy terraworld uses a single shared xorshift cursor. **Byte-parity is impossible by construction.** terraworld_v1 is a side-by-side architecture demonstration showing the v1 pipeline works end-to-end. Visual review during playtest, not byte-comparison.

## Cross-cutting decisions: grounded via the process appendix

The 5-question discipline (\`docs/guides/world-gen-design.md\` process appendix) was applied to FinalizeMask choices:
- **4-connectivity**: convergent prior art (Lague + scikit-image both default).
- **Queue: number[] + head pointer**: matches Lague's shipped C# Queue<Coord> pattern; realistic frontier is O(perimeter), not O(area).
- **Threshold default 1024**: researched anchors (Lague's 50 cells too aggressive at 28,800 px; scikit-image's 64 too small for our CA-domain). 1024 = ~1.8 CA cells, removes single-cell orphans.

## Test status

- 376 tests passing (was 353 on PR 2 master; +18 from WS-A/B/C + 5 from integration test)
- tsc clean
- biome clean

## Bugcheck Phase 3

5 parallel adversarial lenses (algorithm correctness, FinalizeMask BFS edge cases, generator wire-up, determinism, regression+perf+edge cases). **All clean. No Critical, no High, no Medium, no Low.**

## Out of scope (deferred)

- CarveTunnels (long-distance horizontal carving) - future enhancement
- Materials-aware stratum painter - PR 4
- Theme-overridable heightmap params (canyon visual mismatch with default 0.55 baseline vs legacy 0.28-0.38) - PR 8
- Removing legacy terraworld map - PR 8 retirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)