### PR TITLE
feat(world): wider map + significantly more mountainous

### DIFF
--- a/shared/worldConfig.ts
+++ b/shared/worldConfig.ts
@@ -3,5 +3,5 @@
  * Changing these requires a deploy; the wire mask length validation
  * derives from these via packedMaskByteLength().
  */
-export const WORLD_WIDTH_PX = 4096;
+export const WORLD_WIDTH_PX = 6144;
 export const WORLD_HEIGHT_PX = 1280;

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -275,13 +275,13 @@ export const tuning: Tuning = {
     surfaceBaselineFrac: 0.55,
     heightmap: {
       baseStride: 256,
-      baseAmpFrac: 0.08,
+      baseAmpFrac: 0.14,
       detailStride: 96,
       detailAmpFrac: 0.02,
-      mountainStride: 512,
-      mountainAmpFrac: 0.3,
-      mountainSmoothstepLo: 0.3,
-      mountainSmoothstepHi: 0.7,
+      mountainStride: 768,
+      mountainAmpFrac: 0.55,
+      mountainSmoothstepLo: 0.25,
+      mountainSmoothstepHi: 0.55,
     },
     materialBands: {
       dirtDepthPx: 6,
@@ -298,7 +298,7 @@ export const tuning: Tuning = {
       thresholdPx: 1024,
     },
     spawn: {
-      densityPx: 200,
+      densityPx: 450,
       minPerTeam: 2,
     },
     caveAmbient: {


### PR DESCRIPTION
## Summary

Worms were spawning close enough that a single jet burn put them in a perfect firing line. Want fights to require traversal: walk, drill, rope.

- **Width** 4096 -> 6144 (1.5x wider, 7.86M area)
- **Mountains** much taller and chunkier:
  - `mountainAmpFrac` 0.30 -> 0.55 (peaks ~2x absolute height)
  - `mountainStride` 512 -> 768 (fewer/bigger peaks)
  - `mountainSmoothstepLo/Hi` 0.3/0.7 -> 0.25/0.55 (sharper peaks vs flat valleys)
- **Hills** bumpier: `baseAmpFrac` 0.08 -> 0.14
- **Spawn separation:** `densityPx` 200 -> 450 (worms forced apart)

## Test plan
- [ ] Cold-load - terrain looks distinctly more "alpine"
- [ ] Spawns visibly far apart
- [ ] Even with full jet burn, traversing one mountain is hard or requires drilling
- [ ] Mobile fps holds (body count rises with terrain density)

🤖 Generated with [Claude Code](https://claude.com/claude-code)