### PR TITLE
fix: continuous touch walk + jet sensitivity / fuel / button padding

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -100,6 +100,10 @@ export class GameScene extends Phaser.Scene {
   /** Origin of the active aim drag in screen px. Used by pointermove to compute
    * drag length vs dead-zone for fire-on-release. */
   private aimDragStart: { x: number; y: number } | null = null;
+  /** Touch walk direction, applied each frame in update() so a held tap
+   * keeps the worm walking. Without this, InputController.update() reads
+   * keyboard (0 when no keys held) and clobbers the velocity each frame. */
+  private touchWalkDir: -1 | 0 | 1 = 0;
 
   // ---- Init-time data ----
   private mapId: string = firstId();
@@ -508,6 +512,12 @@ export class GameScene extends Phaser.Scene {
     for (const sprite of this.objectSprites.values()) sprite.interpolate(deltaMs);
     this.renderFromAdapter();
     this.inputController.update(deltaMs);
+    // Touch walk: re-apply each frame so a held tap keeps moving the worm.
+    // Must run AFTER inputController.update() since the keyboard path
+    // unconditionally writes worm.walk(0) when no key is held.
+    if (this.touchWalkDir !== 0) {
+      this.sim.walk(this.touchWalkDir);
+    }
     this.turnHUD.update(this.sim.getTurnSecondsRemaining());
     this.aimHUD.update();
     this.windHUD?.update();
@@ -1119,6 +1129,10 @@ export class GameScene extends Phaser.Scene {
           // walk message directly.
           this.sim.setFacing(o.dir);
           this.sim.walk(o.dir);
+          // Track the held direction so update() re-applies the velocity
+          // each frame (otherwise InputController's keyboard path clobbers
+          // it with walk(0) on the next tick).
+          this.touchWalkDir = o.dir;
         }
         // "ignored": no-op. pointermove / pointerup for this pointer won't
         // match activePointerId (null), so they short-circuit.
@@ -1209,6 +1223,7 @@ export class GameScene extends Phaser.Scene {
           this.sim.fire();
         } else if (o.kind === "walk_release") {
           this.sim.walk(0);
+          this.touchWalkDir = 0;
         } else if (o.kind === "jump") {
           this.sim.jump();
         } else if (o.kind === "backflip") {

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -230,12 +230,12 @@ export const tuning: Tuning = {
     fireImpulseMag: 3,
   },
   jetpack: {
-    fuelCapacity: 100,
+    fuelCapacity: 60,
     fuelPerSecond: 30,
-    upwardForce: 35,
-    sideForce: 18,
-    joystickDeadZonePx: 12,
-    joystickMaxSlidePx: 80,
+    upwardForce: 25,
+    sideForce: 14,
+    joystickDeadZonePx: 14,
+    joystickMaxSlidePx: 120,
   },
   drill: {
     lengthPx: 220,

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -85,6 +85,8 @@ export class TouchControls {
     // + jet + drill along the LEFT edge so neither their tap areas nor the End
     // button's hit area overlap.
     const leftX = 60;
+    // Top padding so the button row doesn't crowd the very top of the canvas.
+    const topY = 90;
 
     if (ropeEnabled) {
       // --- Rope button (top-left) ---
@@ -94,7 +96,7 @@ export class TouchControls {
         label: "R",
         radius,
       });
-      ropeBtn.setPosition(leftX, 60);
+      ropeBtn.setPosition(leftX, topY);
       ropeBtn.setScrollFactor(0);
       this.ropeBtn = ropeBtn;
       this.container.add(ropeBtn);
@@ -134,7 +136,7 @@ export class TouchControls {
         radius,
       });
       const jetBtnX = leftX + radius * 2 + 10;
-      const jetBtnY = 60;
+      const jetBtnY = topY;
       jetBtn.setPosition(jetBtnX, jetBtnY);
       jetBtn.setScrollFactor(0);
       this.jetBtn = jetBtn;
@@ -264,7 +266,7 @@ export class TouchControls {
         label: "D",
         radius,
       });
-      drillBtn.setPosition(leftX + (radius * 2 + 10) * 2, 60);
+      drillBtn.setPosition(leftX + (radius * 2 + 10) * 2, topY);
       drillBtn.setScrollFactor(0);
       this.drillBtn = drillBtn;
       this.container.add(drillBtn);


### PR DESCRIPTION
## Summary

Four playtest fixes:

### 1. Touch walk barely moved
`gestureTracker` fired `walk(dir)` once on press, but `InputController.update()` runs every frame and writes `worm.walk(0)` from the keyboard's empty horizontal axis - clobbering the touch velocity within one frame. Track touch walk in `GameScene.touchWalkDir`, re-apply each frame in `update()` after `InputController`. Held tap now keeps moving.

### 2. Jet too sensitive
Tiny slide launches were sending the worm off-screen. `joystickMaxSlidePx` 80 -> 120 (slide further for full thrust), `upwardForce` 35 -> 25, `sideForce` 18 -> 14.

### 3. Jet fuel too plentiful
3.3s burn was longer than most maps need. `fuelCapacity` 100 -> 60 (~2s burn). Jet feels like a positioning tool.

### 4. Top-edge crowding
R/J/D buttons moved from `y=60` to `topY=90`. Single constant so all three stay aligned.

## Test plan
- [ ] Tap-and-hold left/right side - worm walks at the new speed continuously
- [ ] Tap J + slide - thrust feels gentler, takes more slide for full power
- [ ] Burn through fuel - depletes around 2s
- [ ] Visual: R/J/D have breathing room above

🤖 Generated with [Claude Code](https://claude.com/claude-code)