### PR TITLE
fix: drill cuts stone + dpad reliability + rope aim-and-fire

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -365,6 +365,14 @@ export class GameScene extends Phaser.Scene {
             // Drill is a free action - do NOT trigger end-of-turn. TouchControls.update() refreshes button visuals next frame.
             return;
           }
+          if (activeWorm?.ropeUtility?.isArmed()) {
+            // Rope: aim-and-fire (no radial). Activate at current aim direction.
+            activeWorm.ropeUtility.activate();
+            // activate() auto-clears armed on success; if raycast missed, also disarm
+            // so the next tap re-arms cleanly rather than leaving the button lit.
+            activeWorm.ropeUtility.disarm();
+            return;
+          }
           this.sim.fire();
         },
         onCycleMap: () => {
@@ -903,9 +911,8 @@ export class GameScene extends Phaser.Scene {
    *  Works in both offline and networked mode. Runs every frame from `update`. */
   private refreshUtilityDPad(): void {
     if (!this.utilityDPad) return;
-    const isJetPacking = this.sim.isJetPacking();
-    const isRoped = this.offlineSim ? !!this.offlineSim.turns.getActiveWorm()?.isRoped() : false;
-    const active = isJetPacking || isRoped;
+    // Jetpack only - rope is aim-and-fire, swing is passive (no thrust controls).
+    const active = this.sim.isJetPacking();
     if (active && !this.utilityDPadVisible) {
       this.utilityDPad.show();
       this.utilityDPadVisible = true;
@@ -1231,6 +1238,13 @@ export class GameScene extends Phaser.Scene {
             // Drill is a free action - do NOT trigger end-of-turn. TouchControls.update() refreshes button visuals next frame.
             continue;
           }
+          if (activeWorm?.ropeUtility?.isArmed()) {
+            // Rope: aim-and-fire. activate() reads worm.aimAngle which the
+            // drag-aim path has been updating during the drag.
+            activeWorm.ropeUtility.activate();
+            activeWorm.ropeUtility.disarm();
+            continue;
+          }
 
           this.sim.fire();
         } else if (o.kind === "walk_release") {
@@ -1297,6 +1311,10 @@ function adaptRenderableToWormFacade(
     // Networked mode: facade always reports full fuel + no exhaustion. Authoritative
     // state lives on the server; per-turn UX gating will land with networked drill.
     getFuelPercent: () => 1,
+    // Rope armed-mode mirrors (offline only; networked rope is deferred per #82).
+    isArmed: () => false,
+    arm: () => {},
+    disarm: () => {},
     resetForNewTurn: () => {},
   };
   const jetPackUtility = simRef

--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -171,6 +171,7 @@ export class OfflineSimAdapter implements SimAdapter {
         this.getWeaponManager(team)?.resetActivation();
         worm.drillUtility?.resetForNewTurn();
         worm.jetPackUtility?.resetForNewTurn();
+        worm.ropeUtility?.resetForNewTurn();
         for (const sub of this.turnChangedSubs) sub(team.id, worm.name);
         // Offline sim is always immediately stable - fire stable subs on next microtask.
         queueMicrotask(() => {

--- a/src/terrain/Terrain.ts
+++ b/src/terrain/Terrain.ts
@@ -188,9 +188,12 @@ export class Terrain {
         if (t < 0 || t > lengthPx) continue;
         if (s < -halfW || s > halfW) continue;
         if (this.materialMap !== null) {
-          // Material hardness gate: use half-width as the "radius" analogue
+          // Material hardness gate: drill represents itself as a length-scaled
+          // tool, not a small-radius blast. Use lengthPx so drill cuts through
+          // rock (rockMinRadiusPx ~30) and stone (stoneMinRadiusPx ~60). Using
+          // halfW (typically 12) here would silently no-op on stone/rock.
           const material = this.materialMap[worldY * this.widthPx + worldX];
-          if (!gateCutByMaterial(material, halfW, this.hardness)) continue;
+          if (!gateCutByMaterial(material, lengthPx, this.hardness)) continue;
         }
         data[(row * w + col) * 4 + 3] = 0;
       }

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -85,11 +85,24 @@ export class TouchControls {
         hitArea: new Phaser.Geom.Circle(0, 0, radius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
+      // Aim-and-fire pattern (matches drill): tap R to arm, drag-aim, release
+      // fires rope.activate() at the aim direction. Tap R while attached
+      // detaches. No radial dpad for rope - swing is passive under gravity.
       ropeBtn.on("pointerdown", () => {
         const w = this.getActiveWorm();
         if (!w) return;
-        w.ropeUtility.isActive() ? w.ropeUtility.deactivate() : w.ropeUtility.activate();
-        this._setButtonAlpha(ropeBtn, w.ropeUtility.isActive());
+        if (w.ropeUtility.isActive()) {
+          w.ropeUtility.deactivate();
+          return;
+        }
+        if (w.ropeUtility.isArmed()) {
+          w.ropeUtility.disarm();
+          return;
+        }
+        // Mutually exclusive with jet/drill
+        if (w.jetPackUtility?.isActive()) w.jetPackUtility.deactivate();
+        if (w.drillUtility?.isArmed()) w.drillUtility.disarm();
+        w.ropeUtility.arm();
       });
       ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
     }
@@ -160,6 +173,7 @@ export class TouchControls {
         } else {
           // Mutually exclusive with rope/jet
           if (w.ropeUtility?.isActive()) w.ropeUtility.deactivate();
+          if (w.ropeUtility?.isArmed?.()) w.ropeUtility.disarm();
           if (w.jetPackUtility?.isActive()) w.jetPackUtility.deactivate();
           w.drillUtility.arm();
         }
@@ -204,7 +218,9 @@ export class TouchControls {
       this.ropeBtn.setAlpha(tuning.touch.buttonIdleAlpha);
       return;
     }
-    this._setButtonAlpha(this.ropeBtn, w.ropeUtility.isActive());
+    // Pressed alpha when attached OR armed (waiting for drag-fire). Idle otherwise.
+    const isLit = w.ropeUtility.isActive() || w.ropeUtility.isArmed();
+    this._setButtonAlpha(this.ropeBtn, isLit);
   }
 
   private _refreshJetButton(w: Worm | null): void {

--- a/src/ui/UtilityDPad.ts
+++ b/src/ui/UtilityDPad.ts
@@ -104,11 +104,14 @@ export class UtilityDPad {
 
   show(): void {
     this.container.setVisible(true);
-    // Re-enable hit-testing on each button; setInteractive() is a no-op
-    // if already interactive so this is safe to call repeatedly.
+    // Hit area is generously larger than the visual radius so a finger can
+    // drift slightly off the painted button without losing the hold. Combined
+    // with NOT releasing on pointerout (see _wireHoldButton), holding the
+    // up button to thrust stays reliable even if the finger wanders.
+    const hitRadius = Math.round(tuning.touch.buttonRadiusPx * 1.6);
     for (const b of [this.leftBtn, this.rightBtn, this.upBtn, this.downBtn]) {
       b.setInteractive({
-        hitArea: new Phaser.Geom.Circle(0, 0, tuning.touch.buttonRadiusPx),
+        hitArea: new Phaser.Geom.Circle(0, 0, hitRadius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
     }
@@ -184,7 +187,9 @@ export class UtilityDPad {
   }
 
   /** Wire a left / right button so holding dispatches the correct combined
-   *  horizontal direction (last-pressed wins when both held simultaneously). */
+   *  horizontal direction (last-pressed wins when both held simultaneously).
+   *  Releases on pointerup / pointerupoutside but NOT on pointerout - finger
+   *  drift off the button should not stop the thrust. */
   private _wireHorizontalButton(btn: Phaser.GameObjects.Container, dir: -1 | 1): void {
     const press = (): void => {
       if (dir === -1) this.leftHeld = true;
@@ -201,10 +206,11 @@ export class UtilityDPad {
     btn.on("pointerdown", press);
     btn.on("pointerup", release);
     btn.on("pointerupoutside", release);
-    btn.on("pointerout", release);
   }
 
-  /** Wire a simple hold-to-activate button (up / down thrust). */
+  /** Wire a simple hold-to-activate button (up / down thrust). Releases on
+   *  pointerup / pointerupoutside only - pointerout (finger drifted off the
+   *  button while still pressed) keeps the thrust active. */
   private _wireHoldButton(btn: Phaser.GameObjects.Container, cb: (active: boolean) => void): void {
     const press = (): void => {
       btn.setAlpha(tuning.touch.buttonPressedAlpha);
@@ -217,7 +223,6 @@ export class UtilityDPad {
     btn.on("pointerdown", press);
     btn.on("pointerup", release);
     btn.on("pointerupoutside", release);
-    btn.on("pointerout", release);
   }
 
   private _dispatchHorizontal(): void {

--- a/src/utilities/NinjaRope.ts
+++ b/src/utilities/NinjaRope.ts
@@ -27,6 +27,7 @@ export class NinjaRope implements Utility {
   readonly worm: Worm;
 
   private state: RopeState = "inactive";
+  private armed = false;
   private anchor: Body | null = null;
   private joint: DistanceJoint | null = null;
   private lengthM = 0;
@@ -42,6 +43,27 @@ export class NinjaRope implements Utility {
 
   isActive(): boolean {
     return this.state === "attached";
+  }
+
+  /** True when the player has tapped R but hasn't drag-fired yet. The R
+   *  button uses this to drive its visual state; GameScene's drag-release
+   *  handler reads it to decide whether to fire rope on aim_end. */
+  isArmed(): boolean {
+    return this.armed;
+  }
+
+  arm(): void {
+    if (this.state === "attached") return; // can't arm while already roped
+    this.armed = true;
+  }
+
+  disarm(): void {
+    this.armed = false;
+  }
+
+  /** Called at turn-start to clear lingering state from prior owner. */
+  resetForNewTurn(): void {
+    this.armed = false;
   }
 
   /** Fire rope in current aim direction. No-op if already active or raycast misses. */
@@ -128,6 +150,7 @@ export class NinjaRope implements Utility {
 
     this.worm.setActiveRope(this);
     this.state = "attached";
+    this.armed = false;
   }
 
   deactivate(): void {


### PR DESCRIPTION
## Summary

Three fixes from the M6 playtest:

### 1. Drill never cut terrain
`cutRect`'s material hardness gate passed `halfW` (12px) as the cut radius analogue. But `stoneMinRadiusPx = 60` and `rockMinRadiusPx = 30`, so drill silently failed on every pixel that wasn't dirt or crust. Verified live: I sampled the canvas alpha below the worm before and after a direct `cutRect(120, 24, PI/2)` call; pixels stayed at 255 because the gate rejected them. Bazooka explosions cut fine because their radius is 40 (passes rock, fails stone).

Drill is a length-scaled tool, not a small-radius blast. Pass `lengthPx` (120) to the gate; drill now cuts through dirt, rock, and stone.

### 2. DPad released on finger drift
Up/down/left/right hold buttons fired `pointerout` when the finger moved a few pixels off the button while still pressed - thrust would stop mid-burn even though the user was still holding. Two changes:
- Drop `pointerout` from the hold-button event list. `pointerup` and `pointerupoutside` still fire on real release.
- Hit area enlarged to `radius * 1.6` (visual radius unchanged) so a finger drifting up to 18px off-target still registers.

### 3. Rope is now aim-and-fire
Per Scott: "rope should not be radial. It should be aim and fire like the drill."

`NinjaRope` gains arm / disarm / isArmed methods. R button is now: tap to arm, drag from worm + release to fire `rope.activate()` at the aim direction. Tap R while attached detaches. The UtilityDPad no longer shows for rope - swing is passive under gravity.

## Test plan
- [ ] Tap D, drag down, release - drill cuts a vertical hole through dirt, stone, and rock
- [ ] Tap D, drag at angle, release - drill cuts in the dragged direction
- [ ] Tap J, hold UP on dpad - worm rises while finger holds; drift off button keeps thrust
- [ ] Tap J, hold UP, release finger off-button - thrust stops cleanly
- [ ] Tap R, drag up-right from worm, release - rope fires up-right; worm swings naturally
- [ ] Tap R while attached - rope detaches
- [ ] All three utilities reset (jet fuel full, drill use available, rope detached) on turn start

🤖 Generated with [Claude Code](https://claude.com/claude-code)