### PR TITLE
fix(ui): top-left R/J/D buttons unresponsive on mobile (scrollFactor on container child)

### DIFF
--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -73,6 +73,7 @@ export class TouchControls {
         radius,
       });
       ropeBtn.setPosition(leftX, 60);
+      ropeBtn.setScrollFactor(0);
       this.ropeBtn = ropeBtn;
       this.container.add(ropeBtn);
 
@@ -100,6 +101,7 @@ export class TouchControls {
       // Offset by rope's footprint (+10px gap) even if rope is disabled, so
       // the jet button sits at the same absolute position in both modes.
       jetBtn.setPosition(leftX + radius * 2 + 10, 60);
+      jetBtn.setScrollFactor(0);
       this.jetBtn = jetBtn;
       this.container.add(jetBtn);
 
@@ -134,6 +136,7 @@ export class TouchControls {
         radius,
       });
       drillBtn.setPosition(leftX + (radius * 2 + 10) * 2, 60);
+      drillBtn.setScrollFactor(0);
       this.drillBtn = drillBtn;
       this.container.add(drillBtn);
 


### PR DESCRIPTION
## Summary

Top-left utility buttons (R / J / D) don't respond to taps on mobile in offline mode. Reported by Scott while testing PR #200.

## Root cause

Phaser's input hit-test for an interactive child of a `setScrollFactor(0)` container does not propagate the parent's scroll-fixed flag. The child inherits scrollFactor 1, so Phaser camera-transforms the pointer for the hit-test while rendering the child at the parent's fixed screen position. Once the camera scrolls (which it does to follow the active worm), the button renders at viewport (107, 24) but Phaser's hit-test thinks the button is at world coords offset by camera scroll. Clicks miss.

The (now-deleted) `WeaponRadial` had a comment documenting this exact footgun on its scene-root hit zone. `TouchControls` inherited the bug for rope/jet (probably tolerable when the camera was near origin) and inherited it again for drill in #200, where it was fully exposed.

## Fix

Set `scrollFactor(0)` directly on each of `ropeBtn`, `jetBtn`, `drillBtn` so input hit-test stops applying camera scroll for those objects. Three lines added. No structural change.

## Verification

- Browser repro at `mccarrison.me/worms/?offline=1`: clicked at the exact viewport coords for the R button, no reaction.
- After the fix (verified locally + planned re-verify after deploy): buttons toggle on tap.

## Test plan
- [ ] Manual mobile smoke (Chrome DevTools, iPhone 12 viewport): R/J/D each toggle on tap; mutual exclusion still holds
- [ ] Bazooka fire path unaffected (regression check)
- [ ] Camera scroll edge: tap R after scrolling far from origin (e.g. by following a fast-moving worm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)