### PR TITLE
fix(walk): edge-trigger keyboard walk so jump's horizontal impulse survives

### DIFF
--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -252,7 +252,15 @@ export class InputController {
     } else {
       // Normal movement
       const walkDir = this.readHorizontalAxis();
-      worm.walk(walkDir);
+      // Edge-triggered: only call walk() while a key is held or on the
+      // frame a key was just released. Polling walk(0) every idle frame
+      // would clobber the touch-walk velocity AND wipe jump's horizontal
+      // impulse during the brief grounded-foot window post-jump (the foot
+      // sensor extends ~0.12m below the circle bottom, so contact persists
+      // for ~1 step after jump even with -6 m/s upward velocity).
+      if (walkDir !== 0 || this.lastWalkDir !== 0) {
+        worm.walk(walkDir);
+      }
       // Fire onWalk only on direction transitions so the server sees one
       // press + one release event, not a stream of per-frame samples.
       if (walkDir !== this.lastWalkDir) {


### PR DESCRIPTION
## Summary

- Same root-cause class as the jet sputter fix (#223). `InputController.update()` polled `worm.walk(0)` every frame when no keyboard key was held; on a double-tap-to-jump, that wiped the jump's horizontal impulse before the worm could leave the ground (foot sensor extends ~0.12m below the circle bottom, so `footContactCount` stays > 0 for the first ~1 physics step after a -6 m/s upward impulse).
- Edge-trigger the keyboard walk: only call `worm.walk()` when a key is held or was just released this frame.
- PR #216's airborne lockout was the user's prime suspect for the "jump goes straight up" symptom, but it isn't the cause - the clobber happens during the grounded-foot frame post-jump, which #216 doesn't touch. #216 stays in place.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npx vitest run` - all 460 tests pass
- [ ] Manual: double-tap to jump on touch (or arrow+space on keyboard). Worm should arc forward in facing direction, not go straight up.
- [ ] Regression: hold A/D - worm still walks. Release - worm stops. Touch tap-and-hold still walks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)