### PR TITLE
fix(worm): disable walk-control while airborne

### DIFF
--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -87,6 +87,11 @@ export class TouchControls {
     const leftX = 60;
     // Top padding so the button row doesn't crowd the very top of the canvas.
     const topY = 90;
+    // Pixel gap between button visuals. Button centers are radius * 2 + gap apart.
+    const gap = 22;
+    // Hit-test radius is generously larger than the visual radius so a finger
+    // tap doesn't have to land dead-center to register.
+    const hitRadius = Math.round(radius * 1.5);
 
     if (ropeEnabled) {
       // --- Rope button (top-left) ---
@@ -102,7 +107,7 @@ export class TouchControls {
       this.container.add(ropeBtn);
 
       ropeBtn.setInteractive({
-        hitArea: new Phaser.Geom.Circle(0, 0, radius),
+        hitArea: new Phaser.Geom.Circle(0, 0, hitRadius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
       // Aim-and-fire pattern (matches drill): tap R to arm, drag-aim, release
@@ -135,7 +140,7 @@ export class TouchControls {
         label: "J",
         radius,
       });
-      const jetBtnX = leftX + radius * 2 + 10;
+      const jetBtnX = leftX + radius * 2 + gap;
       const jetBtnY = topY;
       jetBtn.setPosition(jetBtnX, jetBtnY);
       jetBtn.setScrollFactor(0);
@@ -165,7 +170,7 @@ export class TouchControls {
       this.jetIndicatorDot.setVisible(false);
 
       jetBtn.setInteractive({
-        hitArea: new Phaser.Geom.Circle(0, 0, radius),
+        hitArea: new Phaser.Geom.Circle(0, 0, hitRadius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
 
@@ -266,13 +271,13 @@ export class TouchControls {
         label: "D",
         radius,
       });
-      drillBtn.setPosition(leftX + (radius * 2 + 10) * 2, topY);
+      drillBtn.setPosition(leftX + (radius * 2 + gap) * 2, topY);
       drillBtn.setScrollFactor(0);
       this.drillBtn = drillBtn;
       this.container.add(drillBtn);
 
       drillBtn.setInteractive({
-        hitArea: new Phaser.Geom.Circle(0, 0, radius),
+        hitArea: new Phaser.Geom.Circle(0, 0, hitRadius),
         hitAreaCallback: Phaser.Geom.Circle.Contains,
       });
       drillBtn.on("pointerdown", () => {

--- a/src/worm/Worm.ts
+++ b/src/worm/Worm.ts
@@ -139,6 +139,14 @@ export class Worm {
     if (!this.isAlive) return;
     if (this.activeRope !== null) return; // rope controls own lateral physics
     if (this.jetPackActive) return; // walk keys intercepted by JetPack.setHorizontalInput
+    // Airborne: walk inputs do not override horizontal velocity. The worm
+    // keeps whatever momentum it had (from jet thrust, jump, or knockback)
+    // until it touches ground again. Facing still updates so aim direction
+    // tracks player intent.
+    if (this.footContactCount === 0) {
+      if (direction !== 0) this.setFacing(direction);
+      return;
+    }
     const vel = this.body.getLinearVelocity();
     const targetVx = direction * tuning.worm.walkSpeedMps;
     this.body.setLinearVelocity({ x: targetVx, y: vel.y });


### PR DESCRIPTION
## Summary

`Worm.walk()` now no-ops on horizontal velocity when the worm has zero foot contacts. After a jet burn or a jump, the worm keeps its momentum until it touches ground - air-strafing is gone. Facing still tracks input so aim follows the player's intent.

Matches classic Worms feel: ground movement is direct, airborne movement is committed.

## Test plan
- [ ] Tap J + slide right - worm thrusts left, releases mid-air, momentum carries left
- [ ] Hold left while airborne - worm does not slow / reverse mid-air
- [ ] Land on ground, hold left - walk works normally