### PR TITLE
feat(worldgen): PR 5 - dressing passes (PlaceCaveAmbient + PlaceSurfaceDressing)

### DIFF
--- a/docs/plans/worldgen-pr5-dressing.md
+++ b/docs/plans/worldgen-pr5-dressing.md
@@ -1,0 +1,547 @@
+# World-gen PR 5: Dressing Passes (PlaceCaveAmbient + PlaceSurfaceDressing)
+
+**Position:** PR 5 of ~6-8 in the world-gen v1 roadmap. Tracks worms#150.
+
+**Status:** Approved. Ready for `/build`.
+
+## Multi-PR roadmap context
+
+Already shipped on master:
+- PR 1 (worms#167): foundation - Pipeline, World struct (Uint8Array mask + materialMap), Pass interface, RNG helper, theme schema, tuning extensions
+- PR 2 (worms#168): substrate passes - Reset, DefineTheme, GenerateHeightmap, ApplyThemeHeightmapMods, PaintSubstrateMask
+- PR 3 (worms#169): carving passes (CarveCaves, FinalizeMask) + terraworldV1 generator + paintMaskToContext
+- PR 4 (worms#170): material passes (PaintMaterialBands, PaintSurfaceCrust) + materials-aware paintWorldToContext + prePainted flag
+
+PR 5 (this plan) adds passes 10-11 of 14: PlaceCaveAmbient and PlaceSurfaceDressing. After this, terraworldV1 will run 11 of 14 v1 passes. PR 6 covers spawn distribution + validation tail.
+
+## What PR 5 delivers
+
+1. **PlaceCaveAmbient pass** (pass 10): writes to `world.caveAmbient: AmbientFeature[]`. Theme-gated by `theme.flags.wantsCaveAmbient`. Type per theme: "frost" (snow), "moss" (jungle), "glow" (volcanic). Other themes never reach the pass body.
+2. **PlaceSurfaceDressing pass** (pass 11): writes to `world.surfaceDressing: DressingFeature[]`. Theme-gated by NEW flag `theme.flags.wantsSurfaceDressing`. Sprite per theme: "grass_tuft" (default, jungle), "cactus" (canyon), "snow_drift" (snow), "ash_pile" (volcanic). Plateau opts out.
+3. **paintDecorationToContext helper**: procedural canvas drawing for the two feature arrays.
+4. **Integration**: terraworldV1 appends both passes; calls paintDecorationToContext after paintWorldToContext.
+
+## Architectural decisions (5-question discipline applied)
+
+### Decision 1: Density convention - attempt-count, not spacing
+
+| Question | Answer |
+|---|---|
+| Bible cite | Silent. |
+| Consensus cite | None. |
+| Prior art | Terraria: `attempts = worldArea * 6E-05` for vanilla decoration passes (https://github.com/tModLoader/tModLoader/blob/master/ExampleMod/ExampleWorld.cs). Each attempt picks uniform random (x, y) and tries to place; no-ops on invalid placement. Phaser dungeon tutorials use per-room probability. Sebastian Lague has no decoration system. |
+| Simplest sufficient | Attempt-count style matches the convergent shipped pattern. |
+| Bite | Random clustering means uneven decoration; some columns/regions get nothing. Acceptable; Terraria has the same property. Per-theme tunable. |
+
+**Decision: attempt-count style.**
+- PlaceCaveAmbient attempts = `max(8, floor(widthPx * heightPx * caveAmbientAttemptFactor))`. Default factor 0.00015 (Terraria's 6E-05 baseline scaled 2.5x for our higher no-op rate; many random points won't land in cave interior).
+- PlaceSurfaceDressing attempts = `max(4, floor(widthPx / surfaceDressingSpacingPx))`. Default spacing 40 (per-width since surface is 1D, not 2D area).
+
+### Decision 2: Vocabulary - keep strings
+
+| Question | Answer |
+|---|---|
+| Bible cite | Silent. |
+| Consensus cite | PR 1 foundation pinned `AmbientFeature.type: string` and `DressingFeature.sprite: string`. |
+| Prior art | Terraria uses integer enums (TileID.Sunflower=27). Noita uses strings at XML authoring boundary, u32 at runtime. Falling-sand engines use TypeID u32. String-only is less common but fine at our scale. |
+| Simplest sufficient | We have 7 strings total (3 ambient types + 4 sprite types). Integer enum gains nothing at this scale. |
+| Bite | If we add a sprite atlas pipeline later, we'd want integer ids. The string-to-integer migration is mechanical (one helper module). Easy fix. |
+
+**Decision: keep strings.** Painter silently skips unknown strings (Terraria's PlaceTile no-op-on-invalid pattern).
+
+### Decision 3: Data shape - separate arrays (deviation documented)
+
+| Question | Answer |
+|---|---|
+| Bible cite | Silent. |
+| Consensus cite | PR 1 foundation pinned `world.caveAmbient: AmbientFeature[]` and `world.surfaceDressing: DressingFeature[]`. |
+| Prior art | Convergent: shipped games write decoration into the substrate grid (Terraria tile id, Noita cell type, Phaser tilemap layer). No surveyed reference uses a separate feature list. |
+| Simplest sufficient | For our case (1-2 px decoration on a small feature count), arrays work. Materials grid integration would expand the palette per type; not better at our scale. |
+| Bite | Decoration drawing is a separate render step (paintDecorationToContext after paintWorldToContext). Two function calls instead of one. Networking would have to ship two arrays in addition to the mask if we want decoration to sync (already a known-deferred concern from PR 4). |
+
+**Decision: separate arrays, as PR 1 committed.** Documenting the deviation in the PR body.
+
+## Workstreams
+
+Three parallel Sonnet agents. Each owns disjoint files for clean merge.
+
+### WS-A: PlaceCaveAmbient pass
+
+**Worktree:** `/home/scott/worms-pr5-ws-a`
+**Branch:** `feature/worldgen-pass-place-cave-ambient`
+**Setup:**
+```bash
+git -C /home/scott/worms-pr5-ws-a checkout -b feature/worldgen-pass-place-cave-ambient
+test -d /home/scott/worms-pr5-ws-a/node_modules || ln -s /home/scott/worms/node_modules /home/scott/worms-pr5-ws-a/node_modules
+```
+
+**Files (2 new):**
+- `src/maps/passes/placeCaveAmbient.ts`
+- `src/maps/passes/placeCaveAmbient.test.ts`
+
+**`src/maps/passes/placeCaveAmbient.ts`:**
+
+```typescript
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+import { MASK_AIR } from "../world";
+
+const AMBIENT_TYPE_BY_THEME: Record<string, string> = {
+  snow: "frost",
+  jungle: "moss",
+  volcanic: "glow",
+};
+
+/**
+ * Places ambient decoration features inside cave cavities. Theme-gated by
+ * theme.flags.wantsCaveAmbient. Type per theme: "frost" (snow), "moss"
+ * (jungle), "glow" (volcanic). Other themes return early.
+ *
+ * Uses Terraria's attempt-count density convention: attempts scale with
+ * world area (widthPx * heightPx * factor). Each attempt picks uniform
+ * random (x, y) and validates; invalid attempts no-op. Many attempts will
+ * not land in cave interior; that is expected and matches shipped procgen.
+ *
+ * RNG: 2 calls per attempt (rngInt for x and y).
+ */
+export const placeCaveAmbientPass: Pass = {
+  name: "PlaceCaveAmbient",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error(
+        "PlaceCaveAmbient: world.theme is null; DefineTheme must run first",
+      );
+    }
+    if (!world.theme.flags.wantsCaveAmbient) return;
+    const type = AMBIENT_TYPE_BY_THEME[world.theme.tag];
+    if (!type) return;
+
+    const { widthPx, heightPx, mask, heightmap } = world;
+    const factor = resolveParam(
+      "caveAmbientAttemptFactor",
+      tuning.worldgen.caveAmbient.attemptFactor,
+    );
+    if (factor <= 0) return;
+    const attempts = Math.max(8, Math.floor(widthPx * heightPx * factor));
+
+    for (let i = 0; i < attempts; i++) {
+      const cx = rngInt(rng, widthPx);
+      const cy = rngInt(rng, heightPx);
+      const surfY = heightmap[cx];
+      if (surfY === undefined || surfY >= heightPx) continue;
+      if (cy <= surfY) continue;
+      if (mask[cy * widthPx + cx] !== MASK_AIR) continue;
+      world.caveAmbient.push({ xPx: cx, yPx: cy, type });
+    }
+  },
+};
+```
+
+**`src/maps/passes/placeCaveAmbient.test.ts`:**
+
+Use vitest. Test setup helper builds a World with theme and pre-populated heightmap + mask (simulating post-CarveCaves state). Tests:
+
+1. `wantsCaveAmbient=false` (default theme) returns early; world.caveAmbient remains empty.
+2. Snow theme on a world with a carved cave produces frost-typed features inside the cave.
+3. All produced features satisfy: `mask[yPx*widthPx+xPx] === MASK_AIR && yPx > heightmap[xPx]`.
+4. Determinism: same seed produces same caveAmbient list (deep-equal).
+5. Theme.params.caveAmbientAttemptFactor override changes the produced count.
+6. Throws on null theme.
+
+**Cross-workstream constraint:** None. This file imports only from existing modules (pass, rng, world).
+
+**Acceptance:** tsc clean, biome clean, tests pass.
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr5-ws-a add src/maps/passes/placeCaveAmbient.ts src/maps/passes/placeCaveAmbient.test.ts
+git -C /home/scott/worms-pr5-ws-a commit -m "feat(worldgen): PlaceCaveAmbient pass
+
+Places ambient decoration features inside cave cavities via Terraria's
+attempt-count convention: attempts = worldArea * factor (default 0.00015).
+Each attempt picks uniform random (x, y) and validates that the position is
+in cave interior (below surface, mask = AIR). Theme-gated by
+theme.flags.wantsCaveAmbient with theme-keyed type strings (frost/moss/glow).
+
+Part of PR 5 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr5-ws-a push -u origin feature/worldgen-pass-place-cave-ambient
+```
+
+### WS-B: PlaceSurfaceDressing pass + theme schema extension
+
+**Worktree:** `/home/scott/worms-pr5-ws-b`
+**Branch:** `feature/worldgen-pass-place-surface-dressing`
+
+**Files (4):**
+- `src/maps/themes.ts` (modify) - add `wantsSurfaceDressing: boolean` to ThemeFlags interface; update all 6 themes
+- `src/maps/themes.test.ts` (modify if it tests flag presence)
+- `src/maps/passes/placeSurfaceDressing.ts` (new)
+- `src/maps/passes/placeSurfaceDressing.test.ts` (new)
+
+**Theme flag values to add:**
+- default: `wantsSurfaceDressing: true`
+- canyon: `wantsSurfaceDressing: true`
+- snow: `wantsSurfaceDressing: true`
+- jungle: `wantsSurfaceDressing: true`
+- plateau: `wantsSurfaceDressing: false`
+- volcanic: `wantsSurfaceDressing: true`
+
+**`src/maps/passes/placeSurfaceDressing.ts`:**
+
+```typescript
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+
+const DRESSING_SPRITE_BY_THEME: Record<string, string> = {
+  default: "grass_tuft",
+  canyon: "cactus",
+  snow: "snow_drift",
+  jungle: "grass_tuft",
+  volcanic: "ash_pile",
+};
+
+/**
+ * Places surface dressing features at uniform random columns along the
+ * surface. Theme-gated by theme.flags.wantsSurfaceDressing. Sprite per theme.
+ *
+ * Terraria-style: attempt count = floor(widthPx / spacingPx), uniform
+ * random x per attempt. Invalid columns (void, missing surface) no-op.
+ *
+ * RNG: 1 call per attempt.
+ */
+export const placeSurfaceDressingPass: Pass = {
+  name: "PlaceSurfaceDressing",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error(
+        "PlaceSurfaceDressing: world.theme is null; DefineTheme must run first",
+      );
+    }
+    if (!world.theme.flags.wantsSurfaceDressing) return;
+    const sprite = DRESSING_SPRITE_BY_THEME[world.theme.tag];
+    if (!sprite) return;
+
+    const { widthPx, heightPx, heightmap } = world;
+    const spacingPx = resolveParam(
+      "surfaceDressingSpacingPx",
+      tuning.worldgen.surfaceDressing.spacingPx,
+    );
+    if (spacingPx <= 0) return;
+    const attempts = Math.max(4, Math.floor(widthPx / spacingPx));
+
+    for (let i = 0; i < attempts; i++) {
+      const cx = rngInt(rng, widthPx);
+      const surfY = heightmap[cx];
+      if (surfY === undefined || surfY < 0 || surfY >= heightPx) continue;
+      const yPx = surfY - 1;
+      if (yPx < 0) continue;
+      world.surfaceDressing.push({ xPx: cx, yPx, sprite });
+    }
+  },
+};
+```
+
+**ThemeFlags extension:**
+
+```typescript
+export interface ThemeFlags {
+  wantsPeaks: boolean;
+  wantsCaves: boolean;
+  noFloor: boolean;
+  wantsSurfaceCrust: boolean;
+  wantsCaveAmbient: boolean;
+  wantsSurfaceDressing: boolean; // NEW
+}
+```
+
+Update each theme to include the new flag with the values above.
+
+**Tests for placeSurfaceDressing.test.ts:**
+
+1. Plateau theme (`wantsSurfaceDressing=false`) returns early; world.surfaceDressing remains empty.
+2. Default theme produces grass_tuft features.
+3. All produced features have `yPx === heightmap[xPx] - 1` and `heightmap[xPx]` is a valid surface (not void).
+4. Determinism.
+5. Theme.params.surfaceDressingSpacingPx override changes the produced count.
+6. Throws on null theme.
+
+**Tests for themes.test.ts:** verify all 6 themes have `wantsSurfaceDressing` as a boolean.
+
+**Cross-workstream constraint:** None. Self-contained.
+
+**Acceptance:** tsc clean, biome clean, tests pass.
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr5-ws-b add src/maps/themes.ts src/maps/themes.test.ts src/maps/passes/placeSurfaceDressing.ts src/maps/passes/placeSurfaceDressing.test.ts
+git -C /home/scott/worms-pr5-ws-b commit -m "feat(worldgen): PlaceSurfaceDressing pass + wantsSurfaceDressing flag
+
+Adds wantsSurfaceDressing to ThemeFlags. Plateau opts out (raw rock surface);
+all other themes have it true.
+
+Pass uses Terraria-style attempt-count density: attempts = widthPx / spacingPx
+(default 40), uniform random column per attempt. Sprite per theme: grass_tuft
+(default, jungle), cactus (canyon), snow_drift (snow), ash_pile (volcanic).
+
+Part of PR 5 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr5-ws-b push -u origin feature/worldgen-pass-place-surface-dressing
+```
+
+### WS-C: paintDecorationToContext helper
+
+**Worktree:** `/home/scott/worms-pr5-ws-c`
+**Branch:** `feature/worldgen-paint-decoration-helper`
+
+**Files (2 new):**
+- `src/maps/generators/paintDecorationToContext.ts`
+- `src/maps/generators/paintDecorationToContext.test.ts`
+
+**`src/maps/generators/paintDecorationToContext.ts`:**
+
+```typescript
+import type { AmbientFeature, DressingFeature } from "../world";
+
+const AMBIENT_COLORS: Record<string, string> = {
+  moss: "#2a5a1a",
+  frost: "#caf0ff",
+  glow: "#ff7a00",
+};
+
+const DRESSING_COLORS: Record<string, string> = {
+  grass_tuft: "#3a8a3a",
+  cactus: "#4a7a3a",
+  snow_drift: "#f5f7fa",
+  ash_pile: "#1a1a1a",
+};
+
+/**
+ * Renders cave ambient and surface dressing features onto a canvas via
+ * procedural shapes. Runs after paintWorldToContext (which paints the
+ * substrate + materials). Out-of-bounds features are clipped by the canvas.
+ *
+ * Cave ambient: 2x2 filled square at (xPx, yPx). Color from AMBIENT_COLORS
+ * keyed by feature.type.
+ *
+ * Surface dressing: 2x3 filled rect anchored at (xPx, yPx) extending
+ * upward (y - 2 to y + 1) so the dressing sits ON the surface. Color from
+ * DRESSING_COLORS keyed by feature.sprite.
+ *
+ * Unknown type or sprite strings are silently skipped (Terraria
+ * PlaceTile no-op-on-invalid convention).
+ */
+export function paintDecorationToContext(
+  ctx: CanvasRenderingContext2D,
+  ambient: readonly AmbientFeature[],
+  dressing: readonly DressingFeature[],
+): void {
+  for (const f of ambient) {
+    const color = AMBIENT_COLORS[f.type];
+    if (!color) continue;
+    ctx.fillStyle = color;
+    ctx.fillRect(f.xPx, f.yPx, 2, 2);
+  }
+  for (const f of dressing) {
+    const color = DRESSING_COLORS[f.sprite];
+    if (!color) continue;
+    ctx.fillStyle = color;
+    ctx.fillRect(f.xPx, f.yPx - 2, 2, 3);
+  }
+}
+```
+
+**Tests (use `canvas` npm package, consistent with paintWorldToContext.test.ts):**
+
+1. Single ambient feature paints the expected color at (xPx, yPx) over a 2x2 area.
+2. Single dressing feature paints the expected color at (xPx, yPx-2) over a 2x3 area.
+3. Unknown ambient type silently skipped; canvas unchanged in that region.
+4. Unknown dressing sprite silently skipped.
+5. Empty arrays no-op (no canvas changes).
+6. Mixed valid + invalid entries: valid ones paint, invalid skipped.
+
+**Cross-workstream constraint:** None. Imports only AmbientFeature and DressingFeature types from world.ts (existing).
+
+**Acceptance:** tsc clean, biome clean, tests pass.
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr5-ws-c add src/maps/generators/paintDecorationToContext.ts src/maps/generators/paintDecorationToContext.test.ts
+git -C /home/scott/worms-pr5-ws-c commit -m "feat(worldgen): paintDecorationToContext helper
+
+Procedural canvas drawing for cave ambient + surface dressing features.
+Maps type/sprite strings to small filled rect shapes via lookup tables.
+Unknown strings silently skip (Terraria no-op-on-invalid convention).
+
+Cave ambient: 2x2 filled squares.
+Surface dressing: 2x3 filled rects anchored above the surface.
+
+Future PR can swap to a sprite atlas without changing the pass interfaces.
+
+Part of PR 5 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr5-ws-c push -u origin feature/worldgen-paint-decoration-helper
+```
+
+## Integration phase (Opus during /build Phase 3)
+
+After WS-A, WS-B, WS-C merge into `integrate/worldgen-dressing`, Opus directly modifies on the integration branch:
+
+### 1. `src/tuning.ts`
+
+Add to the `worldgen` section type and value:
+
+**Type addition:**
+```typescript
+worldgen: {
+  // ... existing fields ...
+  caveAmbient: {
+    /** Attempt count = floor(widthPx * heightPx * factor). 0.00015 derives
+     *  from Terraria's 6E-05 baseline scaled 2.5x to compensate for higher
+     *  no-op rate (random points often miss carved cave interior). */
+    attemptFactor: number;
+  };
+  surfaceDressing: {
+    /** Attempt count = floor(widthPx / spacingPx). Per-width because
+     *  surface is a 1D feature, not 2D area. */
+    spacingPx: number;
+  };
+}
+```
+
+**Value addition:**
+```typescript
+caveAmbient: {
+  attemptFactor: 0.00015,
+},
+surfaceDressing: {
+  spacingPx: 40,
+},
+```
+
+### 2. `src/maps/themes.ts`
+
+Add to `ThemeParams`:
+```typescript
+caveAmbientAttemptFactor?: number;
+surfaceDressingSpacingPx?: number;
+```
+
+### 3. `src/maps/generators/terraworldV1.ts`
+
+Append the two new passes to PASSES (now 11 of 14). Updated array:
+
+```typescript
+import { placeCaveAmbientPass } from "../passes/placeCaveAmbient";
+import { placeSurfaceDressingPass } from "../passes/placeSurfaceDressing";
+import { paintDecorationToContext } from "./paintDecorationToContext";
+
+const PASSES = [
+  resetPass,
+  defineThemePass,
+  generateHeightmapPass,
+  applyThemeHeightmapModsPass,
+  paintSubstrateMaskPass,
+  paintMaterialBandsPass,
+  carveCavesPass,
+  finalizeMaskPass,
+  paintSurfaceCrustPass,
+  placeCaveAmbientPass,        // NEW pass 10
+  placeSurfaceDressingPass,    // NEW pass 11
+];
+```
+
+Update the generator's body to call paintDecorationToContext after paintWorldToContext:
+
+```typescript
+export const terraworldV1Generator: MapGenerator = (ctx, widthPx, heightPx, opts) => {
+  const themeTag = (opts.themeTag as string | undefined) ?? "default";
+  const world = createWorld(opts.seed, widthPx, heightPx, themeTag);
+  new Pipeline(PASSES).run(world);
+  if (!world.theme) {
+    throw new Error("terraworldV1: theme is null after pipeline run; DefineTheme should have populated it");
+  }
+  paintWorldToContext(ctx, world.mask, world.materialMap, world.theme.palette, widthPx, heightPx);
+  paintDecorationToContext(ctx, world.caveAmbient, world.surfaceDressing);
+};
+```
+
+### 4. `src/maps/generators/terraworldV1.integration.test.ts`
+
+Add two assertions:
+
+1. Snow theme produces caveAmbient features with type "frost" inside cave cavities. Verify by running the generator on a snow world and checking that there exists at least one pixel matching the AMBIENT_COLORS["frost"] color value (`#caf0ff`) inside what would be a cave region.
+2. Default theme produces surfaceDressing features with sprite "grass_tuft". Verify by running the generator on a default world and checking that at least one pixel matches DRESSING_COLORS["grass_tuft"] (`#3a8a3a`) just above a surface line.
+
+(Direct color comparison via `ctx.getImageData`; document that we are sampling for known palette colors as proof that the decoration painter ran.)
+
+## Bugcheck Phase 3 expectations
+
+Apply 5 lenses:
+1. Algorithm correctness (attempt math, validation predicates, theme-keyed lookups)
+2. Determinism (rngInt usage, no Math.random anywhere)
+3. Cross-pass interactions (decoration passes run AFTER FinalizeMask and PaintSurfaceCrust; reads heightmap and mask which are settled)
+4. Edge cases (tiny worlds, empty themes, missing types in lookup, attemptFactor=0, spacingPx=0)
+5. Renderer integration (paintDecorationToContext runs after paintWorldToContext; no conflicts on alpha; bounds clipping by canvas; networked path will lose decoration like materials in PR 4)
+
+Known issues to expect (acknowledge in PR body, not blockers):
+- Same Medium as PR 4: networked v1 maps lose decoration because the wire protocol is alpha-only.
+- Random clustering: some columns get no surface dressing, some get multiple. Acceptable per Terraria pattern.
+
+## PR body template
+
+```
+## Summary
+
+PR 5 of the world-gen v1 pipeline. Adds the 2 dressing passes and a
+procedural canvas painter for the resulting feature arrays. terraworldV1
+now runs 11 of 14 v1 passes.
+
+Tracks worms#150.
+
+## Workstreams
+
+- WS-A: PlaceCaveAmbient pass (Terraria-style attempt-count density)
+- WS-B: PlaceSurfaceDressing pass + wantsSurfaceDressing flag
+- WS-C: paintDecorationToContext helper (procedural shapes)
+
+## Integration
+
+- tuning.ts: caveAmbient.attemptFactor (0.00015), surfaceDressing.spacingPx (40)
+- ThemeParams: caveAmbientAttemptFactor, surfaceDressingSpacingPx (per-theme overrides)
+- terraworldV1.ts: appends 2 passes, calls paintDecorationToContext after paintWorldToContext
+- Integration test: assert frost ambient color (snow) and grass_tuft dressing color (default) appear
+
+## Process appendix discipline
+
+Three architectural decisions documented with the 5-question framework:
+- Density convention (attempt-count, grounded in Terraria's 6E-05 baseline)
+- Vocabulary (strings; Terraria/Noita use integers but our scale doesn't justify)
+- Data shape (separate arrays; documented deviation from in-grid prior art)
+
+## Known issue (Medium): networked decoration loss
+
+Same as PR 4: networked v1 clients lose materials and decoration because the
+wire protocol is alpha-only. Geometry (mask) syncs identically; only the
+visual layer differs between host and clients. Future fix is to encode
+materials + decoration in the wire protocol or have clients re-run gen
+from the seed.
+
+## Test plan
+
+- [x] No em dashes
+- [x] All tests pass (~410+ expected after PR 5)
+- [x] tsc clean
+- [x] biome clean
+- [x] Bugcheck Phase 3 complete
+- [ ] Manual review
+```
+
+## Out of scope (deferred)
+
+- Sprite atlas pipeline (would convert string vocab to integer ids)
+- Poisson-disc decoration spacing for more even distribution
+- Networked decoration sync
+- DistributeSpawnPoints + ValidateSpawnCoherence + FinalCleanup (PR 6)
+
+## How to execute
+
+1. `/clear` (this plan and the memory carry the plan forward)
+2. `/build` (executes the plan; reads `docs/plans/worldgen-pr5-dressing.md` for context)

--- a/src/maps/generators/paintDecorationToContext.test.ts
+++ b/src/maps/generators/paintDecorationToContext.test.ts
@@ -1,0 +1,100 @@
+import { createCanvas } from "canvas";
+import { describe, expect, it } from "vitest";
+import { paintDecorationToContext } from "./paintDecorationToContext";
+
+function makeCtx(w: number, h: number) {
+  const c = createCanvas(w, h);
+  return c.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+/** Read a single pixel as [R, G, B, A]. */
+function px(ctx: CanvasRenderingContext2D, x: number, y: number): [number, number, number, number] {
+  const d = ctx.getImageData(x, y, 1, 1).data;
+  return [d[0], d[1], d[2], d[3]];
+}
+
+describe("paintDecorationToContext", () => {
+  it("single ambient frost feature paints #caf0ff over a 2x2 area", () => {
+    const ctx = makeCtx(32, 32);
+    paintDecorationToContext(ctx, [{ xPx: 10, yPx: 20, type: "frost" }], []);
+    // #caf0ff = RGB(202, 240, 255)
+    expect(px(ctx, 10, 20)).toEqual([202, 240, 255, 255]);
+    expect(px(ctx, 11, 20)).toEqual([202, 240, 255, 255]);
+    expect(px(ctx, 10, 21)).toEqual([202, 240, 255, 255]);
+    expect(px(ctx, 11, 21)).toEqual([202, 240, 255, 255]);
+  });
+
+  it("single dressing grass_tuft feature paints #3a8a3a over fillRect(10, 18, 2, 3)", () => {
+    const ctx = makeCtx(32, 32);
+    paintDecorationToContext(ctx, [], [{ xPx: 10, yPx: 20, sprite: "grass_tuft" }]);
+    // fillRect(10, 20-2, 2, 3) = fillRect(10, 18, 2, 3) -> rows 18, 19, 20; cols 10, 11
+    // #3a8a3a = RGB(58, 138, 58)
+    expect(px(ctx, 10, 18)).toEqual([58, 138, 58, 255]);
+    expect(px(ctx, 11, 18)).toEqual([58, 138, 58, 255]);
+    expect(px(ctx, 10, 19)).toEqual([58, 138, 58, 255]);
+    expect(px(ctx, 11, 19)).toEqual([58, 138, 58, 255]);
+    expect(px(ctx, 10, 20)).toEqual([58, 138, 58, 255]);
+    expect(px(ctx, 11, 20)).toEqual([58, 138, 58, 255]);
+  });
+
+  it("unknown ambient type is silently skipped; canvas remains untouched", () => {
+    const ctx = makeCtx(32, 32);
+    paintDecorationToContext(ctx, [{ xPx: 5, yPx: 5, type: "nope" }], []);
+    // All pixels should remain at their default (transparent black)
+    expect(px(ctx, 5, 5)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 6, 5)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 5, 6)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 6, 6)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("unknown dressing sprite is silently skipped; canvas remains untouched", () => {
+    const ctx = makeCtx(32, 32);
+    paintDecorationToContext(ctx, [], [{ xPx: 5, yPx: 10, sprite: "nope" }]);
+    expect(px(ctx, 5, 8)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 5, 9)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 5, 10)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("empty arrays produce no canvas changes", () => {
+    const ctx = makeCtx(16, 16);
+    paintDecorationToContext(ctx, [], []);
+    // Spot-check several pixels; all should be default transparent black
+    expect(px(ctx, 0, 0)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 8, 8)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 15, 15)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("mixed valid + invalid entries: valid ones paint, invalid are skipped", () => {
+    const ctx = makeCtx(32, 32);
+    paintDecorationToContext(
+      ctx,
+      [
+        { xPx: 2, yPx: 2, type: "moss" }, // valid  -> #2a5a1a = RGB(42, 90, 26)
+        { xPx: 10, yPx: 2, type: "unknown" }, // invalid -> skipped
+      ],
+      [
+        { xPx: 2, yPx: 15, sprite: "ash_pile" }, // valid  -> #1a1a1a = RGB(26, 26, 26)
+        { xPx: 10, yPx: 15, sprite: "bad_sprite" }, // invalid -> skipped
+      ],
+    );
+
+    // Valid ambient: moss at (2,2) 2x2 -> #2a5a1a = RGB(42, 90, 26)
+    expect(px(ctx, 2, 2)).toEqual([42, 90, 26, 255]);
+    expect(px(ctx, 3, 2)).toEqual([42, 90, 26, 255]);
+    expect(px(ctx, 2, 3)).toEqual([42, 90, 26, 255]);
+    expect(px(ctx, 3, 3)).toEqual([42, 90, 26, 255]);
+
+    // Invalid ambient: location untouched
+    expect(px(ctx, 10, 2)).toEqual([0, 0, 0, 0]);
+
+    // Valid dressing: ash_pile at sprite=(2,15) -> fillRect(2, 13, 2, 3) -> rows 13,14,15
+    // #1a1a1a = RGB(26, 26, 26)
+    expect(px(ctx, 2, 13)).toEqual([26, 26, 26, 255]);
+    expect(px(ctx, 2, 14)).toEqual([26, 26, 26, 255]);
+    expect(px(ctx, 2, 15)).toEqual([26, 26, 26, 255]);
+
+    // Invalid dressing: location untouched
+    expect(px(ctx, 10, 13)).toEqual([0, 0, 0, 0]);
+    expect(px(ctx, 10, 15)).toEqual([0, 0, 0, 0]);
+  });
+});

--- a/src/maps/generators/paintDecorationToContext.ts
+++ b/src/maps/generators/paintDecorationToContext.ts
@@ -21,9 +21,10 @@ const DRESSING_COLORS: Record<string, string> = {
  * Cave ambient: 2x2 filled square at (xPx, yPx). Color from AMBIENT_COLORS
  * keyed by feature.type.
  *
- * Surface dressing: 2x3 filled rect anchored at (xPx, yPx) extending
- * upward (y - 2 to y + 1) so the dressing sits ON the surface. Color from
- * DRESSING_COLORS keyed by feature.sprite.
+ * Surface dressing: 2x3 filled rect at (xPx, yPx-2) covering rows
+ * (yPx-2, yPx-1, yPx). The pass sets yPx = surfY-1, so the rect's bottom
+ * row sits one pixel above the topmost substrate pixel - flush against
+ * the surface. Color from DRESSING_COLORS keyed by feature.sprite.
  *
  * Unknown type or sprite strings are silently skipped (Terraria
  * PlaceTile no-op-on-invalid convention).

--- a/src/maps/generators/paintDecorationToContext.ts
+++ b/src/maps/generators/paintDecorationToContext.ts
@@ -1,0 +1,48 @@
+import type { AmbientFeature, DressingFeature } from "../world";
+
+const AMBIENT_COLORS: Record<string, string> = {
+  moss: "#2a5a1a",
+  frost: "#caf0ff",
+  glow: "#ff7a00",
+};
+
+const DRESSING_COLORS: Record<string, string> = {
+  grass_tuft: "#3a8a3a",
+  cactus: "#4a7a3a",
+  snow_drift: "#f5f7fa",
+  ash_pile: "#1a1a1a",
+};
+
+/**
+ * Renders cave ambient and surface dressing features onto a canvas via
+ * procedural shapes. Runs after paintWorldToContext (which paints the
+ * substrate + materials). Out-of-bounds features are clipped by the canvas.
+ *
+ * Cave ambient: 2x2 filled square at (xPx, yPx). Color from AMBIENT_COLORS
+ * keyed by feature.type.
+ *
+ * Surface dressing: 2x3 filled rect anchored at (xPx, yPx) extending
+ * upward (y - 2 to y + 1) so the dressing sits ON the surface. Color from
+ * DRESSING_COLORS keyed by feature.sprite.
+ *
+ * Unknown type or sprite strings are silently skipped (Terraria
+ * PlaceTile no-op-on-invalid convention).
+ */
+export function paintDecorationToContext(
+  ctx: CanvasRenderingContext2D,
+  ambient: readonly AmbientFeature[],
+  dressing: readonly DressingFeature[],
+): void {
+  for (const f of ambient) {
+    const color = AMBIENT_COLORS[f.type];
+    if (!color) continue;
+    ctx.fillStyle = color;
+    ctx.fillRect(f.xPx, f.yPx, 2, 2);
+  }
+  for (const f of dressing) {
+    const color = DRESSING_COLORS[f.sprite];
+    if (!color) continue;
+    ctx.fillStyle = color;
+    ctx.fillRect(f.xPx, f.yPx - 2, 2, 3);
+  }
+}

--- a/src/maps/generators/terraworldV1.integration.test.ts
+++ b/src/maps/generators/terraworldV1.integration.test.ts
@@ -25,20 +25,23 @@ describe("terraworldV1 integration", () => {
     expect(transparent).toBeGreaterThan(0);
   });
 
-  it("default theme: opaque pixels have RGB matching the theme palette (not legacy stratumPaint)", () => {
+  it("default theme: opaque pixels have RGB matching the theme palette or known decoration colors", () => {
     const W = 400;
     const H = 300;
     const ctx = makeCtx(W, H);
     terraworldV1Generator(ctx, W, H, { seed: 42 });
     const data = ctx.getImageData(0, 0, W, H).data;
     const palette = getTheme("default").palette;
-    // Pre-extract palette RGB triples
-    const colors = [palette.surface, palette.mid, palette.rock, palette.deep].map((hex) => ({
+    // Palette colors (from substrate + crust passes)
+    const paletteColors = [palette.surface, palette.mid, palette.rock, palette.deep].map((hex) => ({
       r: (hex >> 16) & 0xff,
       g: (hex >> 8) & 0xff,
       b: hex & 0xff,
     }));
-    // Sample a handful of opaque pixels; each must match one of the palette colors
+    // Decoration colors emitted by paintDecorationToContext on the default theme.
+    // Default theme has wantsCaveAmbient=false and wantsSurfaceDressing=true with sprite=grass_tuft.
+    const decorationColors = [{ r: 0x3a, g: 0x8a, b: 0x3a }];
+    const allowedColors = [...paletteColors, ...decorationColors];
     let matched = 0;
     let sampled = 0;
     for (let i = 0; i < data.length && sampled < 100; i += 4) {
@@ -47,7 +50,7 @@ describe("terraworldV1 integration", () => {
       const r = data[i];
       const g = data[i + 1];
       const b = data[i + 2];
-      if (colors.some((c) => c.r === r && c.g === g && c.b === b)) matched++;
+      if (allowedColors.some((c) => c.r === r && c.g === g && c.b === b)) matched++;
     }
     expect(sampled).toBeGreaterThan(0);
     expect(matched).toBe(sampled);
@@ -120,5 +123,35 @@ describe("terraworldV1 integration", () => {
       }
     }
     expect(differs).toBe(true);
+  });
+
+  it("snow theme: canvas contains at least one frost ambient pixel (#caf0ff)", () => {
+    // Larger canvas: at 400x300 the carved caves fall below the FinalizeMask
+    // hygiene threshold (1024px) and get stripped, leaving no AIR below the
+    // surface for PlaceCaveAmbient to land in. 800x600 produces a stable
+    // cave area where ambient features land.
+    const W = 800;
+    const H = 600;
+    const ctx = makeCtx(W, H);
+    terraworldV1Generator(ctx, W, H, { seed: 42, themeTag: "snow" });
+    const data = ctx.getImageData(0, 0, W, H).data;
+    let frostHits = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i] === 0xca && data[i + 1] === 0xf0 && data[i + 2] === 0xff) frostHits++;
+    }
+    expect(frostHits).toBeGreaterThan(0);
+  });
+
+  it("default theme: canvas contains at least one grass_tuft dressing pixel (#3a8a3a)", () => {
+    const W = 400;
+    const H = 300;
+    const ctx = makeCtx(W, H);
+    terraworldV1Generator(ctx, W, H, { seed: 42 });
+    const data = ctx.getImageData(0, 0, W, H).data;
+    let grassHits = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i] === 0x3a && data[i + 1] === 0x8a && data[i + 2] === 0x3a) grassHits++;
+    }
+    expect(grassHits).toBeGreaterThan(0);
   });
 });

--- a/src/maps/generators/terraworldV1.ts
+++ b/src/maps/generators/terraworldV1.ts
@@ -6,14 +6,17 @@ import { generateHeightmapPass } from "../passes/generateHeightmap";
 import { paintMaterialBandsPass } from "../passes/paintMaterialBands";
 import { paintSubstrateMaskPass } from "../passes/paintSubstrateMask";
 import { paintSurfaceCrustPass } from "../passes/paintSurfaceCrust";
+import { placeCaveAmbientPass } from "../passes/placeCaveAmbient";
+import { placeSurfaceDressingPass } from "../passes/placeSurfaceDressing";
 import { resetPass } from "../passes/reset";
 import { Pipeline } from "../pipeline";
 import type { MapGenerator } from "../types";
 import { createWorld } from "../world";
+import { paintDecorationToContext } from "./paintDecorationToContext";
 import { paintWorldToContext } from "./paintWorldToContext";
 
 /**
- * v1 pipeline pass order (9 of 14 passes; spawn + validation deferred to PR 5+):
+ * v1 pipeline pass order (11 of 14 passes; spawn + validation deferred to PR 6):
  *  1. Reset
  *  2. DefineTheme
  *  3. GenerateHeightmap
@@ -23,6 +26,8 @@ import { paintWorldToContext } from "./paintWorldToContext";
  *  7. CarveCaves
  *  8. FinalizeMask
  *  9. PaintSurfaceCrust          (PR 4)
+ * 10. PlaceCaveAmbient           (PR 5)
+ * 11. PlaceSurfaceDressing       (PR 5)
  */
 const PASSES = [
   resetPass,
@@ -34,6 +39,8 @@ const PASSES = [
   carveCavesPass,
   finalizeMaskPass,
   paintSurfaceCrustPass,
+  placeCaveAmbientPass,
+  placeSurfaceDressingPass,
 ];
 
 /**
@@ -64,4 +71,5 @@ export const terraworldV1Generator: MapGenerator = (ctx, widthPx, heightPx, opts
     );
   }
   paintWorldToContext(ctx, world.mask, world.materialMap, world.theme.palette, widthPx, heightPx);
+  paintDecorationToContext(ctx, world.caveAmbient, world.surfaceDressing);
 };

--- a/src/maps/passes/placeCaveAmbient.test.ts
+++ b/src/maps/passes/placeCaveAmbient.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { MASK_AIR, MASK_SOLID, type World, createWorld } from "../world";
+import { placeCaveAmbientPass } from "./placeCaveAmbient";
+
+function makeCtx(world: World, passIndex: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag: string): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+/**
+ * Fills a world with a carved cave: surface crust at surfY, solid below surfY
+ * except for a rectangular cave pocket from caveTop..caveBottom (exclusive)
+ * and caveLeft..caveRight (exclusive), which is air.
+ */
+function setupWorldWithCave(
+  w: number,
+  h: number,
+  themeTag: string,
+  surfY: number,
+  caveTop: number,
+  caveBottom: number,
+  caveLeft: number,
+  caveRight: number,
+): World {
+  const world = setupWorld(w, h, themeTag);
+  // Fill heightmap: all columns have surface at surfY
+  for (let x = 0; x < w; x++) {
+    world.heightmap[x] = surfY;
+  }
+  // Fill mask: solid everywhere below surfY, then carve cave pocket to AIR
+  for (let y = surfY; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      world.mask[y * w + x] = MASK_SOLID;
+    }
+  }
+  for (let y = caveTop; y < caveBottom; y++) {
+    for (let x = caveLeft; x < caveRight; x++) {
+      world.mask[y * w + x] = MASK_AIR;
+    }
+  }
+  return world;
+}
+
+describe("placeCaveAmbientPass", () => {
+  it("wantsCaveAmbient=false returns early; caveAmbient stays empty", () => {
+    // default theme has wantsCaveAmbient: false
+    const world = setupWorldWithCave(40, 40, "default", 5, 10, 35, 5, 35);
+    expect(world.theme?.flags.wantsCaveAmbient).toBe(false);
+    placeCaveAmbientPass.run(makeCtx(world, 10));
+    expect(world.caveAmbient).toHaveLength(0);
+  });
+
+  it("snow theme produces frost-typed features inside the cave", () => {
+    // Use a generous world + cave to ensure attempts land inside the cave.
+    // 200x200 * 0.00015 = 6 attempts; max(8,6) = 8 attempts minimum.
+    // The cave covers 150x150 pixels below surface (y 20..170, x 20..170)
+    // which is a large fraction of the world area, so most attempts land inside.
+    // Use a large world + high factor override to guarantee some hits.
+    const world = setupWorldWithCave(200, 200, "snow", 10, 20, 190, 10, 190);
+    if (!world.theme) throw new Error("theme must be set");
+    // Override factor to guarantee many attempts
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, caveAmbientAttemptFactor: 0.01 },
+    };
+    placeCaveAmbientPass.run(makeCtx(world, 10));
+    expect(world.caveAmbient.length).toBeGreaterThan(0);
+    for (const f of world.caveAmbient) {
+      expect(f.type).toBe("frost");
+    }
+  });
+
+  it("all produced features satisfy mask=AIR and yPx > heightmap[xPx]", () => {
+    const world = setupWorldWithCave(200, 200, "snow", 10, 20, 190, 10, 190);
+    if (!world.theme) throw new Error("theme must be set");
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, caveAmbientAttemptFactor: 0.01 },
+    };
+    placeCaveAmbientPass.run(makeCtx(world, 10));
+    expect(world.caveAmbient.length).toBeGreaterThan(0);
+    const { widthPx, mask, heightmap } = world;
+    for (const f of world.caveAmbient) {
+      expect(mask[f.yPx * widthPx + f.xPx]).toBe(MASK_AIR);
+      const surfY = heightmap[f.xPx];
+      expect(f.yPx).toBeGreaterThan(surfY);
+    }
+  });
+
+  it("determinism: same seed produces identical caveAmbient list", () => {
+    const makeRun = () => {
+      const world = setupWorldWithCave(200, 200, "snow", 10, 20, 190, 10, 190);
+      if (!world.theme) throw new Error("theme must be set");
+      world.theme = {
+        ...world.theme,
+        params: { ...world.theme.params, caveAmbientAttemptFactor: 0.005 },
+      };
+      placeCaveAmbientPass.run(makeCtx(world, 10));
+      return world.caveAmbient;
+    };
+    const first = makeRun();
+    const second = makeRun();
+    expect(first).toEqual(second);
+  });
+
+  it("theme.params.caveAmbientAttemptFactor override changes the produced count", () => {
+    const makeRunWithFactor = (factor: number) => {
+      const world = setupWorldWithCave(200, 200, "snow", 10, 20, 190, 10, 190);
+      if (!world.theme) throw new Error("theme must be set");
+      world.theme = {
+        ...world.theme,
+        params: { ...world.theme.params, caveAmbientAttemptFactor: factor },
+      };
+      placeCaveAmbientPass.run(makeCtx(world, 10));
+      return world.caveAmbient.length;
+    };
+    const lowCount = makeRunWithFactor(0.0005);
+    const highCount = makeRunWithFactor(0.05);
+    // Higher factor = more attempts = more features (stochastic but strong signal at 100x ratio)
+    expect(highCount).toBeGreaterThan(lowCount);
+  });
+
+  it("throws on null theme", () => {
+    const world = createWorld(0, 40, 40, "snow");
+    // theme is null by default after createWorld
+    expect(() => placeCaveAmbientPass.run(makeCtx(world, 10))).toThrow(
+      /DefineTheme must run first/,
+    );
+  });
+});

--- a/src/maps/passes/placeCaveAmbient.ts
+++ b/src/maps/passes/placeCaveAmbient.ts
@@ -42,7 +42,7 @@ export const placeCaveAmbientPass: Pass = {
       const cx = rngInt(rng, widthPx);
       const cy = rngInt(rng, heightPx);
       const surfY = heightmap[cx];
-      if (surfY === undefined || surfY >= heightPx) continue;
+      if (surfY === undefined || surfY < 0 || surfY >= heightPx) continue;
       if (cy <= surfY) continue;
       if (mask[cy * widthPx + cx] !== MASK_AIR) continue;
       world.caveAmbient.push({ xPx: cx, yPx: cy, type });

--- a/src/maps/passes/placeCaveAmbient.ts
+++ b/src/maps/passes/placeCaveAmbient.ts
@@ -1,0 +1,51 @@
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+import { MASK_AIR } from "../world";
+
+const AMBIENT_TYPE_BY_THEME: Record<string, string> = {
+  snow: "frost",
+  jungle: "moss",
+  volcanic: "glow",
+};
+
+/**
+ * Places ambient decoration features inside cave cavities. Theme-gated by
+ * theme.flags.wantsCaveAmbient. Type per theme: "frost" (snow), "moss"
+ * (jungle), "glow" (volcanic). Other themes return early.
+ *
+ * Uses Terraria's attempt-count density convention: attempts scale with
+ * world area (widthPx * heightPx * factor). Each attempt picks uniform
+ * random (x, y) and validates; invalid attempts no-op. Many attempts will
+ * not land in cave interior; that is expected and matches shipped procgen.
+ *
+ * RNG: 2 calls per attempt (rngInt for x and y).
+ */
+export const placeCaveAmbientPass: Pass = {
+  name: "PlaceCaveAmbient",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("PlaceCaveAmbient: world.theme is null; DefineTheme must run first");
+    }
+    if (!world.theme.flags.wantsCaveAmbient) return;
+    const type = AMBIENT_TYPE_BY_THEME[world.theme.tag];
+    if (!type) return;
+
+    const { widthPx, heightPx, mask, heightmap } = world;
+    const factor = resolveParam(
+      "caveAmbientAttemptFactor",
+      tuning.worldgen.caveAmbient.attemptFactor,
+    );
+    if (factor <= 0) return;
+    const attempts = Math.max(8, Math.floor(widthPx * heightPx * factor));
+
+    for (let i = 0; i < attempts; i++) {
+      const cx = rngInt(rng, widthPx);
+      const cy = rngInt(rng, heightPx);
+      const surfY = heightmap[cx];
+      if (surfY === undefined || surfY >= heightPx) continue;
+      if (cy <= surfY) continue;
+      if (mask[cy * widthPx + cx] !== MASK_AIR) continue;
+      world.caveAmbient.push({ xPx: cx, yPx: cy, type });
+    }
+  },
+};

--- a/src/maps/passes/placeSurfaceDressing.test.ts
+++ b/src/maps/passes/placeSurfaceDressing.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { type World, createWorld } from "../world";
+import { placeSurfaceDressingPass } from "./placeSurfaceDressing";
+
+function makeCtx(world: World, passIndex: number, spacingOverride?: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      if (key === "surfaceDressingSpacingPx" && spacingOverride !== undefined) {
+        return spacingOverride;
+      }
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag: string): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+/** Fill a column with a valid surface at surfY. */
+function fillColumn(world: World, x: number, surfY: number): void {
+  world.heightmap[x] = surfY;
+}
+
+describe("placeSurfaceDressingPass", () => {
+  it("plateau theme (wantsSurfaceDressing=false) returns early; surfaceDressing stays empty", () => {
+    const world = setupWorld(400, 200, "plateau");
+    // Fill all columns with a valid surface at y=100
+    for (let x = 0; x < 400; x++) fillColumn(world, x, 100);
+    placeSurfaceDressingPass.run(makeCtx(world, 10));
+    expect(world.surfaceDressing).toHaveLength(0);
+  });
+
+  it("default theme produces grass_tuft features", () => {
+    const world = setupWorld(400, 200, "default");
+    // Fill all columns with a valid surface
+    for (let x = 0; x < 400; x++) fillColumn(world, x, 50);
+    placeSurfaceDressingPass.run(makeCtx(world, 10));
+    // Should have produced some features
+    expect(world.surfaceDressing.length).toBeGreaterThan(0);
+    for (const feat of world.surfaceDressing) {
+      expect(feat.sprite).toBe("grass_tuft");
+    }
+  });
+
+  it("all produced features have yPx === heightmap[xPx] - 1 and a valid surface", () => {
+    const world = setupWorld(800, 300, "default");
+    // Give each column a distinct surface height to detect any mapping errors
+    for (let x = 0; x < 800; x++) {
+      // Surface between y=10 and y=200, varies by x
+      fillColumn(world, x, 10 + (x % 50));
+    }
+    placeSurfaceDressingPass.run(makeCtx(world, 10));
+    expect(world.surfaceDressing.length).toBeGreaterThan(0);
+    for (const feat of world.surfaceDressing) {
+      const surfY = world.heightmap[feat.xPx];
+      // surfY must be a valid surface (not -1, not >= heightPx)
+      expect(surfY).toBeGreaterThanOrEqual(0);
+      expect(surfY).toBeLessThan(world.heightPx);
+      // yPx must be exactly surfY - 1
+      expect(feat.yPx).toBe(surfY - 1);
+    }
+  });
+
+  it("same seed produces the same surfaceDressing list (determinism)", () => {
+    function runOnce(seed: number): typeof world1.surfaceDressing {
+      const w = createWorld(seed, 400, 200, "default");
+      w.theme = getTheme("default");
+      for (let x = 0; x < 400; x++) w.heightmap[x] = 80;
+      placeSurfaceDressingPass.run({
+        world: w,
+        rng: rngForPass(w.seed, 10),
+        passIndex: 10,
+        tuning,
+        resolveParam: (key, fb) => {
+          const v = w.theme?.params[key];
+          return typeof v === "number" ? v : fb;
+        },
+      });
+      return w.surfaceDressing;
+    }
+    const world1 = createWorld(42, 400, 200, "default"); // needed for type only
+    const run1 = runOnce(42);
+    const run2 = runOnce(42);
+    expect(run1).toEqual(run2);
+  });
+
+  it("theme.params.surfaceDressingSpacingPx override changes the produced count", () => {
+    // Run with tight spacing (spacingPx=10) and loose spacing (spacingPx=200)
+    // and verify the tight run produces more attempts (and thus more features
+    // given enough valid surface columns).
+    const makeTightWorld = () => {
+      const world = setupWorld(400, 200, "default");
+      for (let x = 0; x < 400; x++) fillColumn(world, x, 100);
+      return world;
+    };
+
+    const worldTight = makeTightWorld();
+    placeSurfaceDressingPass.run(makeCtx(worldTight, 10, 10));
+
+    const worldLoose = makeTightWorld();
+    placeSurfaceDressingPass.run(makeCtx(worldLoose, 10, 200));
+
+    // Tight spacing = more attempts = more features placed on average.
+    // With widthPx=400: tight attempts = max(4, floor(400/10)) = 40
+    //                   loose attempts = max(4, floor(400/200)) = 4
+    expect(worldTight.surfaceDressing.length).toBeGreaterThan(worldLoose.surfaceDressing.length);
+  });
+
+  it("throws if world.theme is null", () => {
+    const world = createWorld(0, 100, 100, "default");
+    // theme is null by default from createWorld
+    expect(() => placeSurfaceDressingPass.run(makeCtx(world, 10))).toThrow(
+      /DefineTheme must run first/,
+    );
+  });
+});

--- a/src/maps/passes/placeSurfaceDressing.ts
+++ b/src/maps/passes/placeSurfaceDressing.ts
@@ -1,0 +1,48 @@
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+
+const DRESSING_SPRITE_BY_THEME: Record<string, string> = {
+  default: "grass_tuft",
+  canyon: "cactus",
+  snow: "snow_drift",
+  jungle: "grass_tuft",
+  volcanic: "ash_pile",
+};
+
+/**
+ * Places surface dressing features at uniform random columns along the
+ * surface. Theme-gated by theme.flags.wantsSurfaceDressing. Sprite per theme.
+ *
+ * Terraria-style: attempt count = floor(widthPx / spacingPx), uniform
+ * random x per attempt. Invalid columns (void, missing surface) no-op.
+ *
+ * RNG: 1 call per attempt.
+ */
+export const placeSurfaceDressingPass: Pass = {
+  name: "PlaceSurfaceDressing",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("PlaceSurfaceDressing: world.theme is null; DefineTheme must run first");
+    }
+    if (!world.theme.flags.wantsSurfaceDressing) return;
+    const sprite = DRESSING_SPRITE_BY_THEME[world.theme.tag];
+    if (!sprite) return;
+
+    const { widthPx, heightPx, heightmap } = world;
+    const spacingPx = resolveParam(
+      "surfaceDressingSpacingPx",
+      tuning.worldgen.surfaceDressing.spacingPx,
+    );
+    if (spacingPx <= 0) return;
+    const attempts = Math.max(4, Math.floor(widthPx / spacingPx));
+
+    for (let i = 0; i < attempts; i++) {
+      const cx = rngInt(rng, widthPx);
+      const surfY = heightmap[cx];
+      if (surfY === undefined || surfY < 0 || surfY >= heightPx) continue;
+      const yPx = surfY - 1;
+      if (yPx < 0) continue;
+      world.surfaceDressing.push({ xPx: cx, yPx, sprite });
+    }
+  },
+};

