### PR TITLE
fix(bazooka): reduce knockback impulseMag 60 -> 25

### DIFF
--- a/src/weapons/bazooka.ts
+++ b/src/weapons/bazooka.ts
@@ -15,6 +15,6 @@ export const bazooka: WeaponConfig = {
     terrainRadiusPx: 45,
     damageRadiusPx: 60,
     maxDamage: 50,
-    impulseMag: 60,
+    impulseMag: 25,
   },
 };


### PR DESCRIPTION
## Summary

Direct bazooka hits sent worms flying at unrealistic speed. The knob is `bazooka.explosion.impulseMag` (the linear impulse applied to nearby bodies, NOT the blast radius). Cut from 60 to 25.

Damage (`maxDamage: 50`), terrain crater (`terrainRadiusPx: 45`), and damage radius (`damageRadiusPx: 60`) unchanged - same lethality, just less yeet.

## Test plan
- [ ] Direct hit on a worm - knockback feels physical, not catapult-like
- [ ] Glancing hit - smaller knockback as before (scales with distance)