### PR TITLE
fix(input): drill/rope drag-fire bypasses worm hit-zone when armed

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1124,6 +1124,21 @@ export class GameScene extends Phaser.Scene {
       const worm = this.getActiveWormAdapter();
       const myTurn = this.isInputAllowed();
       const utilityActive = !!worm && (worm.isRoped() || worm.isJetPacking());
+
+      // Drill/rope armed: every drag is an aim gesture regardless of where it
+      // starts. The user has explicitly armed the utility via its button, so
+      // the on-worm hit-zone check would just fight thumb imprecision on
+      // mobile. The drag direction is interpreted relative to the worm at
+      // pointerup time.
+      const drillArmed = !!worm && !!worm.drillUtility?.isArmed?.();
+      const ropeArmed = !!worm && !!worm.ropeUtility?.isArmed?.();
+      if (myTurn && (drillArmed || ropeArmed)) {
+        this.activeGestureKind = "aim";
+        this.activePointerId = p.id;
+        this.aimDragStart = { x: p.worldX, y: p.worldY };
+        return;
+      }
+
       // worldX/worldY are camera-adjusted pointer coords. We use these
       // throughout the gesture path so downXPx/downYPx are in the same
       // coord system as worm.xPx/worm.yPx (world) - the on-worm hit test
@@ -1210,6 +1225,13 @@ export class GameScene extends Phaser.Scene {
       this.aimDragStart = null;
 
       const outcomes = this.gestureTracker.processUp(Date.now());
+      // If we bypassed the gestureTracker on pointerdown (armed drill/rope),
+      // the tracker is in idle mode and processUp won't emit aim_end. Synth
+      // one so the existing aim_end branch fires drill/rope.
+      const trackerEmittedAimEnd = outcomes.some((o) => o.kind === "aim_end");
+      if (gestureKind === "aim" && !trackerEmittedAimEnd && aimStart) {
+        outcomes.push({ kind: "aim_end" });
+      }
       for (const o of outcomes) {
         if (o.kind === "aim_end") {
           // Fire-on-release, gated by the dead-zone so a stray tap doesn't


### PR DESCRIPTION
## Summary

After PR #208 the drill cutRect material gate was fixed, but drill still appeared to "do nothing" when aimed. Root cause: the drag-to-fire path required the drag to **start** within 40px of the worm's screen position. Drags from elsewhere were classified as walk gestures by the gestureTracker, never reaching the drill fire branch.

For drill (and rope), the user has explicitly armed the utility. Direction comes from the drag, start position shouldn't have to be precise.

## Fix

In GameScene's pointerdown, before calling gestureTracker.processDown, check if drill or rope is armed. If so, force `activeGestureKind = "aim"` and seed `aimDragStart` with the pointer position. The existing pointermove drag-aim math runs as normal; pointerup synthesizes an `aim_end` outcome so the existing aim_end branch fires drill/rope at the release angle.

## Test plan
- [ ] Tap D, drag from anywhere on screen down, release - drill cuts in the drag direction
- [ ] Tap R, drag from anywhere up-right, release - rope fires up-right
- [ ] No drill/rope armed: drag from worm fires bazooka as before
- [ ] No drill/rope armed: drag from off-worm walks as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)