### PR TITLE
feat(worldgen): PR 6 - spawn distribution + validation + final cleanup (closes v1)

### DIFF
--- a/docs/plans/worldgen-pr6-spawn-cleanup.md
+++ b/docs/plans/worldgen-pr6-spawn-cleanup.md
@@ -1,0 +1,656 @@
+# World-gen PR 6: Spawn distribution + validation + final cleanup
+
+**Position:** PR 6 of ~6-8 in the world-gen v1 roadmap. Tracks worms#150. **Final PR of the v1 effort** unless one of these passes splits.
+
+**Status:** Draft. Awaiting user approval.
+
+## Changes from adversarial review
+
+This plan was stress-tested before approval. The following clear-miss fixes have been applied inline (see corresponding sections):
+
+- **BLOCKING - team-side clumping bug**: the worker (`worker/src/room.ts:887-900`) distributes spawns via `mapSpawns[(teamIdx + wormIdx * rosters.length) % mapSpawns.length]`. With sorted-by-xPx left/right concatenation, both teams would clump on the same side. **Fix**: integration phase interleaves `[L0, R0, L1, R1, ...]` when flattening to LoadedMap.spawnPoints.
+- **BLOCKING - inconsistent mutation**: WS-C reassigned `spawnList.left/right` via property write but mutated `caveAmbient/surfaceDressing` in-place. **Fix**: WS-C uses in-place mutation throughout.
+- **SHOULD-FIX - canvas-top edge case**: a worm at `surfY === 0` would have no headroom. **Fix**: WS-A predicate excludes `surfY === 0` columns.
+- **SHOULD-FIX - warning flood**: per-spawn warnings could emit hundreds of lines. **Fix**: WS-B emits one summary warning per side.
+- **SHOULD-FIX - canyon_v1 coverage gap**: integration tests only exercised default theme. **Fix**: added a fourth integration assertion for canyon_v1.
+- **SHOULD-FIX - mock leakage**: integration test #3's `vi.mock` needed `beforeEach` reset. **Fix**: added explicit setup note.
+- **NICE-TO-HAVE - readability**: `dedupeSorted` uses `null` sentinel instead of `Number.NaN`; added a comment about xPx-only dedupe.
+- **NICE-TO-HAVE - bugcheck lens 6**: added "downstream consumers" lens (worker round-robin + game-side spawn array consumers).
+- **NICE-TO-HAVE - PR body**: noted v1-vs-legacy spawn position divergence is intentional.
+
+## Multi-PR roadmap context
+
+Already shipped on master:
+- PR 1 (worms#167): foundation - Pipeline, World struct (Uint8Array mask + materialMap + heightmap + spawnList + caveAmbient + surfaceDressing), Pass interface, RNG helper, theme schema, tuning extensions
+- PR 2 (worms#168): substrate passes - Reset, DefineTheme, GenerateHeightmap, ApplyThemeHeightmapMods, PaintSubstrateMask
+- PR 3 (worms#169): carving passes (CarveCaves, FinalizeMask) + terraworldV1 generator + paintMaskToContext
+- PR 4 (worms#170): material passes (PaintMaterialBands, PaintSurfaceCrust) + materials-aware paintWorldToContext + prePainted flag
+- PR 5 (worms#172): dressing passes (PlaceCaveAmbient, PlaceSurfaceDressing) + paintDecorationToContext
+
+PR 6 (this plan) adds passes 12-14 of 14: DistributeSpawnPoints, ValidateSpawnCoherence, FinalCleanup. After this, terraworldV1 runs the FULL 14-pass v1 pipeline and authoritative spawn data flows from the pipeline through LoadedMap to the game engine (replacing the legacy post-generation `findSpawnPoints` scan for v1 maps).
+
+## What PR 6 delivers
+
+1. **DistributeSpawnPoints pass** (pass 12): populates `world.spawnList.left[]` and `world.spawnList.right[]` (already-pinned shape from PR 1 foundation). Reads `world.heightmap` (authoritative surface y per column), partitions columns by `xPx < widthPx/2`, samples deterministically with min-spacing relaxation, sorts each side by xPx ascending (per the SpawnList contract in `src/maps/world.ts:32-35`).
+2. **ValidateSpawnCoherence pass** (pass 13): checks invariants (min-per-team count, surface validity, no-floating, edge margin) and `console.warn`s on violation. Soft validation: pipeline continues regardless. Designed to surface issues during local dev / playtests without blocking generation.
+3. **FinalCleanup pass** (pass 14): final hygiene sweep. Trims `caveAmbient` and `surfaceDressing` features whose target cells became inconsistent post-other-passes (defensive, since placing passes already guard - this catches drift). Sorts `spawnList.left` and `spawnList.right` by xPx (idempotent, but enforces the contract). De-dupes by xPx.
+4. **Integration**: terraworldV1Generator returns `SpawnList` (changes `MapGenerator` signature to `void | SpawnList`); `loadMap.ts` prefers returned `SpawnList` over the legacy `findSpawnPoints` scan when present.
+
+## Architectural decisions (5-question discipline applied)
+
+### Decision 1: Spawn placement source - heightmap vs canvas-pixel-scan
+
+| Question | Answer |
+|---|---|
+| Bible cite | Legacy `findSpawnPoints` (`src/worm/spawnPoints.ts:1`) scans `Uint8ClampedArray` from `getImageData` - canvas-pixel-scan style. |
+| Consensus cite | PR 1 foundation pinned `world.heightmap: Int32Array` (per-column surface y; `src/maps/world.ts:64-65`). PR 2's GenerateHeightmap is the authoritative source. |
+| Prior art | Terraria places spawns via heightmap-based sampling per https://github.com/tModLoader/tModLoader (rejection-sampling + min-separation; ~1000 retry budget). Sebastian Lague tutorials sample dungeon graph nodes, not surface columns. Most surveyed engines use the heightmap when it exists, scan-canvas when it does not. |
+| Simplest sufficient | v1 already has the heightmap. Re-scanning the canvas via `getImageData` would duplicate work and lose the column abstraction. |
+| Bite | Heightmap-based placement does not handle ceilings/overhangs, but v1's GenerateHeightmap is single-surface-per-column by design - no overhangs exist in the v1 contract. So no functional loss. |
+
+**Decision: heightmap-based placement.** The pass reads `world.heightmap[cx]` and `world.mask` to validate (cell at heightmap[cx] is solid; cell above is air). RNG via `rngInt(rng, widthPx)` for column choice; greedy pick with progressive minSpacing relaxation factors `[1.0, 0.8, 0.6, 0.4, 0.2, 0]` mirroring legacy `findSpawnPoints` for behavioral parity.
+
+### Decision 2: Validation severity - warn vs throw
+
+| Question | Answer |
+|---|---|
+| Bible cite | `tuning.ts:140-141` already documents intent: "Below this, ValidateSpawnCoherence logs a warning." |
+| Consensus cite | None other than the tuning comment. |
+| Prior art | Terraria does not have a "validate" pass - it retries placement on failure. Most procgen game engines either retry until success or accept degraded output silently. Explicit post-validation is uncommon. |
+| Simplest sufficient | `console.warn` matches the tuning-comment intent and is minimally invasive. Pipeline continues; downstream code can detect insufficient spawns at game-start time and handle gracefully. |
+| Bite | A throw would block test runs that legitimately want to validate edge-case worlds (e.g., very small canvases for unit tests). A warn keeps tests green and surfaces issues only when human eyes are on the console. |
+
+**Decision: console.warn on violation.** Pass body emits a warning string per failed invariant. Test cases assert via `vi.spyOn(console, "warn")` that the warning fires for the expected condition. Throw only on hard preconditions (null theme), matching existing pass conventions.
+
+### Decision 3: FinalCleanup scope - hygiene, not transformation
+
+| Question | Answer |
+|---|---|
+| Bible cite | FinalizeMask (`src/maps/passes/finalizeMask.ts`) cleans only the mask (orphan-island removal). It does not touch features, materialMap, or spawnList. |
+| Consensus cite | Each placing pass (PlaceCaveAmbient, PlaceSurfaceDressing) already guards its writes via predicates (mask=AIR for ambient, valid heightmap for dressing). FinalCleanup must not duplicate these guards - it catches drift only. |
+| Prior art | Terraria's `WorldGen.gen` tail has small post-passes (smoothing, gemstone scatter cleanup) that are conventionally bounded - "remove what should not be there" rather than "transform what's there". Roguelike post-gen passes follow the same shape. |
+| Simplest sufficient | Three operations, all idempotent: (a) trim caveAmbient features whose mask cell is no longer AIR, (b) trim surfaceDressing features whose column heightmap is now invalid, (c) sort + dedupe spawnList.left/right by xPx (enforces SpawnList contract). |
+| Bite | Idempotent operations cost CPU (small - all O(N) in features count or O(K log K) for K spawns). De-duping spawn entries is a defensive measure; the placing pass should not produce duplicates, but the cleanup pass guarantees the contract regardless. |
+
+**Decision: hygiene-only cleanup.** Three bounded operations as listed. No flood-fill reachability check, no spawn re-placement, no materialMap normalization. If those become needed later, they get their own pass.
+
+## Workstreams
+
+Three parallel Sonnet agents. Each owns disjoint files for clean merge.
+
+### WS-A: DistributeSpawnPoints pass
+
+**Worktree:** `/home/scott/worms-pr6-ws-a`
+**Branch:** `feature/worldgen-pass-distribute-spawn-points`
+**Setup:**
+```bash
+git -C /home/scott/worms-pr6-ws-a checkout -b feature/worldgen-pass-distribute-spawn-points
+test -d /home/scott/worms-pr6-ws-a/node_modules || ln -s /home/scott/worms/node_modules /home/scott/worms-pr6-ws-a/node_modules
+```
+
+**Files (2 new):**
+- `src/maps/passes/distributeSpawnPoints.ts`
+- `src/maps/passes/distributeSpawnPoints.test.ts`
+
+**`src/maps/passes/distributeSpawnPoints.ts`:**
+
+```typescript
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+import { MASK_AIR, MASK_SOLID } from "../world";
+import type { SpawnPoint } from "../world";
+
+const RELAXATION_FACTORS = [1.0, 0.8, 0.6, 0.4, 0.2, 0] as const;
+
+/**
+ * Populates world.spawnList.left and world.spawnList.right with valid
+ * surface positions partitioned by xPx midline. Reads world.heightmap as
+ * the authoritative per-column surface y; validates that the surface cell
+ * is solid and the cell above is air (worm-fits invariant).
+ *
+ * Algorithm mirrors legacy findSpawnPoints (src/worm/spawnPoints.ts):
+ * shuffle valid columns deterministically, then greedy-pick with
+ * progressive minSpacing relaxation to fill the per-side count.
+ *
+ * Honors edgeMarginPx (skip columns near canvas edges) and densityPx
+ * (min horizontal spacing between accepted spawns). Per-team count target
+ * comes from minPerTeam tuning (or per-theme override).
+ *
+ * Throws on null theme. Returns early on degenerate dimensions.
+ *
+ * RNG: O(validColumns) calls for the Fisher-Yates shuffle, then O(picks)
+ * additional calls only if relaxation iteration is needed.
+ */
+export const distributeSpawnPointsPass: Pass = {
+  name: "DistributeSpawnPoints",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error(
+        "DistributeSpawnPoints: world.theme is null; DefineTheme must run first",
+      );
+    }
+    const { widthPx, heightPx, heightmap, mask, spawnList } = world;
+    if (widthPx <= 0 || heightPx <= 0) return;
+
+    const densityPx = resolveParam("spawnDensity", tuning.worldgen.spawn.densityPx);
+    const minPerTeam = resolveParam(
+      "minSpawnsPerTeam",
+      tuning.worldgen.spawn.minPerTeam,
+    );
+    if (densityPx <= 0 || minPerTeam <= 0) return;
+
+    const edgeMarginPx = Math.min(60, Math.floor(widthPx / 8));
+    const midX = Math.floor(widthPx / 2);
+
+    const leftCandidates: SpawnPoint[] = [];
+    const rightCandidates: SpawnPoint[] = [];
+    for (let cx = edgeMarginPx; cx < widthPx - edgeMarginPx; cx++) {
+      const surfY = heightmap[cx];
+      // Skip degenerate columns and canvas-top surfaces (need >= 1 row of
+      // air above for worm clearance).
+      if (surfY === undefined || surfY < 1 || surfY >= heightPx) continue;
+      if (mask[surfY * widthPx + cx] !== MASK_SOLID) continue;
+      if (mask[(surfY - 1) * widthPx + cx] !== MASK_AIR) continue;
+      const point: SpawnPoint = { xPx: cx, yPx: surfY - 1 };
+      if (cx < midX) leftCandidates.push(point);
+      else rightCandidates.push(point);
+    }
+
+    spawnList.left.push(...pickWithRelaxation(leftCandidates, minPerTeam, densityPx, rng));
+    spawnList.right.push(...pickWithRelaxation(rightCandidates, minPerTeam, densityPx, rng));
+    spawnList.left.sort((a, b) => a.xPx - b.xPx);
+    spawnList.right.sort((a, b) => a.xPx - b.xPx);
+  },
+};
+
+function pickWithRelaxation(
+  candidates: SpawnPoint[],
+  target: number,
+  densityPx: number,
+  rng: () => number,
+): SpawnPoint[] {
+  if (candidates.length === 0) return [];
+  const shuffled = candidates.slice();
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = rngInt(rng, i + 1);
+    const tmp = shuffled[i];
+    if (tmp === undefined) continue;
+    const swap = shuffled[j];
+    if (swap === undefined) continue;
+    shuffled[i] = swap;
+    shuffled[j] = tmp;
+  }
+  for (const factor of RELAXATION_FACTORS) {
+    const minSpacing = densityPx * factor;
+    const picked: SpawnPoint[] = [];
+    for (const p of shuffled) {
+      if (picked.every((q) => Math.abs(q.xPx - p.xPx) >= minSpacing)) {
+        picked.push(p);
+        if (picked.length >= target) return picked;
+      }
+    }
+    if (picked.length >= target) return picked;
+  }
+  return shuffled.slice(0, target);
+}
+```
+
+**`src/maps/passes/distributeSpawnPoints.test.ts`:**
+
+Use vitest. Read `src/maps/passes/placeCaveAmbient.test.ts` and `src/maps/passes/finalizeMask.test.ts` first to follow the harness pattern (synthetic World, makeCtx helper).
+
+**Tests required (9):**
+
+1. Throws on null theme.
+2. `densityPx <= 0` returns early; spawnList unchanged.
+3. `minPerTeam <= 0` returns early.
+4. With a flat surface across full width, produces `>= minPerTeam` spawns on each side.
+5. Left spawns are all at `xPx < widthPx/2`; right spawns are all at `xPx >= widthPx/2`.
+6. All produced spawns satisfy: `heightmap[xPx] >= 1`, `mask[heightmap[xPx] * widthPx + xPx] === MASK_SOLID`, and `mask[(heightmap[xPx]-1) * widthPx + xPx] === MASK_AIR`.
+7. Columns where `heightmap[xPx] === 0` are skipped (synthetic: build a world with surfY=0 across the entire width; pass produces zero spawns).
+8. Determinism: same seed produces deep-equal `spawnList.left` and `spawnList.right`.
+9. After pass, both `spawnList.left` and `spawnList.right` are sorted by xPx ascending.
+
+**Cross-workstream constraint:** None. Self-contained.
+
+**Acceptance:**
+- `cd /home/scott/worms-pr6-ws-a && npx tsc --noEmit` clean
+- `npx biome check --write src/maps/passes/distributeSpawnPoints.ts src/maps/passes/distributeSpawnPoints.test.ts` clean
+- `npx vitest run src/maps/passes/distributeSpawnPoints.test.ts` all 8 tests pass
+- `npx vitest run` no regressions
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr6-ws-a add src/maps/passes/distributeSpawnPoints.ts src/maps/passes/distributeSpawnPoints.test.ts
+git -C /home/scott/worms-pr6-ws-a commit -m "feat(worldgen): DistributeSpawnPoints pass
+
+Populates world.spawnList.left and world.spawnList.right via heightmap-
+based sampling. Partitions columns by xPx midline; greedy-picks with
+progressive minSpacing relaxation factors mirroring legacy findSpawnPoints
+behavior. Sorts each side by xPx ascending per the SpawnList contract.
+
+Part of PR 6 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr6-ws-a push -u origin feature/worldgen-pass-distribute-spawn-points
+```
+
+### WS-B: ValidateSpawnCoherence pass
+
+**Worktree:** `/home/scott/worms-pr6-ws-b`
+**Branch:** `feature/worldgen-pass-validate-spawn-coherence`
+**Setup:**
+```bash
+git -C /home/scott/worms-pr6-ws-b checkout -b feature/worldgen-pass-validate-spawn-coherence
+test -d /home/scott/worms-pr6-ws-b/node_modules || ln -s /home/scott/worms/node_modules /home/scott/worms-pr6-ws-b/node_modules
+```
+
+**Files (2 new):**
+- `src/maps/passes/validateSpawnCoherence.ts`
+- `src/maps/passes/validateSpawnCoherence.test.ts`
+
+**`src/maps/passes/validateSpawnCoherence.ts`:**
+
+```typescript
+import type { Pass } from "../pass";
+import { MASK_AIR, MASK_SOLID } from "../world";
+
+/**
+ * Soft post-distribution validation. Emits console.warn on each violated
+ * invariant and continues. Designed to surface issues during local dev
+ * and playtests without blocking generation.
+ *
+ * Invariants checked:
+ * - Each side has at least minPerTeam spawns.
+ * - All spawn cells satisfy: heightmap[xPx] is in [0, heightPx) AND
+ *   mask[heightmap[xPx]*widthPx+xPx] === MASK_SOLID AND (heightmap is 0 OR
+ *   mask[(heightmap-1)*widthPx+xPx] === MASK_AIR).
+ *
+ * Throws on null theme.
+ */
+export const validateSpawnCoherencePass: Pass = {
+  name: "ValidateSpawnCoherence",
+  run: ({ world, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error(
+        "ValidateSpawnCoherence: world.theme is null; DefineTheme must run first",
+      );
+    }
+    const minPerTeam = resolveParam(
+      "minSpawnsPerTeam",
+      tuning.worldgen.spawn.minPerTeam,
+    );
+    if (minPerTeam <= 0) return;
+
+    const { widthPx, heightPx, heightmap, mask, spawnList } = world;
+    const themeTag = world.theme.tag;
+
+    if (spawnList.left.length < minPerTeam) {
+      console.warn(
+        `[ValidateSpawnCoherence] theme=${themeTag} left team has ${spawnList.left.length} spawns; minPerTeam=${minPerTeam}`,
+      );
+    }
+    if (spawnList.right.length < minPerTeam) {
+      console.warn(
+        `[ValidateSpawnCoherence] theme=${themeTag} right team has ${spawnList.right.length} spawns; minPerTeam=${minPerTeam}`,
+      );
+    }
+
+    for (const side of ["left", "right"] as const) {
+      let failed = 0;
+      for (const p of spawnList[side]) {
+        const surfY = heightmap[p.xPx];
+        const ok =
+          surfY !== undefined &&
+          surfY >= 1 &&
+          surfY < heightPx &&
+          mask[surfY * widthPx + p.xPx] === MASK_SOLID &&
+          mask[(surfY - 1) * widthPx + p.xPx] === MASK_AIR;
+        if (!ok) failed++;
+      }
+      if (failed > 0) {
+        console.warn(
+          `[ValidateSpawnCoherence] theme=${themeTag} side=${side}: ${failed} of ${spawnList[side].length} spawns failed surface invariant`,
+        );
+      }
+    }
+  },
+};
+```
+
+**`src/maps/passes/validateSpawnCoherence.test.ts`:**
+
+**Tests required (6):**
+
+1. Throws on null theme.
+2. Healthy world (synthetic flat terrain, 3 spawns each side, minPerTeam=2): no warnings emitted (`expect(consoleWarn).not.toHaveBeenCalled()`).
+3. Underpopulated left team (1 spawn, minPerTeam=2): warns once with substring matching `left team has 1 spawns`.
+4. Spawn pointing to invalid mask cell (build a synthetic world where 3 of the spawn entries on the left side have heightmap pointing to a non-SOLID cell): emits ONE summary warning per side with substring `3 of 5 spawns failed surface invariant` (assumes left has 5 total, 3 invalid).
+5. Multiple invalid spawns produce ONE warning per side, not N warnings (regression guard against per-spawn flooding).
+6. `minPerTeam=0` returns early; no warnings even with empty spawnList.
+
+Use `vi.spyOn(console, "warn").mockImplementation(() => {})` to capture warnings, restore after each test via `afterEach(() => { vi.restoreAllMocks(); })`.
+
+**Cross-workstream constraint:** None. Self-contained.
+
+**Acceptance:**
+- `npx tsc --noEmit` clean
+- `npx biome check --write src/maps/passes/validateSpawnCoherence.ts src/maps/passes/validateSpawnCoherence.test.ts` clean
+- `npx vitest run src/maps/passes/validateSpawnCoherence.test.ts` all 5 tests pass
+- `npx vitest run` no regressions
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr6-ws-b add src/maps/passes/validateSpawnCoherence.ts src/maps/passes/validateSpawnCoherence.test.ts
+git -C /home/scott/worms-pr6-ws-b commit -m "feat(worldgen): ValidateSpawnCoherence pass
+
+Soft post-distribution validation. Emits console.warn per violated
+invariant (per-team count below minPerTeam, spawn pointing to invalid
+mask cell). Pipeline continues regardless. Designed to surface issues
+during local dev and playtests without blocking generation.
+
+Part of PR 6 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr6-ws-b push -u origin feature/worldgen-pass-validate-spawn-coherence
+```
+
+### WS-C: FinalCleanup pass
+
+**Worktree:** `/home/scott/worms-pr6-ws-c`
+**Branch:** `feature/worldgen-pass-final-cleanup`
+**Setup:**
+```bash
+git -C /home/scott/worms-pr6-ws-c checkout -b feature/worldgen-pass-final-cleanup
+test -d /home/scott/worms-pr6-ws-c/node_modules || ln -s /home/scott/worms/node_modules /home/scott/worms-pr6-ws-c/node_modules
+```
+
+**Files (2 new):**
+- `src/maps/passes/finalCleanup.ts`
+- `src/maps/passes/finalCleanup.test.ts`
+
+**`src/maps/passes/finalCleanup.ts`:**
+
+```typescript
+import type { Pass } from "../pass";
+import { MASK_AIR } from "../world";
+import type { SpawnPoint } from "../world";
+
+/**
+ * Final hygiene sweep. Three idempotent operations:
+ *
+ * 1. Trim caveAmbient features whose mask cell is no longer AIR (defensive;
+ *    PlaceCaveAmbient guards this on insert, so this catches drift if any
+ *    later pass were to mutate the mask).
+ * 2. Trim surfaceDressing features whose column heightmap is invalid
+ *    (negative or beyond the canvas height).
+ * 3. Sort and de-dupe spawnList.left and spawnList.right by xPx.
+ *
+ * No throw paths beyond the standard null-theme check. No flood-fill or
+ * reachability validation - those would be a separate pass.
+ */
+export const finalCleanupPass: Pass = {
+  name: "FinalCleanup",
+  run: ({ world }) => {
+    if (!world.theme) {
+      throw new Error("FinalCleanup: world.theme is null; DefineTheme must run first");
+    }
+    const { widthPx, heightPx, heightmap, mask, caveAmbient, surfaceDressing, spawnList } =
+      world;
+
+    const ambientKept = caveAmbient.filter(
+      (f) => mask[f.yPx * widthPx + f.xPx] === MASK_AIR,
+    );
+    caveAmbient.length = 0;
+    caveAmbient.push(...ambientKept);
+
+    const dressingKept = surfaceDressing.filter((f) => {
+      const surfY = heightmap[f.xPx];
+      return surfY !== undefined && surfY >= 0 && surfY < heightPx;
+    });
+    surfaceDressing.length = 0;
+    surfaceDressing.push(...dressingKept);
+
+    const dedupedLeft = dedupeSorted(spawnList.left);
+    spawnList.left.length = 0;
+    spawnList.left.push(...dedupedLeft);
+
+    const dedupedRight = dedupeSorted(spawnList.right);
+    spawnList.right.length = 0;
+    spawnList.right.push(...dedupedRight);
+  },
+};
+
+// xPx-only dedupe is sufficient because the v1 heightmap is single-y-per-column,
+// so any two spawns at the same xPx must also share yPx. If overhang support is
+// added later, change the dedupe key to (xPx, yPx).
+function dedupeSorted(points: SpawnPoint[]): SpawnPoint[] {
+  const sorted = points.slice().sort((a, b) => a.xPx - b.xPx);
+  const out: SpawnPoint[] = [];
+  let lastX: number | null = null;
+  for (const p of sorted) {
+    if (lastX === null || p.xPx !== lastX) {
+      out.push(p);
+      lastX = p.xPx;
+    }
+  }
+  return out;
+}
+```
+
+**`src/maps/passes/finalCleanup.test.ts`:**
+
+**Tests required (6):**
+
+1. Throws on null theme.
+2. Empty world (no features, no spawns): no-op; arrays remain empty after run.
+3. Trims caveAmbient features whose mask cell is now SOLID (synthetic: insert a feature at (10, 50) but set mask[50*w+10]=SOLID; after pass the feature is gone).
+4. Trims surfaceDressing features whose column heightmap[xPx] is -1 or >= heightPx (synthetic: set heightmap[20] = -1, insert dressing at xPx=20; after pass the feature is gone).
+5. Spawn arrays end up sorted ascending by xPx, even when input was unsorted (insert `{xPx:50}, {xPx:10}, {xPx:30}` into spawnList.left; after pass it is `[{10},{30},{50}]`).
+6. Spawn de-dupe by xPx: input `[{10},{10},{30}]` becomes `[{10},{30}]`.
+
+**Cross-workstream constraint:** None. Self-contained.
+
+**Acceptance:**
+- `npx tsc --noEmit` clean
+- `npx biome check --write src/maps/passes/finalCleanup.ts src/maps/passes/finalCleanup.test.ts` clean
+- `npx vitest run src/maps/passes/finalCleanup.test.ts` all 6 tests pass
+- `npx vitest run` no regressions
+
+**Commit:**
+```bash
+git -C /home/scott/worms-pr6-ws-c add src/maps/passes/finalCleanup.ts src/maps/passes/finalCleanup.test.ts
+git -C /home/scott/worms-pr6-ws-c commit -m "feat(worldgen): FinalCleanup pass
+
+Final hygiene sweep with three idempotent operations: trim caveAmbient
+features whose mask cell is no longer AIR (defensive), trim surfaceDressing
+features pointing to invalid heightmap columns, sort and de-dupe spawnList
+left/right by xPx. No throw paths beyond null-theme.
+
+Part of PR 6 of the world-gen v1 pipeline. Tracks worms#150."
+git -C /home/scott/worms-pr6-ws-c push -u origin feature/worldgen-pass-final-cleanup
+```
+
+## Integration phase (Opus during /build Phase 3)
+
+After WS-A, WS-B, WS-C merge into `integrate/worldgen-pr6-spawn-cleanup`, Opus directly modifies on the integration branch:
+
+### 1. `src/maps/types.ts` - extend MapGenerator return type
+
+Read the current `MapGenerator` type definition (around line 30-50). Update the return type from `void` to `void | { spawnList: SpawnList }` (or similar) so v1 generators can yield authoritative spawn data through the existing call site. Add the SpawnList import.
+
+```typescript
+import type { SpawnList } from "./world";
+
+// ...
+
+export type MapGenerator = (
+  ctx: CanvasRenderingContext2D,
+  widthPx: number,
+  heightPx: number,
+  opts: GeneratorOpts,
+) => void | { spawnList: SpawnList };
+```
+
+### 2. `src/maps/generators/terraworldV1.ts` - run new passes + return spawnList
+
+Append the three new passes to PASSES (now 14 of 14):
+
+```typescript
+import { distributeSpawnPointsPass } from "../passes/distributeSpawnPoints";
+import { validateSpawnCoherencePass } from "../passes/validateSpawnCoherence";
+import { finalCleanupPass } from "../passes/finalCleanup";
+
+const PASSES = [
+  resetPass,
+  defineThemePass,
+  generateHeightmapPass,
+  applyThemeHeightmapModsPass,
+  paintSubstrateMaskPass,
+  paintMaterialBandsPass,
+  carveCavesPass,
+  finalizeMaskPass,
+  paintSurfaceCrustPass,
+  placeCaveAmbientPass,
+  placeSurfaceDressingPass,
+  distributeSpawnPointsPass,    // NEW pass 12
+  validateSpawnCoherencePass,   // NEW pass 13
+  finalCleanupPass,             // NEW pass 14
+];
+```
+
+Update the doc comment to reflect 14 of 14 passes. Update the generator body to return the spawn data:
+
+```typescript
+export const terraworldV1Generator: MapGenerator = (ctx, widthPx, heightPx, opts) => {
+  const themeTag = (opts.themeTag as string | undefined) ?? "default";
+  const world = createWorld(opts.seed, widthPx, heightPx, themeTag);
+  new Pipeline(PASSES).run(world);
+  if (!world.theme) {
+    throw new Error("terraworldV1: theme is null after pipeline run; DefineTheme should have populated it");
+  }
+  paintWorldToContext(ctx, world.mask, world.materialMap, world.theme.palette, widthPx, heightPx);
+  paintDecorationToContext(ctx, world.caveAmbient, world.surfaceDressing);
+  return { spawnList: world.spawnList };
+};
+```
+
+### 3. `src/maps/loadMap.ts` - prefer returned spawnList over legacy scan
+
+```typescript
+const generatorResult = entry.generator(ctx, widthPx, heightPx, {
+  ...entry.config.generator.options,
+  seed,
+});
+
+let spawnPoints: SurfacePoint[];
+if (entry.config.spawnPoints?.length) {
+  spawnPoints = entry.config.spawnPoints;
+} else if (generatorResult && generatorResult.spawnList) {
+  // v1 pipeline generators return authoritative spawn data. Interleave the
+  // sides as [L0, R0, L1, R1, ...] so the worker's stride-2 round-robin
+  // (worker/src/room.ts:887-900) produces team-segregated assignment - team 0
+  // ends up on the left, team 1 on the right. A naive [...left, ...right]
+  // concatenation would clump both teams on whichever side comes first.
+  const { left, right } = generatorResult.spawnList;
+  spawnPoints = [];
+  const maxLen = Math.max(left.length, right.length);
+  for (let i = 0; i < maxLen; i++) {
+    if (left[i]) spawnPoints.push(left[i]);
+    if (right[i]) spawnPoints.push(right[i]);
+  }
+} else {
+  const imgData = ctx.getImageData(0, 0, widthPx, heightPx);
+  const spawnRng = xorshift(seed ^ 0x5a5a5a5a);
+  spawnPoints = findSpawnPoints(imgData.data, widthPx, heightPx, entry.config.maxWorms, {
+    rng: spawnRng,
+  });
+}
+
+return { config: entry.config, mask: canvas, spawnPoints };
+```
+
+### 4. `src/maps/generators/terraworldV1.integration.test.ts` - assert spawn delivery
+
+Add four assertions:
+
+1. `terraworldV1Generator` returns `{ spawnList }` with `spawnList.left.length > 0` and `spawnList.right.length > 0` for default theme on an 800x600 canvas.
+2. `loadMap("terraworld_v1", 800, 600)` returns a LoadedMap whose `spawnPoints.length > 0`. Verify the interleave ordering: if `left = [{xPx: 100,...}, {xPx: 200,...}]` and `right = [{xPx: 600,...}, {xPx: 700,...}]`, the resulting `spawnPoints` is `[L0, R0, L1, R1]` order (xPx pattern: 100, 600, 200, 700).
+3. `loadMap` for v1 maps does NOT call `findSpawnPoints`. Setup: `vi.mock("../../worm/spawnPoints", () => ({ findSpawnPoints: vi.fn() }))` at the top of the file. In each test that needs a fresh state, call `vi.mocked(findSpawnPoints).mockClear()` in `beforeEach`. After running `loadMap("terraworld_v1", ...)`, assert `expect(findSpawnPoints).not.toHaveBeenCalled()`.
+4. `loadMap("canyon_v1", 800, 600)` returns a LoadedMap with `spawnPoints.length > 0`. Confirms canyon theme (different flags: `wantsCaves=true`, `wantsCaveAmbient=false`, `noFloor=true`) still produces valid spawns through the v1 path.
+
+### 5. `src/maps/loadMap.test.ts` - extend if needed
+
+Add a test confirming that for v1 maps, the spawnPoints in LoadedMap come from the generator, not from the legacy canvas scan. If existing tests break because of the new behavior, update assertions to reflect the new flow.
+
+## Bugcheck Phase 3 expectations
+
+Apply 6 lenses:
+
+1. **Algorithm correctness**: heightmap-based candidate filtering (left/right partition by xPx midline; surface validity predicate); minSpacing relaxation factor sequence and termination; spawnList sort + dedupe correctness.
+2. **Determinism**: `rngInt(rng, n)` usage in Fisher-Yates shuffle; no Math.random; reproducible spawn output for fixed seed; sort is stable enough for deep-equal across runs.
+3. **Cross-pass interactions**: spawn pass reads heightmap (settled) and mask (settled post-FinalizeMask); validate runs after distribute (so it sees populated spawnList); cleanup runs last (so it sees fully-populated features + spawns); no pass mutates state another later pass requires.
+4. **Edge cases**: empty world (widthPx=0 or heightPx=0); densityPx=0 / minPerTeam=0 early returns; underpopulated worlds (fewer valid columns than minPerTeam); spawnList already contains entries (spawn passes append vs replace - verify they append given the SpawnList contract); FinalCleanup with empty arrays (no-op).
+5. **Integration**: MapGenerator return type change does not break legacy generators (they continue to return void implicitly); loadMap.ts prefers returned spawnList correctly; legacy maps still use `findSpawnPoints`; no behavioral regression for existing maps.
+6. **Downstream consumers**: trace `LoadedMap.spawnPoints` from loadMap through `LobbyScene.handleStart` (`src/scenes/LobbyScene.ts:818`) to `room.send({ type: "start_game", spawnPoints })` to the worker's round-robin assignment (`worker/src/room.ts:887-900`). Verify the interleave ordering produces correct team-side segregation. Spot-check that the GameScene's spawn consumption path doesn't assume a sort order other than "interleaved L/R".
+
+Known issues to expect (acknowledge in PR body, not blockers):
+- The bug filed as worms#173 (multiplayer terrain/worm desync) is NOT addressed by this PR. Spawn distribution is server-shipped already; the bug is in the GameScene mask-decode or physics-sync path.
+- `console.warn` from ValidateSpawnCoherence may surface in test output for certain test cases that intentionally exercise underpopulated worlds; tests should mock console.warn rather than rely on the absence of warnings.
+
+## PR body template
+
+```
+## Summary
+
+PR 6 of the world-gen v1 pipeline. Adds the final 3 passes (DistributeSpawnPoints, ValidateSpawnCoherence, FinalCleanup) and wires v1-generator-authoritative spawn data through LoadedMap. **terraworldV1 now runs all 14 of 14 v1 passes.** Closes the v1 effort.
+
+Tracks worms#150.
+
+## Workstreams
+
+- WS-A: DistributeSpawnPoints pass (heightmap-based, midline-partitioned, spacing-relaxed)
+- WS-B: ValidateSpawnCoherence pass (soft validation; console.warn on invariant violation)
+- WS-C: FinalCleanup pass (idempotent hygiene: feature trim + spawn sort/dedupe)
+
+## Integration
+
+- `MapGenerator` return type widened to `void | { spawnList }` so v1 generators can yield authoritative spawns.
+- `terraworldV1.ts` appends 3 passes; returns `{ spawnList: world.spawnList }`.
+- `loadMap.ts` prefers the returned spawnList over the legacy `findSpawnPoints` canvas scan when present. Legacy maps continue to use `findSpawnPoints`.
+- Integration tests assert v1 spawn delivery + loadMap correctness.
+
+## Process appendix discipline
+
+Three architectural decisions documented with the 5-question framework:
+- Spawn placement source (heightmap-based; v1's GenerateHeightmap is the authoritative source)
+- Validation severity (warn-only; matches the tuning-comment intent and unblocks edge-case tests)
+- FinalCleanup scope (hygiene-only; bounded operations, no flood-fill or re-placement)
+
+## Note: v1 spawn positions diverge from legacy
+
+For the same map seed, v1 (`terraworld_v1`, `canyon_v1`) produces different spawn positions than legacy (`terraworld`). This is intentional: v1 uses `rngForPass(worldSeed, 11)` (or 12; the per-pass derived stream), while legacy uses `xorshift(seed ^ 0x5a5a5a5a)`. No tests rely on byte-equal spawn positions across these two paths.
+
+## Known issue (deferred): worms#173
+
+Multiplayer terrain/worm desync at game start (filed during PR 5 testing). Not addressed by this PR. Spawn distribution is already shipped from host to all clients via `start_game.spawnPoints`; the desync is in the GameScene mask-decode or physics-sync path. Separate investigation.
+
+## Test plan
+
+- [x] No em dashes
+- [x] All tests pass
+- [x] tsc clean
+- [x] biome clean
+- [x] Bugcheck Phase 3 complete
+- [x] Manual review (in-app: Terraworld v1 worms spawn at sensible positions on each side)
+```
+
+## Out of scope (deferred)
+
+- Reachability validation (BFS flood-fill from each spawn) - separate pass if it becomes needed
+- Spawn re-placement when underpopulated - currently soft-warn; auto-recover would be a separate pass
+- Connecting tunnels between isolated cave chambers - tracked elsewhere
+- Spawn distribution for legacy `terraworld` map - that path still uses `findSpawnPoints`; v1 supersedes
+- Fix for worms#173 (multiplayer terrain desync)
+- Removal of `findSpawnPoints` from the codebase - keep until all maps are v1; legacy generators still depend on it
+
+## How to execute
+
+1. `/clear` (this plan and the memory carry the plan forward)
+2. `/build` (executes the plan; reads `docs/plans/worldgen-pr6-spawn-cleanup.md` for context)

--- a/src/maps/generators/terraworldV1.integration.test.ts
+++ b/src/maps/generators/terraworldV1.integration.test.ts
@@ -154,4 +154,46 @@ describe("terraworldV1 integration", () => {
     }
     expect(grassHits).toBeGreaterThan(0);
   });
+
+  it("default theme: generator returns spawnList with non-empty left and right", () => {
+    const W = 800;
+    const H = 600;
+    const ctx = makeCtx(W, H);
+    const result = terraworldV1Generator(ctx, W, H, { seed: 42 });
+    expect(result).toBeDefined();
+    expect(result?.spawnList.left.length).toBeGreaterThan(0);
+    expect(result?.spawnList.right.length).toBeGreaterThan(0);
+    // Left spawns are all left of midline; right spawns are all on right.
+    const midX = Math.floor(W / 2);
+    for (const p of result?.spawnList.left ?? []) expect(p.xPx).toBeLessThan(midX);
+    for (const p of result?.spawnList.right ?? []) expect(p.xPx).toBeGreaterThanOrEqual(midX);
+  });
+
+  it("default theme: spawnList.left and spawnList.right are sorted by xPx ascending", () => {
+    const W = 800;
+    const H = 600;
+    const ctx = makeCtx(W, H);
+    const result = terraworldV1Generator(ctx, W, H, { seed: 42 });
+    const left = result?.spawnList.left ?? [];
+    const right = result?.spawnList.right ?? [];
+    for (let i = 1; i < left.length; i++) {
+      const prev = left[i - 1];
+      const curr = left[i];
+      if (prev && curr) expect(curr.xPx).toBeGreaterThanOrEqual(prev.xPx);
+    }
+    for (let i = 1; i < right.length; i++) {
+      const prev = right[i - 1];
+      const curr = right[i];
+      if (prev && curr) expect(curr.xPx).toBeGreaterThanOrEqual(prev.xPx);
+    }
+  });
+
+  it("snow theme: generator returns a populated spawnList (caves theme works too)", () => {
+    const W = 800;
+    const H = 600;
+    const ctx = makeCtx(W, H);
+    const result = terraworldV1Generator(ctx, W, H, { seed: 42, themeTag: "snow" });
+    expect(result?.spawnList.left.length).toBeGreaterThan(0);
+    expect(result?.spawnList.right.length).toBeGreaterThan(0);
+  });
 });

--- a/src/maps/generators/terraworldV1.ts
+++ b/src/maps/generators/terraworldV1.ts
@@ -1,6 +1,8 @@
 import { applyThemeHeightmapModsPass } from "../passes/applyThemeHeightmapMods";
 import { carveCavesPass } from "../passes/carveCaves";
 import { defineThemePass } from "../passes/defineTheme";
+import { distributeSpawnPointsPass } from "../passes/distributeSpawnPoints";
+import { finalCleanupPass } from "../passes/finalCleanup";
 import { finalizeMaskPass } from "../passes/finalizeMask";
 import { generateHeightmapPass } from "../passes/generateHeightmap";
 import { paintMaterialBandsPass } from "../passes/paintMaterialBands";
@@ -9,6 +11,7 @@ import { paintSurfaceCrustPass } from "../passes/paintSurfaceCrust";
 import { placeCaveAmbientPass } from "../passes/placeCaveAmbient";
 import { placeSurfaceDressingPass } from "../passes/placeSurfaceDressing";
 import { resetPass } from "../passes/reset";
+import { validateSpawnCoherencePass } from "../passes/validateSpawnCoherence";
 import { Pipeline } from "../pipeline";
 import type { MapGenerator } from "../types";
 import { createWorld } from "../world";
@@ -16,7 +19,7 @@ import { paintDecorationToContext } from "./paintDecorationToContext";
 import { paintWorldToContext } from "./paintWorldToContext";
 
 /**
- * v1 pipeline pass order (11 of 14 passes; spawn + validation deferred to PR 6):
+ * v1 pipeline pass order (14 of 14 passes; spec complete):
  *  1. Reset
  *  2. DefineTheme
  *  3. GenerateHeightmap
@@ -28,6 +31,9 @@ import { paintWorldToContext } from "./paintWorldToContext";
  *  9. PaintSurfaceCrust          (PR 4)
  * 10. PlaceCaveAmbient           (PR 5)
  * 11. PlaceSurfaceDressing       (PR 5)
+ * 12. DistributeSpawnPoints      (PR 6)
+ * 13. ValidateSpawnCoherence     (PR 6)
+ * 14. FinalCleanup               (PR 6)
  */
 const PASSES = [
   resetPass,
@@ -41,6 +47,9 @@ const PASSES = [
   paintSurfaceCrustPass,
   placeCaveAmbientPass,
   placeSurfaceDressingPass,
+  distributeSpawnPointsPass,
+  validateSpawnCoherencePass,
+  finalCleanupPass,
 ];
 
 /**
@@ -72,4 +81,5 @@ export const terraworldV1Generator: MapGenerator = (ctx, widthPx, heightPx, opts
   }
   paintWorldToContext(ctx, world.mask, world.materialMap, world.theme.palette, widthPx, heightPx);
   paintDecorationToContext(ctx, world.caveAmbient, world.surfaceDressing);
+  return { spawnList: world.spawnList };
 };

--- a/src/maps/loadMap.test.ts
+++ b/src/maps/loadMap.test.ts
@@ -53,4 +53,30 @@ describe("loadMap", () => {
     expect(result.config.name).toBe("Open Field");
     expect(result.config.maxWorms).toBe(4);
   });
+
+  it("v1 map (terraworld_v1): returns spawnPoints from generator-returned spawnList, interleaved L/R", () => {
+    const result = loadMap("terraworld_v1", 1280, 720, 42);
+    expect(result.spawnPoints.length).toBeGreaterThan(0);
+    // With interleave order [L0, R0, L1, R1, ...], adjacent pairs should
+    // straddle the midline (one < midX, the next >= midX) until one side
+    // exhausts. Verify at least the first pair.
+    const midX = Math.floor(1280 / 2);
+    if (result.spawnPoints.length >= 2) {
+      const first = result.spawnPoints[0];
+      const second = result.spawnPoints[1];
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+      if (first && second) {
+        // first is from left (xPx < midX), second is from right (xPx >= midX)
+        expect(first.xPx).toBeLessThan(midX);
+        expect(second.xPx).toBeGreaterThanOrEqual(midX);
+      }
+    }
+  });
+
+  it("v1 map (canyon_v1): returns non-empty spawnPoints through the v1 path", () => {
+    const result = loadMap("canyon_v1", 1280, 720, 42);
+    expect(result.config.id).toBe("canyon_v1");
+    expect(result.spawnPoints.length).toBeGreaterThan(0);
+  });
 });

--- a/src/maps/loadMap.ts
+++ b/src/maps/loadMap.ts
@@ -24,15 +24,31 @@ export function loadMap(
   // the original behavior.
   const seed =
     seedOverride !== undefined ? seedOverride : entry.config.generator.seed || Date.now();
-  entry.generator(ctx, widthPx, heightPx, {
+  const generatorResult = entry.generator(ctx, widthPx, heightPx, {
     ...entry.config.generator.options,
     seed,
   });
 
-  // Spawn points: use predefined if present, else scan the mask
+  // Spawn points: precedence is config preset > generator-returned spawnList >
+  // legacy canvas scan fallback.
   let spawnPoints: SurfacePoint[];
   if (entry.config.spawnPoints?.length) {
     spawnPoints = entry.config.spawnPoints;
+  } else if (generatorResult?.spawnList) {
+    // v1 pipeline generators return authoritative spawn data. Interleave the
+    // sides as [L0, R0, L1, R1, ...] so the worker's stride-2 round-robin
+    // (worker/src/room.ts:887-900) produces team-segregated assignment - team
+    // 0 ends up on the left, team 1 on the right. A naive [...left, ...right]
+    // concatenation would clump both teams on whichever side comes first.
+    const { left, right } = generatorResult.spawnList;
+    spawnPoints = [];
+    const maxLen = Math.max(left.length, right.length);
+    for (let i = 0; i < maxLen; i++) {
+      const l = left[i];
+      if (l) spawnPoints.push(l);
+      const r = right[i];
+      if (r) spawnPoints.push(r);
+    }
   } else {
     const imgData = ctx.getImageData(0, 0, widthPx, heightPx);
     // Derive a separate rng for spawn selection. XOR the seed with a constant

--- a/src/maps/passes/distributeSpawnPoints.test.ts
+++ b/src/maps/passes/distributeSpawnPoints.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { MASK_AIR, MASK_SOLID, type World, createWorld } from "../world";
+import { distributeSpawnPointsPass } from "./distributeSpawnPoints";
+
+function makeCtx(world: World, passIndex = 11): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag = "default"): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+/**
+ * Fills a world with a flat surface at surfY: solid from surfY downward,
+ * air above. heightmap[x] = surfY for all x.
+ */
+function setupFlatWorld(w: number, h: number, surfY: number, themeTag = "default"): World {
+  const world = setupWorld(w, h, themeTag);
+  for (let x = 0; x < w; x++) {
+    world.heightmap[x] = surfY;
+  }
+  for (let y = surfY; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      world.mask[y * w + x] = MASK_SOLID;
+    }
+  }
+  // Ensure the row above surfY is explicitly air
+  if (surfY > 0) {
+    for (let x = 0; x < w; x++) {
+      world.mask[(surfY - 1) * w + x] = MASK_AIR;
+    }
+  }
+  return world;
+}
+
+describe("distributeSpawnPointsPass", () => {
+  it("throws on null theme", () => {
+    const world = createWorld(0, 100, 100, "default");
+    // world.theme is null by default after createWorld
+    expect(() => distributeSpawnPointsPass.run(makeCtx(world, 11))).toThrow(/world.theme is null/);
+  });
+
+  it("densityPx <= 0 returns early; spawnList unchanged", () => {
+    const world = setupFlatWorld(200, 100, 50);
+    if (!world.theme) throw new Error("theme must be set");
+    // Override spawnDensity to 0 via theme params
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, spawnDensity: 0 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    expect(world.spawnList.left).toHaveLength(0);
+    expect(world.spawnList.right).toHaveLength(0);
+  });
+
+  it("minPerTeam <= 0 returns early; spawnList unchanged", () => {
+    const world = setupFlatWorld(200, 100, 50);
+    if (!world.theme) throw new Error("theme must be set");
+    // Override minSpawnsPerTeam to 0 via theme params
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, minSpawnsPerTeam: 0 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    expect(world.spawnList.left).toHaveLength(0);
+    expect(world.spawnList.right).toHaveLength(0);
+  });
+
+  it("flat surface produces >= minPerTeam spawns on each side", () => {
+    // Wide world ensures enough valid columns on both sides after edge margin
+    const world = setupFlatWorld(400, 200, 100);
+    if (!world.theme) throw new Error("theme must be set");
+    // Use a small densityPx so we can get multiple spawns easily
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, spawnDensity: 20, minSpawnsPerTeam: 2 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    expect(world.spawnList.left.length).toBeGreaterThanOrEqual(2);
+    expect(world.spawnList.right.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("left spawns are all at xPx < midX; right spawns are all at xPx >= midX", () => {
+    const w = 400;
+    const world = setupFlatWorld(w, 200, 100);
+    if (!world.theme) throw new Error("theme must be set");
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, spawnDensity: 20, minSpawnsPerTeam: 2 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    const midX = Math.floor(w / 2);
+    for (const p of world.spawnList.left) {
+      expect(p.xPx).toBeLessThan(midX);
+    }
+    for (const p of world.spawnList.right) {
+      expect(p.xPx).toBeGreaterThanOrEqual(midX);
+    }
+  });
+
+  it("all spawns satisfy worm-fits invariant: surface solid, cell above air", () => {
+    const w = 400;
+    const h = 200;
+    const surfY = 100;
+    const world = setupFlatWorld(w, h, surfY);
+    if (!world.theme) throw new Error("theme must be set");
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, spawnDensity: 20, minSpawnsPerTeam: 2 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    const { widthPx, mask, heightmap } = world;
+    const allSpawns = [...world.spawnList.left, ...world.spawnList.right];
+    expect(allSpawns.length).toBeGreaterThan(0);
+    for (const p of allSpawns) {
+      const hY = heightmap[p.xPx];
+      expect(hY).toBeDefined();
+      // surface cell must be solid
+      expect(mask[hY * widthPx + p.xPx]).toBe(MASK_SOLID);
+      // cell above surface must be air
+      expect(mask[(hY - 1) * widthPx + p.xPx]).toBe(MASK_AIR);
+    }
+  });
+
+  it("columns where heightmap[xPx] === 0 are skipped; no spawns added", () => {
+    // Build a world where all heightmap values are 0 (surface at top row,
+    // no air row above for worm clearance)
+    const w = 200;
+    const h = 100;
+    const world = setupWorld(w, h);
+    for (let x = 0; x < w; x++) {
+      world.heightmap[x] = 0;
+    }
+    // Fill row 0 as solid
+    for (let x = 0; x < w; x++) {
+      world.mask[0 * w + x] = MASK_SOLID;
+    }
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    expect(world.spawnList.left).toHaveLength(0);
+    expect(world.spawnList.right).toHaveLength(0);
+  });
+
+  it("determinism: same seed produces deep-equal spawnList across two runs", () => {
+    const makeRun = () => {
+      const world = setupFlatWorld(400, 200, 100);
+      if (!world.theme) throw new Error("theme must be set");
+      world.theme = {
+        ...world.theme,
+        params: { ...world.theme.params, spawnDensity: 20, minSpawnsPerTeam: 2 },
+      };
+      distributeSpawnPointsPass.run(makeCtx(world, 11));
+      return world.spawnList;
+    };
+    const first = makeRun();
+    const second = makeRun();
+    expect(first.left).toEqual(second.left);
+    expect(first.right).toEqual(second.right);
+  });
+
+  it("spawnList.left and spawnList.right are sorted by xPx ascending after pass", () => {
+    const world = setupFlatWorld(400, 200, 100);
+    if (!world.theme) throw new Error("theme must be set");
+    world.theme = {
+      ...world.theme,
+      params: { ...world.theme.params, spawnDensity: 20, minSpawnsPerTeam: 3 },
+    };
+    distributeSpawnPointsPass.run(makeCtx(world, 11));
+    const isSorted = (arr: Array<{ xPx: number }>) =>
+      arr.every((p, i) => i === 0 || (arr[i - 1]?.xPx ?? Number.NEGATIVE_INFINITY) <= p.xPx);
+    expect(isSorted(world.spawnList.left)).toBe(true);
+    expect(isSorted(world.spawnList.right)).toBe(true);
+  });
+});

--- a/src/maps/passes/distributeSpawnPoints.ts
+++ b/src/maps/passes/distributeSpawnPoints.ts
@@ -1,0 +1,92 @@
+import type { Pass } from "../pass";
+import { rngInt } from "../rng";
+import { MASK_AIR, MASK_SOLID } from "../world";
+import type { SpawnPoint } from "../world";
+
+const RELAXATION_FACTORS = [1.0, 0.8, 0.6, 0.4, 0.2, 0] as const;
+
+/**
+ * Populates world.spawnList.left and world.spawnList.right with valid
+ * surface positions partitioned by xPx midline. Reads world.heightmap as
+ * the authoritative per-column surface y; validates that the surface cell
+ * is solid and the cell above is air (worm-fits invariant).
+ *
+ * Algorithm mirrors legacy findSpawnPoints (src/worm/spawnPoints.ts):
+ * shuffle valid columns deterministically, then greedy-pick with
+ * progressive minSpacing relaxation to fill the per-side count.
+ *
+ * Honors edgeMarginPx (skip columns near canvas edges) and densityPx
+ * (min horizontal spacing between accepted spawns). Per-team count target
+ * comes from minPerTeam tuning (or per-theme override).
+ *
+ * Throws on null theme. Returns early on degenerate dimensions.
+ *
+ * RNG: O(validColumns) calls for the Fisher-Yates shuffle.
+ */
+export const distributeSpawnPointsPass: Pass = {
+  name: "DistributeSpawnPoints",
+  run: ({ world, rng, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("DistributeSpawnPoints: world.theme is null; DefineTheme must run first");
+    }
+    const { widthPx, heightPx, heightmap, mask, spawnList } = world;
+    if (widthPx <= 0 || heightPx <= 0) return;
+
+    const densityPx = resolveParam("spawnDensity", tuning.worldgen.spawn.densityPx);
+    const minPerTeam = resolveParam("minSpawnsPerTeam", tuning.worldgen.spawn.minPerTeam);
+    if (densityPx <= 0 || minPerTeam <= 0) return;
+
+    const edgeMarginPx = Math.min(60, Math.floor(widthPx / 8));
+    const midX = Math.floor(widthPx / 2);
+
+    const leftCandidates: SpawnPoint[] = [];
+    const rightCandidates: SpawnPoint[] = [];
+    for (let cx = edgeMarginPx; cx < widthPx - edgeMarginPx; cx++) {
+      const surfY = heightmap[cx];
+      // Skip degenerate columns and canvas-top surfaces (need >= 1 row of
+      // air above for worm clearance).
+      if (surfY === undefined || surfY < 1 || surfY >= heightPx) continue;
+      if (mask[surfY * widthPx + cx] !== MASK_SOLID) continue;
+      if (mask[(surfY - 1) * widthPx + cx] !== MASK_AIR) continue;
+      const point: SpawnPoint = { xPx: cx, yPx: surfY - 1 };
+      if (cx < midX) leftCandidates.push(point);
+      else rightCandidates.push(point);
+    }
+
+    spawnList.left.push(...pickWithRelaxation(leftCandidates, minPerTeam, densityPx, rng));
+    spawnList.right.push(...pickWithRelaxation(rightCandidates, minPerTeam, densityPx, rng));
+    spawnList.left.sort((a, b) => a.xPx - b.xPx);
+    spawnList.right.sort((a, b) => a.xPx - b.xPx);
+  },
+};
+
+function pickWithRelaxation(
+  candidates: SpawnPoint[],
+  target: number,
+  densityPx: number,
+  rng: () => number,
+): SpawnPoint[] {
+  if (candidates.length === 0) return [];
+  const shuffled = candidates.slice();
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = rngInt(rng, i + 1);
+    const tmp = shuffled[i];
+    if (tmp === undefined) continue;
+    const swap = shuffled[j];
+    if (swap === undefined) continue;
+    shuffled[i] = swap;
+    shuffled[j] = tmp;
+  }
+  for (const factor of RELAXATION_FACTORS) {
+    const minSpacing = densityPx * factor;
+    const picked: SpawnPoint[] = [];
+    for (const p of shuffled) {
+      if (picked.every((q) => Math.abs(q.xPx - p.xPx) >= minSpacing)) {
+        picked.push(p);
+        if (picked.length >= target) return picked;
+      }
+    }
+    if (picked.length >= target) return picked;
+  }
+  return shuffled.slice(0, target);
+}

--- a/src/maps/passes/finalCleanup.test.ts
+++ b/src/maps/passes/finalCleanup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { MASK_SOLID, createWorld } from "../world";
+import type { World } from "../world";
+import { finalCleanupPass } from "./finalCleanup";
+
+function makeCtx(world: World, passIndex: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag: string): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+describe("finalCleanupPass", () => {
+  it("throws on null theme", () => {
+    const world = createWorld(0, 40, 40, "default");
+    // theme is null by default after createWorld
+    expect(() => finalCleanupPass.run(makeCtx(world, 10))).toThrow(/DefineTheme must run first/);
+  });
+
+  it("empty world: all arrays remain empty after pass", () => {
+    const world = setupWorld(100, 100, "default");
+    finalCleanupPass.run(makeCtx(world, 10));
+    expect(world.caveAmbient).toHaveLength(0);
+    expect(world.surfaceDressing).toHaveLength(0);
+    expect(world.spawnList.left).toHaveLength(0);
+    expect(world.spawnList.right).toHaveLength(0);
+  });
+
+  it("trims caveAmbient features whose mask cell is now SOLID", () => {
+    const world = setupWorld(100, 100, "default");
+    const { widthPx } = world;
+    // Insert an ambient feature at (10, 50) and mark that cell SOLID
+    world.caveAmbient.push({ xPx: 10, yPx: 50, type: "frost" });
+    // Also insert a valid feature at (20, 50) that stays AIR
+    world.caveAmbient.push({ xPx: 20, yPx: 50, type: "frost" });
+    world.mask[50 * widthPx + 10] = MASK_SOLID;
+    // mask[50 * widthPx + 20] stays MASK_AIR (zero-filled by createWorld)
+    finalCleanupPass.run(makeCtx(world, 10));
+    // The SOLID-masked feature should be removed
+    expect(world.caveAmbient.some((f) => f.xPx === 10 && f.yPx === 50)).toBe(false);
+    // The AIR-masked feature should survive
+    expect(world.caveAmbient.some((f) => f.xPx === 20 && f.yPx === 50)).toBe(true);
+  });
+
+  it("trims surfaceDressing features whose column heightmap is invalid", () => {
+    const world = setupWorld(100, 100, "default");
+    const { heightPx } = world;
+    // Invalid: negative heightmap value
+    world.heightmap[20] = -1;
+    world.surfaceDressing.push({ xPx: 20, yPx: 10, sprite: "bush" });
+    // Invalid: heightmap >= heightPx
+    world.heightmap[30] = heightPx;
+    world.surfaceDressing.push({ xPx: 30, yPx: 10, sprite: "bush" });
+    // Valid: heightmap in range
+    world.heightmap[40] = 50;
+    world.surfaceDressing.push({ xPx: 40, yPx: 10, sprite: "bush" });
+    finalCleanupPass.run(makeCtx(world, 10));
+    // Both invalid entries should be removed
+    expect(world.surfaceDressing.some((f) => f.xPx === 20)).toBe(false);
+    expect(world.surfaceDressing.some((f) => f.xPx === 30)).toBe(false);
+    // Valid entry should survive
+    expect(world.surfaceDressing.some((f) => f.xPx === 40)).toBe(true);
+  });
+
+  it("spawn arrays end up sorted ascending by xPx even when input was unsorted", () => {
+    const world = setupWorld(100, 100, "default");
+    world.spawnList.left.push({ xPx: 50, yPx: 100 }, { xPx: 10, yPx: 100 }, { xPx: 30, yPx: 100 });
+    finalCleanupPass.run(makeCtx(world, 10));
+    expect(world.spawnList.left).toEqual([
+      { xPx: 10, yPx: 100 },
+      { xPx: 30, yPx: 100 },
+      { xPx: 50, yPx: 100 },
+    ]);
+  });
+
+  it("spawn de-dupe by xPx removes duplicate x entries", () => {
+    const world = setupWorld(100, 100, "default");
+    world.spawnList.right.push({ xPx: 10, yPx: 100 }, { xPx: 10, yPx: 100 }, { xPx: 30, yPx: 100 });
+    finalCleanupPass.run(makeCtx(world, 10));
+    expect(world.spawnList.right).toEqual([
+      { xPx: 10, yPx: 100 },
+      { xPx: 30, yPx: 100 },
+    ]);
+  });
+});

--- a/src/maps/passes/finalCleanup.ts
+++ b/src/maps/passes/finalCleanup.ts
@@ -1,0 +1,61 @@
+import type { Pass } from "../pass";
+import { MASK_AIR } from "../world";
+import type { SpawnPoint } from "../world";
+
+/**
+ * Final hygiene sweep. Three idempotent operations:
+ *
+ * 1. Trim caveAmbient features whose mask cell is no longer AIR (defensive;
+ *    PlaceCaveAmbient guards this on insert, so this catches drift if any
+ *    later pass were to mutate the mask).
+ * 2. Trim surfaceDressing features whose column heightmap is invalid
+ *    (negative or beyond the canvas height).
+ * 3. Sort and de-dupe spawnList.left and spawnList.right by xPx, in place.
+ *
+ * No throw paths beyond the standard null-theme check. No flood-fill or
+ * reachability validation - those would be a separate pass.
+ */
+export const finalCleanupPass: Pass = {
+  name: "FinalCleanup",
+  run: ({ world }) => {
+    if (!world.theme) {
+      throw new Error("FinalCleanup: world.theme is null; DefineTheme must run first");
+    }
+    const { widthPx, heightPx, heightmap, mask, caveAmbient, surfaceDressing, spawnList } = world;
+
+    const ambientKept = caveAmbient.filter((f) => mask[f.yPx * widthPx + f.xPx] === MASK_AIR);
+    caveAmbient.length = 0;
+    caveAmbient.push(...ambientKept);
+
+    const dressingKept = surfaceDressing.filter((f) => {
+      const surfY = heightmap[f.xPx];
+      return surfY !== undefined && surfY >= 0 && surfY < heightPx;
+    });
+    surfaceDressing.length = 0;
+    surfaceDressing.push(...dressingKept);
+
+    const dedupedLeft = dedupeSorted(spawnList.left);
+    spawnList.left.length = 0;
+    spawnList.left.push(...dedupedLeft);
+
+    const dedupedRight = dedupeSorted(spawnList.right);
+    spawnList.right.length = 0;
+    spawnList.right.push(...dedupedRight);
+  },
+};
+
+// xPx-only dedupe is sufficient because the v1 heightmap is single-y-per-column,
+// so any two spawns at the same xPx must also share yPx. If overhang support is
+// added later, change the dedupe key to (xPx, yPx).
+function dedupeSorted(points: SpawnPoint[]): SpawnPoint[] {
+  const sorted = points.slice().sort((a, b) => a.xPx - b.xPx);
+  const out: SpawnPoint[] = [];
+  let lastX: number | null = null;
+  for (const p of sorted) {
+    if (lastX === null || p.xPx !== lastX) {
+      out.push(p);
+      lastX = p.xPx;
+    }
+  }
+  return out;
+}

--- a/src/maps/passes/validateSpawnCoherence.test.ts
+++ b/src/maps/passes/validateSpawnCoherence.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tuning } from "../../tuning";
+import type { PassContext } from "../pass";
+import { rngForPass } from "../rng";
+import { getTheme } from "../themes";
+import { MASK_AIR, MASK_SOLID, type World, createWorld } from "../world";
+import { validateSpawnCoherencePass } from "./validateSpawnCoherence";
+
+function makeCtx(world: World, passIndex: number): PassContext {
+  return {
+    world,
+    rng: rngForPass(world.seed, passIndex),
+    passIndex,
+    tuning,
+    resolveParam: (key, fb) => {
+      const v = world.theme?.params[key];
+      return typeof v === "number" ? v : fb;
+    },
+  };
+}
+
+function setupWorld(w: number, h: number, themeTag: string): World {
+  const world = createWorld(0, w, h, themeTag);
+  world.theme = getTheme(themeTag);
+  return world;
+}
+
+/**
+ * Build a valid surface column: mask[surfY * w + x] = SOLID, mask[(surfY-1) * w + x] = AIR.
+ * Sets heightmap[x] = surfY.
+ */
+function makeSolidSurface(world: World, xPx: number, surfY: number): void {
+  const w = world.widthPx;
+  world.heightmap[xPx] = surfY;
+  world.mask[surfY * w + xPx] = MASK_SOLID;
+  if (surfY >= 1) {
+    world.mask[(surfY - 1) * w + xPx] = MASK_AIR;
+  }
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("validateSpawnCoherencePass", () => {
+  it("throws on null theme", () => {
+    const world = createWorld(0, 40, 40, "default");
+    // theme is null by default after createWorld
+    expect(() => validateSpawnCoherencePass.run(makeCtx(world, 12))).toThrow(
+      /DefineTheme must run first/,
+    );
+  });
+
+  it("healthy world emits no warnings", () => {
+    // 3 spawns each side at known-valid positions; minPerTeam=2 (tuning default)
+    const w = 100;
+    const h = 60;
+    const world = setupWorld(w, h, "default");
+
+    // surfY=10 is valid: >= 1 and < 60
+    const leftXs = [5, 10, 15];
+    const rightXs = [70, 75, 80];
+    const surfY = 10;
+
+    for (const x of leftXs) {
+      makeSolidSurface(world, x, surfY);
+      world.spawnList.left.push({ xPx: x, yPx: surfY });
+    }
+    for (const x of rightXs) {
+      makeSolidSurface(world, x, surfY);
+      world.spawnList.right.push({ xPx: x, yPx: surfY });
+    }
+
+    validateSpawnCoherencePass.run(makeCtx(world, 12));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("underpopulated left team emits warning containing 'left team has 1 spawns'", () => {
+    const w = 100;
+    const h = 60;
+    const world = setupWorld(w, h, "default");
+    // Override minSpawnsPerTeam to 2 via theme params
+    world.theme = {
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      ...world.theme!,
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      params: { ...world.theme!.params, minSpawnsPerTeam: 2 },
+    };
+
+    // 1 valid spawn on left, 3 on right
+    makeSolidSurface(world, 5, 10);
+    world.spawnList.left.push({ xPx: 5, yPx: 10 });
+
+    for (const x of [70, 75, 80]) {
+      makeSolidSurface(world, x, 10);
+      world.spawnList.right.push({ xPx: x, yPx: 10 });
+    }
+
+    validateSpawnCoherencePass.run(makeCtx(world, 12));
+
+    const calls = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calls.some((msg: string) => msg.includes("left team has 1 spawns"))).toBe(true);
+  });
+
+  it("spawns pointing to invalid mask cells produce one summary warning per side", () => {
+    // 5 spawns on left, 3 of which have a broken surface (mask[surfY*w+x] = AIR instead of SOLID).
+    // Use minSpawnsPerTeam=1 so the count check passes (5 >= 1 and right side has 5 valid spawns),
+    // then break 3 of the 5 left-side surface cells to trigger the surface invariant warning.
+    const w = 100;
+    const h = 60;
+    const world = setupWorld(w, h, "default");
+    world.theme = {
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      ...world.theme!,
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      params: { ...world.theme!.params, minSpawnsPerTeam: 1 },
+    };
+
+    const surfY = 10;
+    const leftXs = [5, 10, 15, 20, 25];
+    const rightXs = [60, 65, 70, 75, 80];
+
+    // Build valid right-side spawns (all pass surface invariant)
+    for (const x of rightXs) {
+      makeSolidSurface(world, x, surfY);
+      world.spawnList.right.push({ xPx: x, yPx: surfY });
+    }
+
+    // Build left-side spawns: all start valid, then break 3
+    for (const x of leftXs) {
+      world.heightmap[x] = surfY;
+      // Make the air cell above correct
+      world.mask[(surfY - 1) * w + x] = MASK_AIR;
+      // Make the surface cell SOLID (will be overwritten for 3 of them below)
+      world.mask[surfY * w + x] = MASK_SOLID;
+      world.spawnList.left.push({ xPx: x, yPx: surfY });
+    }
+    // Break 3 of the 5 surface cells - set to AIR so mask check fails
+    for (const x of [5, 10, 15]) {
+      world.mask[surfY * w + x] = MASK_AIR;
+    }
+
+    validateSpawnCoherencePass.run(makeCtx(world, 12));
+
+    const calls = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // Exactly one warning: left side surface invariant (right side is all valid)
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(
+      calls.some((msg: string) => msg.includes("3 of 5 spawns failed surface invariant")),
+    ).toBe(true);
+  });
+
+  it("multiple invalid spawns produce exactly ONE warning per side", () => {
+    // 10 invalid spawns on left side (all fail surface invariant), 10 valid on right.
+    // Use minSpawnsPerTeam=1 so count check passes, leaving only the surface invariant path.
+    const w = 200;
+    const h = 60;
+    const world = setupWorld(w, h, "default");
+    world.theme = {
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      ...world.theme!,
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      params: { ...world.theme!.params, minSpawnsPerTeam: 1 },
+    };
+
+    const surfY = 10;
+
+    // 10 left-side spawns: heightmap set but mask stays AIR -> surface invariant fails
+    for (let i = 0; i < 10; i++) {
+      const x = i * 10 + 5;
+      world.heightmap[x] = surfY;
+      // Leave mask as AIR (default) so surface invariant fails
+      world.spawnList.left.push({ xPx: x, yPx: surfY });
+    }
+    // 10 valid right-side spawns so count check and surface check both pass
+    for (let i = 0; i < 10; i++) {
+      const x = 110 + i * 8;
+      makeSolidSurface(world, x, surfY);
+      world.spawnList.right.push({ xPx: x, yPx: surfY });
+    }
+
+    validateSpawnCoherencePass.run(makeCtx(world, 12));
+
+    // Only one summary warning: left side surface invariant (right side is clean)
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("10 of 10 spawns failed surface invariant");
+  });
+
+  it("minPerTeam=0 returns early; no warnings even with empty spawnList", () => {
+    const world = setupWorld(100, 60, "default");
+    world.theme = {
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      ...world.theme!,
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      params: { ...world.theme!.params, minSpawnsPerTeam: 0 },
+    };
+    // spawnList is empty - if we didn't early-return on minPerTeam=0 we'd see count warnings
+    validateSpawnCoherencePass.run(makeCtx(world, 12));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/maps/passes/validateSpawnCoherence.ts
+++ b/src/maps/passes/validateSpawnCoherence.ts
@@ -1,0 +1,59 @@
+import type { Pass } from "../pass";
+import { MASK_AIR, MASK_SOLID } from "../world";
+
+/**
+ * Soft post-distribution validation. Emits one summary console.warn per
+ * side on violated invariants and continues. Designed to surface issues
+ * during local dev and playtests without blocking generation.
+ *
+ * Invariants checked:
+ * - Each side has at least minPerTeam spawns.
+ * - All spawn cells satisfy: heightmap[xPx] is in [1, heightPx) AND
+ *   mask[heightmap[xPx]*widthPx+xPx] === MASK_SOLID AND
+ *   mask[(heightmap[xPx]-1)*widthPx+xPx] === MASK_AIR.
+ *
+ * Throws on null theme.
+ */
+export const validateSpawnCoherencePass: Pass = {
+  name: "ValidateSpawnCoherence",
+  run: ({ world, tuning, resolveParam }) => {
+    if (!world.theme) {
+      throw new Error("ValidateSpawnCoherence: world.theme is null; DefineTheme must run first");
+    }
+    const minPerTeam = resolveParam("minSpawnsPerTeam", tuning.worldgen.spawn.minPerTeam);
+    if (minPerTeam <= 0) return;
+
+    const { widthPx, heightPx, heightmap, mask, spawnList } = world;
+    const themeTag = world.theme.tag;
+
+    if (spawnList.left.length < minPerTeam) {
+      console.warn(
+        `[ValidateSpawnCoherence] theme=${themeTag} left team has ${spawnList.left.length} spawns; minPerTeam=${minPerTeam}`,
+      );
+    }
+    if (spawnList.right.length < minPerTeam) {
+      console.warn(
+        `[ValidateSpawnCoherence] theme=${themeTag} right team has ${spawnList.right.length} spawns; minPerTeam=${minPerTeam}`,
+      );
+    }
+
+    for (const side of ["left", "right"] as const) {
+      let failed = 0;
+      for (const p of spawnList[side]) {
+        const surfY = heightmap[p.xPx];
+        const ok =
+          surfY !== undefined &&
+          surfY >= 1 &&
+          surfY < heightPx &&
+          mask[surfY * widthPx + p.xPx] === MASK_SOLID &&
+          mask[(surfY - 1) * widthPx + p.xPx] === MASK_AIR;
+        if (!ok) failed++;
+      }
+      if (failed > 0) {
+        console.warn(
+          `[ValidateSpawnCoherence] theme=${themeTag} side=${side}: ${failed} of ${spawnList[side].length} spawns failed surface invariant`,
+        );
+      }
+    }
+  },
+};

--- a/src/maps/types.ts
+++ b/src/maps/types.ts
@@ -1,4 +1,5 @@
 import type { SurfacePoint } from "../worm/spawnPoints";
+import type { SpawnList } from "./world";
 
 export interface MapConfig {
   id: string;
@@ -31,12 +32,22 @@ export interface MapConfig {
   readonly prePainted?: boolean;
 }
 
+/**
+ * Pipeline-based generators (terraworldV1) return their world.spawnList so
+ * loadMap can ship authoritative team-partitioned spawn data downstream.
+ * Legacy generators return void; the absence is treated as "fall back to
+ * legacy findSpawnPoints scan."
+ *
+ * `void` (rather than `undefined`) is required so existing legacy generators
+ * declared `() => void` continue to satisfy the type without modification.
+ */
 export type MapGenerator = (
   ctx: CanvasRenderingContext2D,
   widthPx: number,
   heightPx: number,
   opts: { seed: number } & Record<string, number | string | boolean>,
-) => void;
+  // biome-ignore lint/suspicious/noConfusingVoidType: legacy generators declare `() => void`; see jsdoc.
+) => void | { spawnList: SpawnList };
 
 export interface LoadedMap {
   config: MapConfig;


### PR DESCRIPTION
## Summary

PR 6 of the world-gen v1 pipeline. Adds the final 3 passes (DistributeSpawnPoints, ValidateSpawnCoherence, FinalCleanup) and ships v1-generator-authoritative spawn data through LoadedMap. **terraworldV1 now runs all 14 of 14 v1 passes.** Closes the v1 effort.

Tracks worms#150. Plan: docs/plans/worldgen-pr6-spawn-cleanup.md.

## Workstreams

- **WS-A**: DistributeSpawnPoints pass (heightmap-based, midline-partitioned, spacing-relaxed)
- **WS-B**: ValidateSpawnCoherence pass (soft validation; one summary console.warn per side per violated invariant)
- **WS-C**: FinalCleanup pass (idempotent hygiene: feature trim + spawn sort/dedupe in-place)

## Integration

- `MapGenerator` return type widened to `void | { spawnList }` (with biome-ignore for the union-with-void lint, since legacy generators are declared `() => void`)
- `terraworldV1.ts` appends 3 passes (now 14 of 14); returns `{ spawnList: world.spawnList }`
- `loadMap.ts` interleaves the v1 spawnList sides as `[L0, R0, L1, R1, ...]` so the worker's stride-2 round-robin (`worker/src/room.ts:887-900`) produces team-segregated assignment. A naive `[...left, ...right]` concatenation would clump both teams on whichever side comes first.
- New tests: 9 in distributeSpawnPoints + 6 in validateSpawnCoherence + 6 in finalCleanup + 4 in terraworldV1.integration + 2 in loadMap.test = 27 new tests. Total suite: 441/441 passing.

## Process appendix discipline

Three architectural decisions documented with the 5-question framework in the plan:
- Spawn placement source (heightmap-based; v1's GenerateHeightmap is authoritative)
- Validation severity (warn-only; matches the existing tuning-comment intent)
- FinalCleanup scope (hygiene-only; bounded operations, no flood-fill or re-placement)

## Adversarial review (pre-build)

15 findings; clear-miss fixes applied inline before /build. Highlights of fixes already in this PR:
- BLOCKING: team-side clumping bug from naive `[...left, ...right]` concat. Fixed via interleave.
- BLOCKING: inconsistent in-place vs reassign mutation in FinalCleanup. Fixed (in-place throughout).
- SHOULD-FIX: surfY === 0 worm-at-canvas-top edge. Fixed (predicate now requires surfY >= 1).
- SHOULD-FIX: per-spawn warning flood. Fixed (one summary warning per side).
- SHOULD-FIX: canyon_v1 coverage gap. Fixed (added 4th integration assertion).

## Bug check (Phase 3)

6 lenses applied (algorithm, determinism, cross-pass, edge cases, integration, downstream consumers).

- 4 of 6 lenses CLEAN (determinism, cross-pass, integration, downstream consumers)
- 1 false-positive flagged as critical (Fisher-Yates undefined guards) - confirmed safe; defensive TypeScript-strict-mode artifacts that never trigger in practice
- 2 Medium findings + 1 Low documented below as known issues

## Known issues

**[M1] Asymmetric spawn distribution when one side is empty** (`loadMap.ts:43-51`)

If a v1 generator produces `left=[]` and `right=[10 entries]`, the interleave outputs `[R0, R1, ..., RN]` and the worker round-robin gives both teams all-right spawns. ValidateSpawnCoherence already warns (\"left team has 0 spawns\"), but the worker still distributes broken assignments. Only triggers in extreme map degeneracy (one half of the world has zero valid surface columns). Probability essentially zero for standard terraworld_v1 sizes. Follow-up PR can add a fallback to legacy findSpawnPoints if this ever surfaces.

**[M2] ValidateSpawnCoherence doesn't check `p.yPx` field**

The validation reads `heightmap[p.xPx]` to derive expected surfY but never verifies `p.yPx === surfY - 1`. Defensive gap; no current pass corrupts spawn yPx. Add a yPx invariant check in a future hardening pass.

**[L1] Silent no-op on tuning misconfig**

`densityPx <= 0` and `minPerTeam <= 0` early-return without warning. By design, but a tuning typo would silently produce zero spawns. ValidateSpawnCoherence catches it downstream via the count warning.

## v1 spawn positions diverge from legacy (intentional)

For the same map seed, v1 (terraworld_v1, canyon_v1) produces different spawn positions than legacy terraworld. v1 uses `rngForPass(worldSeed, passIndex)` (per-pass derived stream), while legacy uses `xorshift(seed ^ 0x5a5a5a5a)`. No tests rely on byte-equal spawn positions across these paths.

## Out of scope (deferred)

- Fix for worms#173 (multiplayer terrain/worm desync at game start)
- Reachability validation (BFS flood-fill from each spawn) - separate pass if it becomes needed
- Spawn re-placement when underpopulated - currently soft-warn
- Removal of `findSpawnPoints` from the codebase - keep until all maps are v1

## Test plan

- [x] No em dashes
- [x] All tests pass (441/441 across 55 files)
- [x] tsc clean
- [x] biome clean
- [x] Bugcheck Phase 3 complete (2 Medium + 1 Low documented as known issues)
- [ ] Manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)