### PR TITLE
feat(tuning): wider + longer drill tunnel (48 x 220)

### DIFF
--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -234,8 +234,8 @@ export const tuning: Tuning = {
     sideForce: 8,
   },
   drill: {
-    lengthPx: 120,
-    widthPx: 24,
+    lengthPx: 220,
+    widthPx: 48,
     cooldownMs: 800,
     usesPerTurn: 1,
   },


### PR DESCRIPTION
## Summary

Drill tunnel was 24x120 - exactly worm-width, making the hole almost impassable. Bump to 48x220:

- **Width 48** (was 24): worm radius is 12, so 12px clearance on each side. Comfortable squeeze, not a wide cavern.
- **Length 220** (was 120): roughly 2x reach so a single drill use is meaningful traversal.

Both stay in `src/tuning.ts` so we can iterate via dat.gui in dev.

## Test plan
- [ ] Tap D, drag down, release - tunnel is visibly wider; worm walks/falls through cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)