--- a/src/maps/themes.test.ts
+++ b/src/maps/themes.test.ts
@@ -8,6 +8,7 @@ const FLAG_KEYS: (keyof import("./themes").ThemeFlags)[] = [
   "noFloor",
   "wantsSurfaceCrust",
   "wantsCaveAmbient",
+  "wantsSurfaceDressing",
 ];
 
 describe("THEMES registry", () => {
@@ -55,5 +56,22 @@ describe("getTheme", () => {
     expect(() => getTheme("nonsense")).toThrowError(/Known themes:/);
     expect(() => getTheme("nonsense")).toThrowError(/default/);
     expect(() => getTheme("nonsense")).toThrowError(/canyon/);
+  });
+
+  it("wantsSurfaceDressing is true for all themes except plateau", () => {
+    const dressingEnabled: Record<string, boolean> = {
+      default: true,
+      canyon: true,
+      snow: true,
+      jungle: true,
+      plateau: false,
+      volcanic: true,
+    };
+    for (const tag of EXPECTED_TAGS) {
+      const theme = getTheme(tag);
+      expect(theme.flags.wantsSurfaceDressing, `${tag}.flags.wantsSurfaceDressing`).toBe(
+        dressingEnabled[tag],
+      );
+    }
   });
 });

--- a/src/maps/themes.ts
+++ b/src/maps/themes.ts
@@ -13,6 +13,7 @@ export interface ThemeFlags {
   noFloor: boolean;
   wantsSurfaceCrust: boolean;
   wantsCaveAmbient: boolean;
+  wantsSurfaceDressing: boolean; // NEW
 }
 
 export interface ThemeParams {
@@ -27,6 +28,7 @@ export interface ThemeParams {
   minSpawnsPerTeam?: number;
   bandDirtDepthPx?: number;
   bandRockDepthPx?: number;
+  surfaceDressingSpacingPx?: number;
 }
 
 export interface ThemePalette {
@@ -56,6 +58,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: false,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: false,
+      wantsSurfaceDressing: true,
     },
     params: {},
     palette: { surface: 0x3a7a3c, mid: 0x7a4a2c, rock: 0x6a4f24, deep: 0x5a5a5a },
@@ -68,6 +71,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: true,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: false,
+      wantsSurfaceDressing: true,
     },
     params: {},
     palette: { surface: 0xb05c3a, mid: 0x8a4523, rock: 0x7a3c1c, deep: 0x6a3010 },
