### PR TITLE
fix(camera): play turn-start cinematic on game open

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -470,6 +470,15 @@ export class GameScene extends Phaser.Scene {
         simAdapter: this.networkedSim ?? undefined,
       });
 
+      // Initial turn cinematic: handleTurnChanged fired earlier (before
+      // TurnTransition existed) primed HUD/InputController state, but the
+      // camera zoom-out -> hold -> zoom-in animation needs TurnTransition
+      // wired up first. Replay it now so the game opens with the standard
+      // turn-start cinematic on the first worm.
+      if (initialTeamId) {
+        this.turnTransition.begin(initialTeamId, initialWormId);
+      }
+
       this.debugGfx = this.add.graphics();
       this.debugGfx.setDepth(10);
       this.hud = this.add


### PR DESCRIPTION
## Summary

The first turn was missing the zoom-out / hold / zoom-in transition because `handleTurnChanged` fires before `TurnTransition` is constructed in `create()`. The cinematic only kicked in starting with the *second* turn.

Fix: after constructing TurnTransition, explicitly call `begin(initialTeamId, initialWormId)` so the cinematic plays on game open.

## Test plan
- [ ] Cold-load `?offline=1` - camera zooms out, holds, zooms in on the first worm
- [ ] End turn - second turn cinematic still plays as before (regression check)