### PR TITLE
fix(ui): SNES-style triangle layout + less-sensitive jet

### DIFF
--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -232,10 +232,10 @@ export const tuning: Tuning = {
   jetpack: {
     fuelCapacity: 60,
     fuelPerSecond: 30,
-    upwardForce: 25,
-    sideForce: 14,
+    upwardForce: 12,
+    sideForce: 7,
     joystickDeadZonePx: 14,
-    joystickMaxSlidePx: 120,
+    joystickMaxSlidePx: 160,
   },
   drill: {
     lengthPx: 220,

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -81,14 +81,22 @@ export class TouchControls {
 
     const radius = tuning.touch.buttonRadiusPx;
     this.buttonRadius = radius;
-    // End-turn button occupies the top-right 80px square (TurnHUD). Stack rope
-    // + jet + drill along the LEFT edge so neither their tap areas nor the End
-    // button's hit area overlap.
-    const leftX = 60;
-    // Top padding so the button row doesn't crowd the very top of the canvas.
-    const topY = 90;
-    // Pixel gap between button visuals. Button centers are radius * 2 + gap apart.
-    const gap = 22;
+    // SNES-style face-button cluster, anchored bottom-left for thumb reach.
+    // Triangle: J at the top (anchor for the joystick slide); R + D form the
+    // base. J is set 220px above the bottom edge so a downward slide (which
+    // thrusts the worm UP via slingshot) has the full joystickMaxSlidePx
+    // budget before the finger leaves the canvas.
+    const sceneH = this.scene.scale.height;
+    const triangleCenterX = 130;
+    const triangleTopY = sceneH - 220;
+    const triangleBaseY = sceneH - 110;
+    const triangleHorizSpread = 60; // half-width: R is -spread, D is +spread from center
+    const rPosX = triangleCenterX - triangleHorizSpread;
+    const rPosY = triangleBaseY;
+    const jPosX = triangleCenterX;
+    const jPosY = triangleTopY;
+    const dPosX = triangleCenterX + triangleHorizSpread;
+    const dPosY = triangleBaseY;
     // Hit-test radius is generously larger than the visual radius so a finger
     // tap doesn't have to land dead-center to register.
     const hitRadius = Math.round(radius * 1.5);
@@ -101,7 +109,7 @@ export class TouchControls {
         label: "R",
         radius,
       });
-      ropeBtn.setPosition(leftX, topY);
+      ropeBtn.setPosition(rPosX, rPosY);
       ropeBtn.setScrollFactor(0);
       this.ropeBtn = ropeBtn;
       this.container.add(ropeBtn);
@@ -140,8 +148,8 @@ export class TouchControls {
         label: "J",
         radius,
       });
-      const jetBtnX = leftX + radius * 2 + gap;
-      const jetBtnY = topY;
+      const jetBtnX = jPosX;
+      const jetBtnY = jPosY;
       jetBtn.setPosition(jetBtnX, jetBtnY);
       jetBtn.setScrollFactor(0);
       this.jetBtn = jetBtn;
@@ -271,7 +279,7 @@ export class TouchControls {
         label: "D",
         radius,
       });
-      drillBtn.setPosition(leftX + (radius * 2 + gap) * 2, topY);
+      drillBtn.setPosition(dPosX, dPosY);
       drillBtn.setScrollFactor(0);
       this.drillBtn = drillBtn;
       this.container.add(drillBtn);


### PR DESCRIPTION
## Summary

Two playtest items in one PR:

### Jet less sensitive
Cut force values in half-ish, bumped slide range. Catapult-into-fall-damage should be much rarer.
- `upwardForce` 25 -> 12
- `sideForce` 14 -> 7
- `joystickMaxSlidePx` 120 -> 160

### SNES-style triangle in bottom-left
R/J/D moved from a top-left horizontal row to a bottom-left triangle:
```
   J        <- top of triangle (joystick slide anchor)
 R   D      <- base
```
- J 220px above bottom edge so a downward slide (slingshot thrust UP) has full 160px slide budget before the finger runs off the canvas.
- 120px between R and D centers (was 78), 90px between J and the base.
- Bottom-left feels natural for left-thumb mobile play.

## Test plan
- [ ] Bottom-left triangle renders cleanly
- [ ] Tap J + slide down - worm rises gently, takes more slide for full thrust
- [ ] Tap R, drag from anywhere, release - rope still fires
- [ ] Tap D, drag, release - drill still cuts
- [ ] Bazooka drag-aim from worm still works (no overlap with new button positions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)