@@ -80,6 +84,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: false,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: true,
+      wantsSurfaceDressing: true,
     },
     params: {},
     palette: { surface: 0xf5f7fa, mid: 0x6a7a8a, rock: 0x5a6a78, deep: 0x4a5a6a },
@@ -92,6 +97,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: false,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: true,
+      wantsSurfaceDressing: true,
     },
     params: {},
     palette: { surface: 0x2a8a3a, mid: 0x4a3a1a, rock: 0x3a2812, deep: 0x3a2a0a },
@@ -104,6 +110,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: false,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: false,
+      wantsSurfaceDressing: false,
     },
     params: {},
     palette: { surface: 0x8a7a5a, mid: 0x6a5a3a, rock: 0x5a4828, deep: 0x4a3a2a },
@@ -116,6 +123,7 @@ export const THEMES: Record<string, Theme> = {
       noFloor: false,
       wantsSurfaceCrust: true,
       wantsCaveAmbient: true,
+      wantsSurfaceDressing: true,
     },
     params: {},
     palette: { surface: 0x3a1a0a, mid: 0x5a2a0a, rock: 0x4a1a05, deep: 0x2a0a00 },

--- a/src/maps/themes.ts
+++ b/src/maps/themes.ts
@@ -27,6 +27,7 @@ export interface ThemeParams {
   minSpawnsPerTeam?: number;
   bandDirtDepthPx?: number;
   bandRockDepthPx?: number;
+  caveAmbientAttemptFactor?: number;
 }
 
 export interface ThemePalette {

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -140,6 +140,11 @@ export interface Tuning {
       /** Minimum spawns per team. Below this, ValidateSpawnCoherence logs a warning. */
       minPerTeam: number;
     };
+    surfaceDressing: {
+      /** Average horizontal spacing between surface dressing attempts, in pixels.
+       *  Attempts = floor(widthPx / spacingPx); each attempt picks a random column. */
+      spacingPx: number;
+    };
   };
   camera: {
     turnZoomOutMs: number;
@@ -256,6 +261,9 @@ export const tuning: Tuning = {
     spawn: {
       densityPx: 200,
       minPerTeam: 2,
+    },
+    surfaceDressing: {
+      spacingPx: 40,
     },
   },
   camera: {

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -140,6 +140,12 @@ export interface Tuning {
       /** Minimum spawns per team. Below this, ValidateSpawnCoherence logs a warning. */
       minPerTeam: number;
     };
+    caveAmbient: {
+      /** Attempts = widthPx * heightPx * attemptFactor. Each attempt picks a
+       *  random (x, y) and validates; invalid attempts no-op. Matches Terraria's
+       *  attempt-count density convention. */
+      attemptFactor: number;
+    };
   };
   camera: {
     turnZoomOutMs: number;
@@ -256,6 +262,9 @@ export const tuning: Tuning = {
     spawn: {
       densityPx: 200,
       minPerTeam: 2,
+    },
+    caveAmbient: {
+      attemptFactor: 0.00015,
     },
   },
   camera: {


### PR DESCRIPTION
## Summary

PR 5 of the world-gen v1 pipeline. Adds the 2 dressing passes and a procedural canvas painter for the resulting feature arrays. terraworldV1 now runs 11 of 14 v1 passes.

Tracks worms#150. Plan: docs/plans/worldgen-pr5-dressing.md.

## Workstreams

- **WS-A**: PlaceCaveAmbient pass (Terraria-style attempt-count density). Theme-gated by ` wantsCaveAmbient`; types per theme: frost (snow), moss (jungle), glow (volcanic).
- **WS-B**: PlaceSurfaceDressing pass + new ThemeFlags.wantsSurfaceDressing flag. Plateau opts out (raw rock surface); all other themes enable. Sprites per theme: grass_tuft (default, jungle), cactus (canyon), snow_drift (snow), ash_pile (volcanic).
- **WS-C**: paintDecorationToContext helper (procedural shapes; unknown strings silently skipped per Terraria PlaceTile convention).

## Integration

- `tuning.ts`: caveAmbient.attemptFactor (0.00015), surfaceDressing.spacingPx (40)
- `ThemeParams`: caveAmbientAttemptFactor, surfaceDressingSpacingPx (per-theme overrides)
- `terraworldV1.ts`: appends 2 passes; calls paintDecorationToContext after paintWorldToContext
- Integration tests: assert frost ambient (#caf0ff) appears for snow theme and grass_tuft (#3a8a3a) appears for default theme

## Bug Check (Phase 3)

5 lenses (algorithm, determinism, cross-pass, edge cases, renderer integration). Two LOW findings flagged and fixed inline before PR:

- placeCaveAmbient: added defensive ` surfY < 0` guard for symmetry with placeSurfaceDressing (unreachable in practice; PaintSubstrateMask validates heightmap upstream)
- paintDecorationToContext: corrected docstring for the dressing rect bounds

No Critical or High findings. CarveCaves keeps caves below the surface by surfaceBufferPx (default 80px), so dressing cannot float above carved gaps.

## Process appendix

Three architectural decisions documented with the 5-question framework in the plan:
- Density convention (attempt-count, grounded in Terraria's 6E-05 baseline scaled 2.5x for our higher no-op rate)
- Vocabulary (strings; integer enum gains nothing at our scale of 7 total decoration strings)
- Data shape (separate arrays; documented deviation from in-grid prior art - decoration drawing is a separate paint step)

## Known issue (Medium): networked decoration loss

Same as PR 4 (materials): networked v1 clients lose decoration because the wire protocol is alpha-only. Geometry (mask) syncs identically; only the visual layer differs between host and clients. Future fix is to encode materials + decoration in the wire protocol or have clients re-run gen from the seed.

## Known issue (Medium): random clustering

Acceptable per Terraria pattern: some columns get no surface dressing, some get multiple. Per-theme tunable via surfaceDressingSpacingPx.

## Test plan

- [x] No em dashes
- [x] All tests pass (415/415, 52 files)
- [x] tsc clean
- [x] biome clean
- [x] Bugcheck Phase 3 complete (2 LOW findings fixed)
- [ ] Manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)