### PR TITLE
fix(ui): drill aim direction + utility-dpad position and tap-through

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -352,7 +352,12 @@ export class GameScene extends Phaser.Scene {
             const hasUses = activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
             const onCooldown = activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs);
             if (hasUses && !onCooldown) {
-              const aimRad = activeWorm.aimAngle * activeWorm.facing;
+              // aimAngle is in worm-forward frame (-PI/2 = up, +PI/2 = down,
+              // 0 = forward in facing direction). cutRect needs a screen-frame
+              // angle, so combine with facing to get the screen direction.
+              const screenDx = Math.cos(activeWorm.aimAngle) * activeWorm.facing;
+              const screenDy = Math.sin(activeWorm.aimAngle);
+              const aimRad = Math.atan2(screenDy, screenDx);
               activeWorm.drillUtility.fire(aimRad, now);
             } else if (!hasUses) {
               activeWorm.drillUtility.disarm();
@@ -908,6 +913,13 @@ export class GameScene extends Phaser.Scene {
       this.utilityDPad.hide();
       this.utilityDPadVisible = false;
     }
+    if (this.utilityDPadVisible) {
+      const w = this.getActiveWormAdapter();
+      if (w) {
+        const cam = this.cameras.main;
+        this.utilityDPad.update(w.xPx, w.yPx, cam.scrollX, cam.scrollY);
+      }
+    }
   }
 
   /** Down-button: rope extend only (jetpack has no "down"). */
