### PR TITLE
feat(world): 2x area + higher mountains + bigger caverns

### DIFF
--- a/shared/worldConfig.ts
+++ b/shared/worldConfig.ts
@@ -3,5 +3,5 @@
  * Changing these requires a deploy; the wire mask length validation
  * derives from these via packedMaskByteLength().
  */
-export const WORLD_WIDTH_PX = 2560;
-export const WORLD_HEIGHT_PX = 1024;
+export const WORLD_WIDTH_PX = 4096;
+export const WORLD_HEIGHT_PX = 1280;

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -260,7 +260,7 @@ export const tuning: Tuning = {
     // 24 gives 2560x1024 a ~107x43 grid. Each cell is ~1 worm tall, so
     // a single void cell is a small pocket; groups of adjacent cells
     // form real chambers. Smaller values (8-16) read as pixel-dust.
-    cellSizePx: 24,
+    cellSizePx: 36,
     // 0.50 is the edge between "stable mostly-solid" and "collapse
     // toward void" under B5/S4. Biasing very slightly toward void
     // lets chambers coalesce while keeping the subsurface mostly
@@ -279,7 +279,7 @@ export const tuning: Tuning = {
       detailStride: 96,
       detailAmpFrac: 0.02,
       mountainStride: 512,
-      mountainAmpFrac: 0.18,
+      mountainAmpFrac: 0.3,
       mountainSmoothstepLo: 0.3,
       mountainSmoothstepHi: 0.7,
     },


### PR DESCRIPTION
## Summary

First pass on world-feel bump per playtest feedback:

- **Size:** 2560x1024 -> 4096x1280 (~2x total area, aspect 3.2:1 stays Terraria-wide)
- **Mountains:** `mountainAmpFrac` 0.18 -> 0.30 (peaks ~3x taller at the new height)
- **Caverns:** `caves.cellSizePx` 24 -> 36 (chambers ~2.25x in area, fewer-but-bigger rooms)

`shared/worldConfig.ts` is read by client + worker, so the deploy propagates to both. Wire mask payload grows from ~327KB packed to ~655KB - noticeable on first-join sync but fine over wifi/4G. Body count roughly doubles; mobile smoke will validate.

## Test plan
- [ ] Cold-load `?offline=1` - world looks bigger, mountains are visibly tall
- [ ] Caverns feel like rooms you can fight in, not slits
- [ ] Mobile fps holds at 60
- [ ] Networked join still works (mask sync larger but valid)