### PR TITLE
fix(ui): J button is a tap-to-toggle (not press-and-hold)

### DIFF
--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -116,23 +116,20 @@ export class TouchControls {
         hitArea: new Phaser.Geom.Circle(0, 0, radius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
-      const jetDeactivate = (): void => {
-        const w = this.getActiveWorm();
-        if (!w) return;
-        if (w.jetPackUtility.isActive()) w.jetPackUtility.deactivate();
-        // Visual refresh handled by update() next frame
-      };
+      // Toggle pattern matching R and D: tap engages jet, tap again disengages.
+      // Directional thrust comes from the UtilityDPad (which appears while jet is
+      // active). Press-and-hold on the J button is intentionally NOT used.
       jetBtn.on("pointerdown", () => {
         const w = this.getActiveWorm();
         if (!w) return;
-        // Exhausted: tap is a no-op (JetPack.activate() already gates on fuel,
-        // but we skip the visual flash too).
+        if (w.jetPackUtility.isActive()) {
+          w.jetPackUtility.deactivate();
+          return;
+        }
+        // Exhausted: tap is a no-op. JetPack.activate() also gates internally.
         if (w.jetPackUtility.getFuelPercent() <= 0) return;
-        if (!w.jetPackUtility.isActive()) w.jetPackUtility.activate();
+        w.jetPackUtility.activate();
       });
-      jetBtn.on("pointerup", jetDeactivate);
-      jetBtn.on("pointerupoutside", jetDeactivate);
-      jetBtn.on("pointerout", jetDeactivate);
       jetBtn.setAlpha(tuning.touch.buttonIdleAlpha);
     }
 


### PR DESCRIPTION
## Summary

Touch J button was press-and-hold (pointerdown activate, pointerup deactivate). R and D are tap-to-toggle, and keyboard J is also a toggle. Inconsistent + not how the user expects mobile utilities to work: holding the J button while reaching for the directional radial is awkward.

Now: tap J once to engage jetpack, tap again to disengage. Directional thrust still comes from the UtilityDPad (tap-and-hold on the radial buttons), which appears while jet is active.

## Test plan
- [ ] Tap J on mobile - jet engages, button alpha goes pressed, UtilityDPad appears
- [ ] Tap UP on radial - worm rises while held, fuel drains, releases without dropping the jet
- [ ] Tap J again - jet disengages, DPad hides, button back to idle alpha
- [ ] Tap J when fuel is empty - no-op (exhausted state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)