### PR TITLE
fix(input): drill drag-fire is slingshot like bazooka

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1249,10 +1249,13 @@ export class GameScene extends Phaser.Scene {
             const hasUses = activeWorm.drillUtility.hasUsesRemaining(tuning.drill.usesPerTurn);
             const onCooldown = activeWorm.drillUtility.isOnCooldown(now, tuning.drill.cooldownMs);
             if (hasUses && !onCooldown) {
-              // Drill cuts in the direction the user dragged (worm -> pointer
-              // in screen-frame y-down). cutRect uses cos/sin directly so we
-              // pass a screen-frame angle.
-              const drillAngle = Math.atan2(p.worldY - activeWorm.yPx, p.worldX - activeWorm.xPx);
+              // Slingshot: drag-aim sets aimAngle in worm-forward frame and
+              // may have flipped facing during the drag. Convert (aimAngle,
+              // facing) to a screen-frame angle for cutRect. Matches bazooka's
+              // "drag away to fire toward" convention.
+              const screenDx = Math.cos(activeWorm.aimAngle) * activeWorm.facing;
+              const screenDy = Math.sin(activeWorm.aimAngle);
+              const drillAngle = Math.atan2(screenDy, screenDx);
               activeWorm.drillUtility.fire(drillAngle, now);
             } else if (!hasUses) {
               activeWorm.drillUtility.disarm();


### PR DESCRIPTION
## Summary

Drill was firing in the **same** direction as the drag (drag left -> cut left). Bazooka's convention is slingshot: drag away to fire toward. Match it for drill so the two utilities share one mental model.

The drag-aim pointermove path already updates `worm.aimAngle` with the slingshot convention (used for bazooka). The fix: drag-release drill now derives its angle from `aimAngle + facing` instead of computing a fresh `atan2(pointer - worm)`.

The F-key drill path was already using the slingshot convention.

## Test plan
- [ ] Tap D, drag left, release - drill cuts to the right
- [ ] Tap D, drag down, release - drill cuts up
- [ ] Bazooka unaffected: same drag-aim flow
- [ ] Rope: also uses aimAngle slingshot internally (no change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)