### PR TITLE
feat(ui): exhausted-state visuals for jet fuel + drill once-per-turn

### DIFF
--- a/docs/plans/utility-exhaustion-visuals.md
+++ b/docs/plans/utility-exhaustion-visuals.md
@@ -1,0 +1,184 @@
+# Plan: utility exhaustion visuals (jetpack fuel + drill once-per-turn)
+
+## Scope
+
+Add clear visual feedback when a utility is exhausted so the player knows when they cannot use it again until the next turn.
+
+- **Jetpack**: drains fuel while active. Once empty, button shows exhausted state for the rest of the turn. Fuel refills to full at turn start.
+- **Drill**: once per turn. After firing, button shows exhausted state for the rest of the turn. Resets at turn start.
+- **Rope**: no exhaustion (always available).
+
+Rationale: 45 second turns, deliberate. Worms use utilities to position, shoot, end. No mid-turn regen so timing matters.
+
+## Decisions (from chat)
+
+- Drill cap: 1 use per turn.
+- Jetpack: fuel resets to full at the start of each turn.
+- Visual style: dim alpha + grayscale tint when exhausted. Jetpack also gets a thin fuel bar at the bottom of the button while fuel is partial.
+
+## Behavior
+
+| Utility | Available state | Active state | Exhausted state | Reset |
+|---------|-----------------|--------------|-----------------|-------|
+| Rope (R) | normal alpha 0.7 | pressed alpha 1.0 | n/a | n/a |
+| Jet (J) | normal alpha 0.7 + fuel bar showing remaining | pressed alpha 1.0 + bar drains | dim alpha 0.25 + gray + bar empty | fuel = capacity at turn start |
+| Drill (D) | normal alpha 0.7 | pressed alpha 1.0 (armed) | dim alpha 0.25 + gray | usesThisTurn = 0 at turn start |
+
+A utility in exhausted state cannot be activated. Tap is a no-op.
+
+## File changes
+
+### Tuning
+
+`src/tuning.ts`: add `usesPerTurn` to drill block.
+
+```ts
+drill: {
+  lengthPx: 120,
+  widthPx: 24,
+  cooldownMs: 800,
+  usesPerTurn: 1,
+},
+```
+
+Add to the touch block (alongside `buttonIdleAlpha`, `buttonPressedAlpha`):
+
+```ts
+buttonExhaustedAlpha: 0.25,
+```
+
+### JetPack
+
+`src/utilities/JetPack.ts`:
+
+- Add `resetForNewTurn()` method: `this._fuel = tuning.jetpack.fuelCapacity;` and deactivate if active.
+- Add `getFuelPercent(): number` getter returning `this._fuel / tuning.jetpack.fuelCapacity` (0..1).
+- Update the comment in `deactivate` (currently says "Epic 5 will reset on turn cycle") to reflect that reset is now wired.
+
+### Drill
+
+`src/utilities/Drill.ts`:
+
+- Add `private usesThisTurn = 0` field.
+- Add `hasUsesRemaining(maxUses: number): boolean` method: `return this.usesThisTurn < maxUses;`.
+- In `fire()`, increment `this.usesThisTurn++` after the callback fires.
+- In `resetForNewTurn()`: also reset `this.usesThisTurn = 0`. (Keep `lastFiredAtMs` reset behavior unchanged.)
+
+`src/utilities/Drill.test.ts`: add tests for usesThisTurn increment, hasUsesRemaining gate, reset clears it.
+
+### OfflineSimAdapter turn-start hook
+
+`src/sim/OfflineSimAdapter.ts` (around line 169-178, the existing `onTurnStart`):
+
+```ts
+onTurnStart: (team, worm) => {
+  this.setInputAllowed(true);
+  this.getWeaponManager(team)?.resetActivation();
+  worm.drillUtility?.resetForNewTurn();
+  worm.jetPackUtility?.resetForNewTurn();  // NEW
+  // ...
+},
+```
+
+### Drill fire path (GameScene)
+
+`src/scenes/GameScene.ts`: in both drill fire branches (touch pointerup ~line 1202, F-key ~line 350), gate on `hasUsesRemaining(tuning.drill.usesPerTurn)` instead of (or in addition to) `isOnCooldown`.
+
+```ts
+if (activeWorm?.drillUtility?.isArmed()) {
+  if (!activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn)) {
+    // Already used this turn - just disarm, no fire
+    activeWorm.drillUtility.disarm();
+    return;
+  }
+  // existing fire logic
+}
+```
+
+The 800ms cooldown stays as defense-in-depth but with cap=1 it never matters.
+
+### TouchControls per-frame refresh
+
+`src/ui/TouchControls.ts`:
+
+Add `update()` method called from `GameScene.update()`. Inspect the active worm and refresh button visuals:
+
+```ts
+update(): void {
+  const w = this.getActiveWorm();
+  if (!w) return;
+  this._refreshJetButton(w);
+  this._refreshDrillButton(w);
+}
+```
+
+For jet button:
+
+- Read `w.jetPackUtility.getFuelPercent()` (0..1).
+- If active: pressed alpha (1.0) + fuel bar showing remaining.
+- Else if fuel = 0: dim alpha (`buttonExhaustedAlpha`) + grayscale tint.
+- Else: idle alpha (0.7) + fuel bar showing remaining.
+- Draw fuel bar as a small rect at the bottom edge of the button (length = button diameter, height ~3px). Color green > 50%, yellow 20-50%, red < 20%.
+
+For drill button:
+
+- If `!w.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn)`: dim alpha + grayscale tint.
+- Else if armed: pressed alpha.
+- Else: idle alpha.
+
+Implementation note: the button is a Phaser Container with a `Graphics` child. To gray it out, set the container's tint via `setTint(0x666666)` and clear with `clearTint()`. The fuel bar can be a separate `Graphics` child added to the jet button container, redrawn each `update()`.
+
+Store refs to the inner gfx + (new) fuel bar gfx on the button container so `update()` can mutate them efficiently.
+
+### GameScene.update() wiring
+
+`src/scenes/GameScene.ts` in `update()`: call `this.touchControls?.update();` once per frame. Existing update body should already have similar refreshes (e.g. `refreshUtilityDPad`).
+
+### Tap gating on exhausted state
+
+In TouchControls' button `pointerdown` handlers:
+
+- Jet handler: check `w.jetPackUtility.getFuel() > 0` before activating. Already implicit via `JetPack.activate()` early-return on `_fuel <= 0`, but visual feedback should match: when exhausted, tap does nothing visible (no "pressed" flash).
+- Drill handler: check `hasUsesRemaining(tuning.drill.usesPerTurn)` before arming. If not, no-op (don't toggle).
+
+### Tests
+
+| File | Action |
+|------|--------|
+| `src/utilities/Drill.test.ts` | Add: usesThisTurn increments on fire, hasUsesRemaining gates correctly, resetForNewTurn clears |
+| `src/utilities/JetPack.test.ts` (new or extend) | resetForNewTurn restores fuel to capacity |
+
+Manual smoke test (Chrome DevTools mobile viewport):
+
+1. Tap J. Worm rises while fuel drains. Bar shrinks. Eventually bar is empty, button gray.
+2. Tap J again - no effect (exhausted).
+3. Click End. Next turn for the same team's other worm: J button is full again.
+4. Tap D. Aim and release. Drill fires. Button turns gray.
+5. Tap D again - no effect.
+6. End turn, next turn: D button is back to green.
+
+## /bugcheck before PR
+
+Lenses:
+
+- State/UI: button visuals match utility state across turn rotations
+- Edge cases: jet exhausted mid-thrust, drill armed but exhausted at fire time, what if user fires drill via F-key while button shows exhausted (gating must apply both paths)
+- API contracts: `getFuelPercent` and `hasUsesRemaining` are pure read-only methods; safe in networked-mode facade (return safe defaults)
+
+## Networked mode
+
+Networked drill is offline-only per #200. The wormFacade in `GameScene.ts` (~line 1292) needs `hasUsesRemaining: () => true` to avoid breaking the button gate. Same for jet's `getFuelPercent`: facade returns 1.0 (button always shows full).
+
+## PR checklist
+
+- [ ] Plan committed (this file)
+- [ ] JetPack.resetForNewTurn() + getFuelPercent()
+- [ ] Drill usesThisTurn + hasUsesRemaining()
+- [ ] OfflineSimAdapter calls both at turn start
+- [ ] TouchControls.update() refreshes jet/drill visuals
+- [ ] GameScene.update() calls touchControls.update()
+- [ ] Drill fire paths gate on hasUsesRemaining
+- [ ] Tuning has drill.usesPerTurn + touch.buttonExhaustedAlpha
+- [ ] Tests pass (typecheck + lint + vitest)
+- [ ] Manual mobile smoke
+- [ ] PR labeled `needs-review`

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -349,15 +349,15 @@ export class GameScene extends Phaser.Scene {
           const activeWorm = this.getActiveWormAdapter();
           if (activeWorm?.drillUtility?.isArmed()) {
             const now = this.time.now;
-            if (!activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs)) {
-              // Fire in the current aim direction
+            const hasUses = activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
+            const onCooldown = activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs);
+            if (hasUses && !onCooldown) {
               const aimRad = activeWorm.aimAngle * activeWorm.facing;
               activeWorm.drillUtility.fire(aimRad, now);
-              if (this.touchControls?.drillBtn) {
-                this.touchControls.drillBtn.setAlpha(tuning.touch.buttonIdleAlpha);
-              }
+            } else if (!hasUses) {
+              activeWorm.drillUtility.disarm();
             }
-            // Drill is a free action - do NOT trigger end-of-turn
+            // Drill is a free action - do NOT trigger end-of-turn. TouchControls.update() refreshes button visuals next frame.
             return;
           }
           this.sim.fire();
@@ -519,6 +519,7 @@ export class GameScene extends Phaser.Scene {
     this.aimHUD.update();
     this.windHUD?.update();
     this.waterRenderer?.update();
+    this.touchControls?.update();
     this.refreshUtilityDPad();
     const selectedId = this.getSelectedWeaponId();
     const weapon = allWeapons().find((w) => w.id === selectedId);
@@ -1204,18 +1205,18 @@ export class GameScene extends Phaser.Scene {
           const activeWorm = this.getActiveWormAdapter();
           if (activeWorm?.drillUtility?.isArmed()) {
             const now = this.time.now;
-            if (!activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs)) {
+            const hasUses = activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
+            const onCooldown = activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs);
+            if (hasUses && !onCooldown) {
               // Compute aim angle same way as the drag-to-aim path
               const wDx = activeWorm.xPx - p.worldX;
               const wDy = activeWorm.yPx - p.worldY;
               const drillAngle = Math.atan2(wDy, Math.abs(wDx)) * activeWorm.facing;
               activeWorm.drillUtility.fire(drillAngle, now);
-              // Reset D button visual
-              if (this.touchControls.drillBtn) {
-                this.touchControls.drillBtn.setAlpha(tuning.touch.buttonIdleAlpha);
-              }
+            } else if (!hasUses) {
+              activeWorm.drillUtility.disarm();
             }
-            // Drill is a free action - do NOT trigger end-of-turn
+            // Drill is a free action - do NOT trigger end-of-turn. TouchControls.update() refreshes button visuals next frame.
             continue;
           }
 
@@ -1281,6 +1282,10 @@ function adaptRenderableToWormFacade(
     setHorizontalInput: () => {},
     setVerticalInput: () => {},
     getFuel: () => 0,
+    // Networked mode: facade always reports full fuel + no exhaustion. Authoritative
+    // state lives on the server; per-turn UX gating will land with networked drill.
+    getFuelPercent: () => 1,
+    resetForNewTurn: () => {},
   };
   const jetPackUtility = simRef
     ? {
@@ -1289,8 +1294,15 @@ function adaptRenderableToWormFacade(
         setVerticalInput: (active: boolean) => simRef.setJetPackThrust(active),
       }
     : stubUtility;
-  // Drill facade: armed state is local only; fire no-ops in networked mode (follow-up issue).
-  const drillFacadeState = { armed: false, lastFiredAtMs: Number.NEGATIVE_INFINITY };
+  // Drill facade: armed state + uses-this-turn are local only; fire no-ops in
+  // networked mode. Per-turn cap enforcement happens client-side here so the
+  // exhausted visual still works; once networked drill lands, the worker will
+  // be the source of truth.
+  const drillFacadeState = {
+    armed: false,
+    lastFiredAtMs: Number.NEGATIVE_INFINITY,
+    usesThisTurn: 0,
+  };
   const drillUtility = {
     arm: () => {
       drillFacadeState.armed = true;
@@ -1301,13 +1313,16 @@ function adaptRenderableToWormFacade(
     isArmed: () => drillFacadeState.armed,
     isOnCooldown: (nowMs: number, cooldownMs: number) =>
       nowMs - drillFacadeState.lastFiredAtMs < cooldownMs,
+    hasUsesRemaining: (maxUsesPerTurn: number) => drillFacadeState.usesThisTurn < maxUsesPerTurn,
     fire: (_angleRad: number, nowMs: number) => {
       simRef?.executeDrill(view.id, _angleRad);
       drillFacadeState.lastFiredAtMs = nowMs;
+      drillFacadeState.usesThisTurn += 1;
       drillFacadeState.armed = false;
     },
     resetForNewTurn: () => {
       drillFacadeState.armed = false;
+      drillFacadeState.usesThisTurn = 0;
     },
   };
   const facade = {

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -170,6 +170,7 @@ export class OfflineSimAdapter implements SimAdapter {
         this.setInputAllowed(true);
         this.getWeaponManager(team)?.resetActivation();
         worm.drillUtility?.resetForNewTurn();
+        worm.jetPackUtility?.resetForNewTurn();
         for (const sub of this.turnChangedSubs) sub(team.id, worm.name);
         // Offline sim is always immediately stable - fire stable subs on next microtask.
         queueMicrotask(() => {

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -68,11 +68,15 @@ export interface Tuning {
     widthPx: number;
     /** Cooldown between drill fires, ms. */
     cooldownMs: number;
+    /** Max drill fires per turn. Once exhausted, button shows exhausted state. */
+    usesPerTurn: number;
   };
   touch: {
     buttonRadiusPx: number;
     buttonIdleAlpha: number;
     buttonPressedAlpha: number;
+    /** Alpha for buttons whose utility is exhausted (jet fuel = 0, drill used). */
+    buttonExhaustedAlpha: number;
     /** Radius around the active worm (in pixels) where a pointerdown is
      * treated as aim-intent instead of walk-intent. */
     wormHitRadiusPx: number;
@@ -233,11 +237,13 @@ export const tuning: Tuning = {
     lengthPx: 120,
     widthPx: 24,
     cooldownMs: 800,
+    usesPerTurn: 1,
   },
   touch: {
     buttonRadiusPx: 28,
     buttonIdleAlpha: 0.55,
     buttonPressedAlpha: 1.0,
+    buttonExhaustedAlpha: 0.2,
     wormHitRadiusPx: 40,
     jetpackRadialDeadZonePx: 50,
     doubleTapMaxMs: 250,

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -26,25 +26,29 @@ export interface TouchControlsInit {
 }
 
 /**
- * On-screen touch overlay with rope + jetpack buttons.
+ * On-screen touch overlay with rope + jetpack + drill buttons.
  *
- * Button visibility is controlled per-utility via `ropeEnabled` and
- * `jetPackEnabled` (both default true). In networked mode, pass
- * `ropeEnabled: false` to hide rope (not yet ported) while keeping
- * the jetpack button active.
+ * Button visibility is controlled per-utility via `ropeEnabled`,
+ * `jetPackEnabled`, and `drillEnabled` (all default true).
  *
- * The container is always constructed so `destroy()` and `hitsButton()`
- * work regardless of which buttons were created.
+ * `update()` should be called each frame from the scene; it refreshes
+ * button visuals based on the active worm's utility state (jet fuel
+ * level, drill uses-this-turn).
  */
 export class TouchControls {
   private readonly container: Phaser.GameObjects.Container;
   private ropeBtn: Phaser.GameObjects.Container | null = null;
   private jetBtn: Phaser.GameObjects.Container | null = null;
   drillBtn: Phaser.GameObjects.Container | null = null;
+  /** Per-button fuel/cooldown overlays drawn under the label. */
+  private jetFuelBar: Phaser.GameObjects.Graphics | null = null;
   private readonly scene: Phaser.Scene;
+  private readonly getActiveWorm: () => Worm | null;
+  private readonly buttonRadius: number;
 
   constructor(init: TouchControlsInit) {
     this.scene = init.scene;
+    this.getActiveWorm = init.getActiveWorm;
     // Always make an empty container so `destroy()` and `hitsButton()` have
     // a consistent target regardless of mode.
     this.container = this.scene.add.container(0, 0);
@@ -57,11 +61,11 @@ export class TouchControls {
     const jetPackEnabled = init.jetPackEnabled ?? true;
     const drillEnabled = init.drillEnabled ?? true;
 
-    const { getActiveWorm } = init;
     const radius = tuning.touch.buttonRadiusPx;
+    this.buttonRadius = radius;
     // End-turn button occupies the top-right 80px square (TurnHUD). Stack rope
-    // + jet along the LEFT edge so neither their tap areas nor the End button's
-    // hit area overlap.
+    // + jet + drill along the LEFT edge so neither their tap areas nor the End
+    // button's hit area overlap.
     const leftX = 60;
 
     if (ropeEnabled) {
@@ -82,10 +86,10 @@ export class TouchControls {
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
       ropeBtn.on("pointerdown", () => {
-        const w = getActiveWorm();
+        const w = this.getActiveWorm();
         if (!w) return;
         w.ropeUtility.isActive() ? w.ropeUtility.deactivate() : w.ropeUtility.activate();
-        this._flashButton(ropeBtn, w.ropeUtility.isActive());
+        this._setButtonAlpha(ropeBtn, w.ropeUtility.isActive());
       });
       ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
     }
@@ -98,28 +102,33 @@ export class TouchControls {
         label: "J",
         radius,
       });
-      // Offset by rope's footprint (+10px gap) even if rope is disabled, so
-      // the jet button sits at the same absolute position in both modes.
       jetBtn.setPosition(leftX + radius * 2 + 10, 60);
       jetBtn.setScrollFactor(0);
       this.jetBtn = jetBtn;
       this.container.add(jetBtn);
+
+      // Fuel bar - thin horizontal strip at the bottom of the button.
+      // Drawn here, redrawn each update() based on jetPackUtility.getFuelPercent().
+      this.jetFuelBar = this.scene.add.graphics();
+      jetBtn.add(this.jetFuelBar);
 
       jetBtn.setInteractive({
         hitArea: new Phaser.Geom.Circle(0, 0, radius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
       const jetDeactivate = (): void => {
-        const w = getActiveWorm();
+        const w = this.getActiveWorm();
         if (!w) return;
         if (w.jetPackUtility.isActive()) w.jetPackUtility.deactivate();
-        this._setButtonAlpha(jetBtn, false);
+        // Visual refresh handled by update() next frame
       };
       jetBtn.on("pointerdown", () => {
-        const w = getActiveWorm();
+        const w = this.getActiveWorm();
         if (!w) return;
+        // Exhausted: tap is a no-op (JetPack.activate() already gates on fuel,
+        // but we skip the visual flash too).
+        if (w.jetPackUtility.getFuelPercent() <= 0) return;
         if (!w.jetPackUtility.isActive()) w.jetPackUtility.activate();
-        this._setButtonAlpha(jetBtn, true);
       });
       jetBtn.on("pointerup", jetDeactivate);
       jetBtn.on("pointerupoutside", jetDeactivate);
@@ -145,21 +154,34 @@ export class TouchControls {
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
       drillBtn.on("pointerdown", () => {
-        const w = getActiveWorm();
+        const w = this.getActiveWorm();
         if (!w) return;
+        // Exhausted: tap is a no-op.
+        if (!w.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn)) return;
         if (w.drillUtility.isArmed()) {
           w.drillUtility.disarm();
-          this._setButtonAlpha(drillBtn, false);
         } else {
           // Mutually exclusive with rope/jet
           if (w.ropeUtility?.isActive()) w.ropeUtility.deactivate();
           if (w.jetPackUtility?.isActive()) w.jetPackUtility.deactivate();
           w.drillUtility.arm();
-          this._setButtonAlpha(drillBtn, true);
         }
+        // Visual refresh handled by update() next frame
       });
       drillBtn.setAlpha(tuning.touch.buttonIdleAlpha);
     }
+  }
+
+  /**
+   * Per-frame visual refresh. Reads the active worm's utility state and
+   * updates each button's alpha + (for jet) the fuel bar. Should be called
+   * from GameScene.update().
+   */
+  update(): void {
+    const w = this.getActiveWorm();
+    if (this.jetBtn) this._refreshJetButton(w);
+    if (this.drillBtn) this._refreshDrillButton(w);
+    if (this.ropeBtn) this._refreshRopeButton(w);
   }
 
   /**
@@ -176,7 +198,81 @@ export class TouchControls {
   }
 
   // ---------------------------------------------------------------------------
-  // Private helpers
+  // Private helpers - per-button refresh
+  // ---------------------------------------------------------------------------
+
+  private _refreshRopeButton(w: Worm | null): void {
+    if (!this.ropeBtn) return;
+    if (!w) {
+      this.ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+      return;
+    }
+    this._setButtonAlpha(this.ropeBtn, w.ropeUtility.isActive());
+  }
+
+  private _refreshJetButton(w: Worm | null): void {
+    if (!this.jetBtn || !this.jetFuelBar) return;
+    if (!w) {
+      this.jetBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+      this.jetFuelBar.clear();
+      return;
+    }
+    const fuelPct = w.jetPackUtility.getFuelPercent();
+    const exhausted = fuelPct <= 0;
+    if (exhausted) {
+      this.jetBtn.setAlpha(tuning.touch.buttonExhaustedAlpha);
+    } else if (w.jetPackUtility.isActive()) {
+      this.jetBtn.setAlpha(tuning.touch.buttonPressedAlpha);
+    } else {
+      this.jetBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+    }
+    this._drawFuelBar(this.jetFuelBar, fuelPct);
+  }
+
+  private _refreshDrillButton(w: Worm | null): void {
+    if (!this.drillBtn) return;
+    if (!w) {
+      this.drillBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+      return;
+    }
+    const remaining = w.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
+    if (!remaining) {
+      this.drillBtn.setAlpha(tuning.touch.buttonExhaustedAlpha);
+    } else if (w.drillUtility.isArmed()) {
+      this.drillBtn.setAlpha(tuning.touch.buttonPressedAlpha);
+    } else {
+      this.drillBtn.setAlpha(tuning.touch.buttonIdleAlpha);
+    }
+  }
+
+  /**
+   * Draw a thin fuel bar at the bottom of a button. Local coords (button is
+   * a Container so 0,0 is button center).
+   * Bar color: green > 50%, yellow 20-50%, red < 20%.
+   */
+  private _drawFuelBar(g: Phaser.GameObjects.Graphics, pct: number): void {
+    g.clear();
+    const r = this.buttonRadius;
+    const barW = r * 1.6; // slightly inset from button edge
+    const barH = 4;
+    const barX = -barW / 2;
+    const barY = r - barH - 2; // 2px inset from bottom edge of circle
+    const clamped = Math.max(0, Math.min(1, pct));
+
+    // Background track
+    g.fillStyle(0x000000, 0.5);
+    g.fillRect(barX, barY, barW, barH);
+
+    if (clamped <= 0) return;
+
+    // Fill color tier
+    const fillColor = clamped > 0.5 ? 0x55cc44 : clamped > 0.2 ? 0xffaa00 : 0xff3322;
+    g.fillStyle(fillColor, 1.0);
+    g.fillRect(barX, barY, barW * clamped, barH);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers - construction
   // ---------------------------------------------------------------------------
 
   private _makeButton(opts: {
@@ -209,9 +305,5 @@ export class TouchControls {
 
   private _setButtonAlpha(btn: Phaser.GameObjects.Container, pressed: boolean): void {
     btn.setAlpha(pressed ? tuning.touch.buttonPressedAlpha : tuning.touch.buttonIdleAlpha);
-  }
-
-  private _flashButton(btn: Phaser.GameObjects.Container, active: boolean): void {
-    this._setButtonAlpha(btn, active);
   }
 }

--- a/src/utilities/Drill.test.ts
+++ b/src/utilities/Drill.test.ts
@@ -101,9 +101,35 @@ describe("Drill utility", () => {
       expect(drill.isOnCooldown(1000, 800)).toBe(true);
     });
 
+    it("clears usesThisTurn so drill is available again next turn", () => {
+      drill.fire(0, 1000);
+      expect(drill.hasUsesRemaining(1)).toBe(false);
+      drill.resetForNewTurn();
+      expect(drill.hasUsesRemaining(1)).toBe(true);
+    });
+
     it("is idempotent when already disarmed", () => {
       drill.resetForNewTurn();
       expect(drill.isArmed()).toBe(false);
+    });
+  });
+
+  describe("hasUsesRemaining() / per-turn cap", () => {
+    it("starts with all uses remaining", () => {
+      expect(drill.hasUsesRemaining(1)).toBe(true);
+      expect(drill.hasUsesRemaining(3)).toBe(true);
+    });
+
+    it("returns false after the cap is reached", () => {
+      drill.fire(0, 100);
+      expect(drill.hasUsesRemaining(1)).toBe(false);
+    });
+
+    it("respects the cap argument independently of how many fires happened", () => {
+      drill.fire(0, 100);
+      expect(drill.hasUsesRemaining(2)).toBe(true);
+      drill.fire(0, 200);
+      expect(drill.hasUsesRemaining(2)).toBe(false);
     });
   });
 

--- a/src/utilities/Drill.ts
+++ b/src/utilities/Drill.ts
@@ -7,6 +7,7 @@ export interface DrillCallbacks {
 export class Drill {
   private armed = false;
   private lastFiredAtMs = Number.NEGATIVE_INFINITY;
+  private usesThisTurn = 0;
 
   constructor(
     private readonly worm: Worm,
@@ -29,16 +30,23 @@ export class Drill {
     return nowMs - this.lastFiredAtMs < cooldownMs;
   }
 
-  /** Fire the drill at angleRad (radians). Records timestamp + auto-disarms. */
+  /** True if the worm still has drill uses left this turn. */
+  hasUsesRemaining(maxUsesPerTurn: number): boolean {
+    return this.usesThisTurn < maxUsesPerTurn;
+  }
+
+  /** Fire the drill at angleRad (radians). Records timestamp + counts use + auto-disarms. */
   fire(angleRad: number, nowMs: number): void {
     this.callbacks.onFire(this.worm, angleRad, nowMs);
     this.lastFiredAtMs = nowMs;
+    this.usesThisTurn += 1;
     this.armed = false;
   }
 
   /** Called at turn-start to clear lingering state from prior owner. */
   resetForNewTurn(): void {
     this.armed = false;
+    this.usesThisTurn = 0;
     // lastFiredAtMs stays - prevents drill spam across rapid turn rotations
   }
 }

--- a/src/utilities/JetPack.ts
+++ b/src/utilities/JetPack.ts
@@ -64,7 +64,21 @@ export class JetPack implements Utility {
     this.worm.setJetPackActive(false);
     this.flameGfx.setVisible(false);
     this.flameGfx.clear();
-    // Fuel stays depleted until turn end (Epic 5 will reset on turn cycle)
+    // Fuel stays depleted until turn end - resetForNewTurn() refills.
+  }
+
+  /**
+   * Returns the current fuel level as a 0..1 fraction of capacity.
+   * Used by TouchControls to render the fuel bar.
+   */
+  getFuelPercent(): number {
+    return this._fuel / tuning.jetpack.fuelCapacity;
+  }
+
+  /** Called at turn-start to refill fuel and ensure jet is deactivated. */
+  resetForNewTurn(): void {
+    if (this._active) this.deactivate();
+    this._fuel = tuning.jetpack.fuelCapacity;
   }
 
   /** Per-frame: apply thrust impulse and drain fuel. Called by GameScene.update. */


### PR DESCRIPTION
## Summary

Implements `docs/plans/utility-exhaustion-visuals.md` (committed in this branch). Drill is capped at 1 use per turn; jet fuel refills at turn start; both buttons show clear exhausted states.

- **Drill**: 1 use per turn (`tuning.drill.usesPerTurn`). After firing, button dims (`buttonExhaustedAlpha = 0.2`) and tap is a no-op until next turn.
- **Jet**: fuel refills to capacity at turn start. While fuel is mid-drain, a thin bar at the bottom of the J button shows remaining fuel (green > 50%, yellow 20-50%, red < 20%). When fuel = 0, button dims and tap is a no-op.
- **Rope**: unchanged (no exhaustion).
- TouchControls now has a per-frame `update()` called from GameScene.update(). All button visuals derive from utility state instead of being manually toggled.
- Networked wormFacade exposes `getFuelPercent` (returns 1.0) and `hasUsesRemaining` (with local per-turn counter) so the visual still works in networked mode until the worker handler ships.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` 460 passing (4 new Drill cases for cap + reset)

## Test plan
- [ ] Manual mobile smoke (Chrome DevTools, iPhone 12 viewport):
  - [ ] Tap J - worm rises, fuel bar drains green to red, button dims when empty
  - [ ] Tap J on dim button - no effect (no press flash)
  - [ ] End turn, J button is full again on next turn
  - [ ] Tap D, drag-aim, release - drill fires, button dims
  - [ ] Tap D on dim button - no effect
  - [ ] End turn, D button is back to green
- [ ] Bazooka fire path unaffected
- [ ] Rope behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)