### PR TITLE
fix(jet): sustain thrust while touch joystick held still

### DIFF
--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -35,6 +35,10 @@ export class InputController {
   // Track last walk direction so we only fire onWalk on transitions
   // (matches the server contract: press -> send {dir:-1}, release -> send {dir:0}).
   private lastWalkDir: -1 | 0 | 1 = 0;
+  // Tracks whether any jet-thrust key was active last frame, so we can fire
+  // a single "release" zero-out without overwriting the touch-joystick thrust
+  // vector every frame when no keys are pressed.
+  private lastJetKeyActive = false;
 
   // Key bindings
   private readonly keyLeft: Phaser.Input.Keyboard.Key;
@@ -233,9 +237,18 @@ export class InputController {
     } else if (worm.isJetPacking()) {
       // While jetpacking: walk keys steer horizontally, up thrusts vertical.
       // Aim is LOCKED (arrow keys are consumed by thrust controls).
+      // Polling these setters every frame would clobber the touch-joystick
+      // thrust vector (which is event-driven; pointermove only fires on
+      // actual movement). Only push keyboard state when a jet key is held
+      // or was just released this frame.
+      const jetUpActive = this.keyUp.isDown || this.keyW.isDown;
       const hDir = this.readHorizontalAxis();
-      worm.jetPackUtility.setHorizontalInput(hDir);
-      worm.jetPackUtility.setVerticalInput(this.keyUp.isDown || this.keyW.isDown);
+      const anyJetKey = jetUpActive || hDir !== 0;
+      if (anyJetKey || this.lastJetKeyActive) {
+        worm.jetPackUtility.setHorizontalInput(hDir);
+        worm.jetPackUtility.setVerticalInput(jetUpActive);
+      }
+      this.lastJetKeyActive = anyJetKey;
     } else {
       // Normal movement
       const walkDir = this.readHorizontalAxis();


### PR DESCRIPTION
## Summary

- Fixes touch-joystick jetpack sputter / "looks like jumping" when pulling back on J and holding still.
- Root cause: `InputController.update()` polls `setHorizontalInput(0)` + `setVerticalInput(false)` every frame when no keyboard keys are pressed. That overwrites the touch joystick's thrust vector to (0,0). The joystick only re-writes thrust on `pointermove`, which Phaser fires only when the finger actually moves - so holding the stick still produces no force on most frames.
- Mirror what the rope branch already does: only push keyboard state when a jet key is held or was just released this frame. `lastJetKeyActive` makes the release transition still zero out the vector exactly once.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npx vitest run` - all 460 tests pass
- [ ] Manual: offline mode, drag J straight down past dead zone, hold still. Worm rises smoothly while finger is held. Fuel bar drains steadily. No sputter, no falling between bursts.
- [ ] Manual regression: keyboard W still thrusts up while held and stops on release. A/D still steers horizontally. W+D diagonal still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)