### PR TITLE
feat(sim): off-map margin scaling + wind opt-in (#189 A+B)

### DIFF
--- a/src/weapons/drill.ts
+++ b/src/weapons/drill.ts
@@ -14,6 +14,7 @@ export const drill: WeaponConfig = {
   restitution: 0, // no bounce - tunnels into terrain on first contact
   fuseMs: 3500, // after 3.5s, detonate
   tunnel: { cutRadiusPx: 14, cutIntervalMs: 40 }, // carves a tunnel every 40ms
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 40,
     damageRadiusPx: 55,

--- a/src/weapons/dynamite.ts
+++ b/src/weapons/dynamite.ts
@@ -13,6 +13,7 @@ export const dynamite: WeaponConfig = {
   fuseMs: 5000,
   restitution: 0.2,
   powerCapMps: 2, // tiny - dynamite drops at feet, barely any arc
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 70,
     damageRadiusPx: 85,

--- a/src/weapons/holygrenade.ts
+++ b/src/weapons/holygrenade.ts
@@ -13,6 +13,7 @@ export const holyGrenade: WeaponConfig = {
   fuseMs: 4000,
   restitution: 0.6,
   powerCapMps: 14,
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 80,
     damageRadiusPx: 100,

--- a/src/weapons/minigun.ts
+++ b/src/weapons/minigun.ts
@@ -10,6 +10,7 @@ export const minigun: WeaponConfig = {
   iconLabel: "M",
   shotsPerActivation: 12,
   hitscanSpreadRad: 0.08, // ~4.6 degrees of spread per shot
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 12,
     damageRadiusPx: 20,

--- a/src/weapons/shotgun.ts
+++ b/src/weapons/shotgun.ts
@@ -9,6 +9,7 @@ export const shotgun: WeaponConfig = {
   iconColor: 0x444444,
   iconLabel: "S",
   shotsPerActivation: 2,
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 20,
     damageRadiusPx: 30,

--- a/src/weapons/types.ts
+++ b/src/weapons/types.ts
@@ -1,3 +1,4 @@
+// MUST mirror worker/src/weapons/types.ts - kept in sync manually.
 export type WeaponArchetype = "hitscan" | "projectile" | "throwable";
 
 export interface ExplosionConfig {
@@ -31,6 +32,13 @@ export interface WeaponConfig {
    * (uniformly sampled in [-spread, +spread]). Used by Minigun.
    */
   hitscanSpreadRad?: number;
+  /**
+   * If false, wind force is not applied to this weapon's projectiles. Default true.
+   * Hitscan weapons set this explicitly to false for self-documentation; they
+   * never go through the wind-apply loop today, but the explicit flag prevents
+   * a future regression if they ever do.
+   */
+  affectedByWind?: boolean;
   explosion: ExplosionConfig;
 }
 

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -236,7 +236,7 @@ export class Simulation {
     const marginXPx = Math.max(200, this.widthPx * 0.1);
     this.killMinXMeters = -marginXPx / 30;
     this.killMaxXMeters = (this.widthPx + marginXPx) / 30;
-    this.killMaxYMeters = (this.heightPx + 200) / 30; // Y stays fixed at 200
+    this.killMaxYMeters = (this.heightPx + 200) / 30; // Y margin stays fixed at 200px (bottom kill is fall-out-of-pit, not visual)
     this.world = createPhysicsWorld(init.gravity ?? { x: 0, y: 10 });
     this.terrain = new Terrain({
       world: this.world,

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -45,7 +45,6 @@ import { fire } from "../weapons/fire.js";
 import type { FireResult as WeaponFireResult } from "../weapons/fire.js";
 import { defaultAmmoForMatch, getById } from "../weapons/registry.js";
 
-const OFF_MAP_MARGIN_PX = 200;
 const MAX_PROJECTILES = 8;
 
 export interface SimEventTerrainCut {
@@ -202,6 +201,9 @@ export class Simulation {
   readonly widthPx: number;
   readonly heightPx: number;
   readonly seed: number;
+  private readonly killMinXMeters: number;
+  private readonly killMaxXMeters: number;
+  private readonly killMaxYMeters: number;
   private readonly worms: Map<string, Worm> = new Map();
   private readonly projectiles: Projectile[] = [];
   private readonly pendingDetonate: Projectile[] = [];
@@ -231,6 +233,10 @@ export class Simulation {
     this.heightPx = init.heightPx;
     this.seed = init.seed;
     this.getLogCtx = init.logCtx ?? (() => ({}));
+    const marginXPx = Math.max(200, this.widthPx * 0.1);
+    this.killMinXMeters = -marginXPx / 30;
+    this.killMaxXMeters = (this.widthPx + marginXPx) / 30;
+    this.killMaxYMeters = (this.heightPx + 200) / 30; // Y stays fixed at 200
     this.world = createPhysicsWorld(init.gravity ?? { x: 0, y: 10 });
     this.terrain = new Terrain({
       world: this.world,
@@ -503,7 +509,7 @@ export class Simulation {
       proj.tickTunnel(dtMs, this.terrain);
       // Wind: apply horizontal force per tick to in-flight projectiles.
       // WIND_FORCE is Newtons per unit wind; tunable in src/tuning.ts.
-      if (this.wind !== 0) {
+      if (this.wind !== 0 && (proj.config.affectedByWind ?? true)) {
         // Mirror of src/tuning.ts wind.forceNewtonsPerUnit - keep in sync.
         // 0.8 N/unit gives ~9 m/s^2 lateral accel at wind=0.8 on a 0.07kg projectile,
         // approximately gravity strength - meaningful but not trajectory-breaking.
@@ -545,13 +551,14 @@ export class Simulation {
     //    plus a margin) is marked dead. Absorbs issue #53.
     //    Top boundary intentionally excluded: gravity returns airborne worms;
     //    turn timer caps duration. Fix for issue #141.
-    const killMinX = -OFF_MAP_MARGIN_PX / 30; // meters
-    const killMaxX = (this.widthPx + OFF_MAP_MARGIN_PX) / 30;
-    const killMaxY = (this.heightPx + OFF_MAP_MARGIN_PX) / 30;
     for (const worm of this.worms.values()) {
       if (!worm.alive) continue;
       const pos = worm.body.getPosition();
-      if (pos.x < killMinX || pos.x > killMaxX || pos.y > killMaxY) {
+      if (
+        pos.x < this.killMinXMeters ||
+        pos.x > this.killMaxXMeters ||
+        pos.y > this.killMaxYMeters
+      ) {
         worm.kill();
         if (!this.diedThisTick.has(worm.id)) {
           this.diedThisTick.add(worm.id);

--- a/worker/src/weapons/drill.ts
+++ b/worker/src/weapons/drill.ts
@@ -14,6 +14,7 @@ export const drill: WeaponConfig = {
   restitution: 0, // no bounce - tunnels into terrain on first contact
   fuseMs: 3500, // after 3.5s, detonate
   tunnel: { cutRadiusPx: 14, cutIntervalMs: 40 }, // carves a tunnel every 40ms
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 40,
     damageRadiusPx: 55,

--- a/worker/src/weapons/dynamite.ts
+++ b/worker/src/weapons/dynamite.ts
@@ -13,6 +13,7 @@ export const dynamite: WeaponConfig = {
   fuseMs: 5000,
   restitution: 0.2,
   powerCapMps: 2, // tiny - dynamite drops at feet, barely any arc
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 70,
     damageRadiusPx: 85,

--- a/worker/src/weapons/holygrenade.ts
+++ b/worker/src/weapons/holygrenade.ts
@@ -13,6 +13,7 @@ export const holyGrenade: WeaponConfig = {
   fuseMs: 4000,
   restitution: 0.6,
   powerCapMps: 14,
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 80,
     damageRadiusPx: 100,

--- a/worker/src/weapons/minigun.ts
+++ b/worker/src/weapons/minigun.ts
@@ -10,6 +10,7 @@ export const minigun: WeaponConfig = {
   iconLabel: "M",
   shotsPerActivation: 12,
   hitscanSpreadRad: 0.08, // ~4.6 degrees of spread per shot
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 12,
     damageRadiusPx: 20,

--- a/worker/src/weapons/shotgun.ts
+++ b/worker/src/weapons/shotgun.ts
@@ -9,6 +9,7 @@ export const shotgun: WeaponConfig = {
   iconColor: 0x444444,
   iconLabel: "S",
   shotsPerActivation: 2,
+  affectedByWind: false,
   explosion: {
     terrainRadiusPx: 20,
     damageRadiusPx: 30,

--- a/worker/src/weapons/types.ts
+++ b/worker/src/weapons/types.ts
@@ -4,6 +4,7 @@
  * passes these configs into fire() / explode() directly - the
  * Simulation owns the world + terrain + projectiles list.
  */
+// MUST mirror src/weapons/types.ts - kept in sync manually.
 
 export type WeaponArchetype = "hitscan" | "projectile" | "throwable";
 
@@ -38,5 +39,12 @@ export interface WeaponConfig {
    * (uniformly sampled in [-spread, +spread]). Used by Minigun.
    */
   hitscanSpreadRad?: number;
+  /**
+   * If false, wind force is not applied to this weapon's projectiles. Default true.
+   * Hitscan weapons set this explicitly to false for self-documentation; they
+   * never go through the wind-apply loop today, but the explicit flag prevents
+   * a future regression if they ever do.
+   */
+  affectedByWind?: boolean;
   explosion: ExplosionConfig;
 }


### PR DESCRIPTION
## Summary
**A. Off-map margin scales with widthPx.** Replaced fixed `OFF_MAP_MARGIN_PX = 200` X bounds with `max(200, widthPx * 0.1)`. Worms survive proportionally further off-screen on wide maps (e.g. 256px on a 2560-wide map vs 200px). Y margin stays fixed at 200px (bottom kill is fall-out-of-pit, not visual). Kill bounds hoisted to constructor as private readonly fields since widthPx/heightPx are constant per simulation.

**B. Per-projectile wind opt-in.** Added `WeaponConfig.affectedByWind?: boolean` (default true). Wind apply loop now gates on `proj.config.affectedByWind ?? true`. Opted out:
- drill (low-speed tunneler, wind would interfere with intent)
- dynamite (very low power, ballistics-critical at close range)
- holygrenade (heavy payload, positioning is skill-based)
- minigun, shotgun (hitscan; explicit false for self-documentation, prevents future regression)

Bazooka and handgrenade keep default-true (wind-affected).

## Files (13)
- Worker: `worker/src/sim/simulation.ts` (kill bounds + wind gate)
- Type mirror: `worker/src/weapons/types.ts`, `src/weapons/types.ts` (`affectedByWind?` field + sync-warning comments)
- Weapon configs: drill, dynamite, holygrenade, minigun, shotgun in BOTH `worker/src/weapons/` and `src/weapons/` (10 files)

## Bug check
- 2 lenses run (edge cases, regression).
- Edge cases: 1 Medium - misleading comment on Y kill bound. Fixed in `e0d936c` ("Y margin stays fixed at 200px").
- Regression: clean. Existing `worker/test/sim.test.ts:399` "wind pushes a projectile horizontally" passes (uses bazooka, default-true). No tests hardcoded the old margin. No code consumed OFF_MAP_MARGIN_PX externally.

## Test plan
- [x] `npm test` 458 pass
- [x] `npm test --prefix worker` 113 pass (incl. wind test)
- [x] `tsc --noEmit` clean (root + worker)
- [x] `biome check` clean
- [x] `npm run build` green
- [ ] Manual: wide-map worm-survives-edge confirmed in play
- [ ] Manual: drill in wind tunnels straight; bazooka still drifts

## Sub-task C deferred
Damage ring (sub-task C of #189) split off as #197. Originally bundled in #189 with the assumption it was 1-5 lines; recon during #186 showed it requires a new buffer + wire format + canvas scorch render path with open design questions.

Refs #189