@@ -1208,10 +1220,10 @@ export class GameScene extends Phaser.Scene {
             const hasUses = activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
             const onCooldown = activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs);
             if (hasUses && !onCooldown) {
-              // Compute aim angle same way as the drag-to-aim path
-              const wDx = activeWorm.xPx - p.worldX;
-              const wDy = activeWorm.yPx - p.worldY;
-              const drillAngle = Math.atan2(wDy, Math.abs(wDx)) * activeWorm.facing;
+              // Drill cuts in the direction the user dragged (worm -> pointer
+              // in screen-frame y-down). cutRect uses cos/sin directly so we
+              // pass a screen-frame angle.
+              const drillAngle = Math.atan2(p.worldY - activeWorm.yPx, p.worldX - activeWorm.xPx);
               activeWorm.drillUtility.fire(drillAngle, now);
             } else if (!hasUses) {
               activeWorm.drillUtility.disarm();

--- a/src/ui/UtilityDPad.ts
+++ b/src/ui/UtilityDPad.ts
@@ -9,6 +9,11 @@ import { tuning } from "../tuning";
  * so this d-pad replaces it with persistent left / right / up (/ down)
  * buttons the player can hold.
  *
+ * Layout: 4-button cross centered on the active worm. The container is
+ * repositioned each frame via `update(worm, camera)` so the buttons follow
+ * the worm. Spacing is wide enough that the worm sprite stays visible in
+ * the empty middle. Position is clamped so no button leaves the viewport.
+ *
  * Mounted by GameScene when the active worm activates a utility;
  * destroyed when the utility deactivates. Never shown in networked mode
  * (per plan #65: utilities are offline-only).
@@ -32,6 +37,7 @@ export class UtilityDPad {
   private readonly upBtn: Phaser.GameObjects.Container;
   private readonly downBtn: Phaser.GameObjects.Container;
   private readonly scene: Phaser.Scene;
+  private readonly spacing: number;
   // Tracks which horizontal button is currently held so we can resolve
   // simultaneous left+right to a defined direction (last pressed wins).
   private leftHeld = false;
@@ -42,24 +48,25 @@ export class UtilityDPad {
     this.scene = init.scene;
     this.onLeft = init.onLeft;
     const radius = tuning.touch.buttonRadiusPx;
-    const sw = this.scene.scale.width;
-    const sh = this.scene.scale.height;
+    // Wide enough that the worm sprite (radius ~12) sits in the empty middle
+    // and the player can see + tap any direction without their finger covering
+    // the worm.
+    this.spacing = radius * 3;
 
-    // Layout: 4-button cross, bottom-center. Positions are rough; dat.gui
-    // panel doesn't expose these yet so values are hardcoded relative to
-    // screen size.
-    const cx = sw / 2;
-    const cy = sh - 80;
-    const spacing = radius * 2 + 12;
-
+    // Buttons positioned at relative offsets from the container origin.
+    // Container origin = worm screen position (set each frame via update()).
     this.leftBtn = this._makeButton({ label: "<", radius });
-    this.leftBtn.setPosition(cx - spacing, cy);
+    this.leftBtn.setPosition(-this.spacing, 0);
+    this.leftBtn.setScrollFactor(0);
     this.rightBtn = this._makeButton({ label: ">", radius });
-    this.rightBtn.setPosition(cx + spacing, cy);
+    this.rightBtn.setPosition(this.spacing, 0);
+    this.rightBtn.setScrollFactor(0);
     this.upBtn = this._makeButton({ label: "^", radius });
-    this.upBtn.setPosition(cx, cy - spacing);
+    this.upBtn.setPosition(0, -this.spacing);
+    this.upBtn.setScrollFactor(0);
     this.downBtn = this._makeButton({ label: "v", radius });
-    this.downBtn.setPosition(cx, cy + spacing);
+    this.downBtn.setPosition(0, this.spacing);
+    this.downBtn.setScrollFactor(0);
 
     this.container = this.scene.add.container(0, 0, [
       this.leftBtn,
@@ -122,6 +129,22 @@ export class UtilityDPad {
       this.rightHeld = false;
       this.onLeft(0);
     }
+  }
+
+  /**
+   * Position the d-pad centered on the active worm's current screen position.
+   * Called each frame from GameScene.update() while visible.
+   * Clamps to the viewport so all four buttons remain reachable.
+   */
+  update(wormXPx: number, wormYPx: number, cameraScrollX: number, cameraScrollY: number): void {
+    if (!this.container.visible) return;
+    const radius = tuning.touch.buttonRadiusPx;
+    const sw = this.scene.scale.width;
+    const sh = this.scene.scale.height;
+    const margin = this.spacing + radius + 8;
+    const cx = Math.max(margin, Math.min(sw - margin, wormXPx - cameraScrollX));
+    const cy = Math.max(margin, Math.min(sh - margin, wormYPx - cameraScrollY));
+    this.container.setPosition(cx, cy);
   }
 
   destroy(): void {


### PR DESCRIPTION
## Summary

Three fixes from the M6 playtest of #200 / #205 / #206:

### 1. Drill cuts the wrong direction
`cutRect` uses screen-frame angles (`cos -> right-x`, `sin -> down-y`), but both drill fire branches were passing worm-forward-frame angles. Result: drag up-right, drill cuts down-right. Fixed both paths to use screen-frame angles.

### 2. UtilityDPad buttons don't respond
Same scrollFactor child bug fixed for TouchControls in #204. The DPad buttons inherited scrollFactor 1 inside a scrollFactor(0) container, so hit-test camera-transformed the pointer while rendering stayed fixed. Add `setScrollFactor(0)` on each button.

### 3. UtilityDPad now follows the worm
Per Scott's feedback: directional buttons should be centered on the active worm so the layout maps to spatial intuition. Container is repositioned each frame to the worm's screen-projected position, clamped to viewport. Spacing widened so the worm sprite is visible in the empty middle.

## Test plan
- [ ] Tap D, drag up-right, release - drill cuts up-right (rectangular hole, not down-right)
- [ ] Tap D, drag down-left, release - drill cuts down-left
- [ ] Tap J - DPad appears centered on worm with worm in the middle
- [ ] Tap UP on DPad - worm rises, fuel drains
- [ ] Tap RIGHT on DPad - worm moves right, fuel drains
- [ ] DPad follows the worm as it moves; clamps near screen edges so all buttons stay reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)