### PR TITLE
fix(tuning): revert walkSpeedMps to 2.5

### DIFF
--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -211,7 +211,7 @@ export const tuning: Tuning = {
   worm: {
     radiusPx: 12,
     density: 1.0,
-    walkSpeedMps: 5.5,
+    walkSpeedMps: 2.5,
     aimSpeedRadPerSec: 2.0,
     maxHealth: 100,
     linearDamping: 0.1,


### PR DESCRIPTION
## Summary

Walk feels too fast after #213's continuous-walk fix. Revert `walkSpeedMps` 5.5 -> 2.5. The earlier bump was compensating for the bug where touch walk only applied velocity for one frame; now that it applies every frame, 2.5 is enough.

## Test plan
- [ ] Tap-and-hold left/right - worm walks at a comfortable pace