### PR TITLE
feat(worldgen): promote terraworld_v1 to default; hide legacy

### DIFF
--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -122,10 +122,12 @@ export const MAPS: Record<string, RegistryEntry> = {
   terraworld: {
     config: {
       id: "terraworld",
-      name: "Terraworld",
-      description: "Procedural heightmap surface with grass, dirt, and stone strata.",
+      name: "Terraworld (legacy)",
+      description:
+        "Procedural heightmap surface with grass, dirt, and stone strata. Superseded by terraworld_v1.",
       maxWorms: 4,
       generator: { id: "terraworld", seed: 0 },
+      visibleInLobby: false,
     },
     generator: terraworldGenerator,
   },

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -225,7 +225,7 @@ export const tuning: Tuning = {
     longPressMs: 400,
   },
   maps: {
-    defaultId: "terraworld", // registry lookup; falls back to firstId() if invalid
+    defaultId: "terraworld_v1", // registry lookup; falls back to firstId() if invalid
   },
   caves: {
     // 24 gives 2560x1024 a ~107x43 grid. Each cell is ~1 worm tall, so

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -162,8 +162,9 @@ export class Room implements DurableObject {
       code: this.code ?? "",
       phase: "lobby",
       hostSessionId: "",
-      // ADR-003: default to the procgen world as the canonical starting biome
-      selectedMapId: "terraworld",
+      // ADR-003: default to the procgen world as the canonical starting biome.
+      // terraworld_v1 is the 14-pass pipeline (replaces legacy terraworld since PR 6).
+      selectedMapId: "terraworld_v1",
       players: {},
       teamOrder: [],
       currentTeamId: "",


### PR DESCRIPTION
## Summary

After PR 6 (#174) merged, terraworld_v1 runs all 14 of 14 v1 passes and is feature-complete. Promoting it to the canonical procgen world:

- **`src/tuning.ts`**: `defaultId: "terraworld"` -> `"terraworld_v1"`. New games boot to v1.
- **`src/maps/registry.ts`**: legacy `terraworld` renamed to "Terraworld (legacy)" and hidden via `visibleInLobby: false`. Still reachable via `?offline=1&map=terraworld` for regression testing. Description updated to note it's superseded.
- **`worker/src/room.ts`**: freshLobby `selectedMapId: "terraworld"` -> `"terraworld_v1"`. New rooms boot to v1 by default.

Result: lobby cycle is now `[canyon, terraworld_v1]`. Both procgen, no legacy clutter.

## Test plan

- [x] All tests pass (441/441)
- [x] tsc clean
- [x] biome clean
- [x] No em dashes
- [ ] Manual review

Tracks worms#150 (will close after deploy + smoke test).