### PR TITLE
fix(world): clamp mountain peaks below top edge so spawns stay on-canvas

### DIFF
--- a/src/maps/passes/generateHeightmap.test.ts
+++ b/src/maps/passes/generateHeightmap.test.ts
@@ -123,6 +123,17 @@ describe("generateHeightmapPass", () => {
     expect(y).not.toBe(HEIGHTMAP_UNINIT);
   });
 
+  it("all surfaceY values are >= minSurfaceYPx - sky buffer leaves room above tallest peak", () => {
+    // Wide world + peak-bearing theme stresses the mountain octave so the
+    // clamp is exercised on multiple columns.
+    const world = makeWorld(7, 6144, 1280, "default");
+    generateHeightmapPass.run(makeCtx(world, 1));
+    const minY = tuning.worldgen.heightmap.minSurfaceYPx;
+    for (let x = 0; x < world.widthPx; x++) {
+      expect(world.heightmap[x]).toBeGreaterThanOrEqual(minY);
+    }
+  });
+
   it("throws if world.theme is null", () => {
     const world = createWorld(1, 100, 100, "default");
     // theme intentionally left null

--- a/src/maps/passes/generateHeightmap.ts
+++ b/src/maps/passes/generateHeightmap.ts
@@ -29,8 +29,12 @@ function cosInterp(a: number, b: number, t: number): number {
  *   blend            = smoothstep(mountainSmoothstepLo, mountainSmoothstepHi, t)
  *   mountainContribution = -blend * mountainAmp                    (negative => surfaceY decreases => taller peak)
  *
- * surfaceY clamped to [0, heightPx - 1] - never produces the heightPx void
- * sentinel (only ApplyThemeHeightmapMods is allowed to write that).
+ * surfaceY clamped to [minSurfaceYPx, heightPx - 1] - never produces the
+ * heightPx void sentinel (only ApplyThemeHeightmapMods is allowed to write
+ * that), and never overflows the top edge of the world. minSurfaceYPx
+ * leaves a sky buffer above the tallest peak so spawn placement near a
+ * clamped peak doesn't clip the worm body off-canvas. minSurfaceYPx is
+ * floored at maxY to stay valid on degenerate-height worlds.
  *
  * RNG call count is deterministic for given (widthPx, theme.flags.wantsPeaks):
  *   - octave 1: ceil(widthPx / baseStride) + 2
@@ -78,6 +82,11 @@ export const generateHeightmapPass: Pass = {
       : null;
 
     const maxY = heightPx - 1; // never produce the heightPx void sentinel
+    // Sky buffer above the tallest peak so spawn placement near a clamped peak
+    // doesn't put the worm's body partly off the top edge of the world. Honors
+    // the design doc's "open air above" spawn invariant via substrate shaping
+    // rather than smarter spawn logic.
+    const minY = Math.min(cfg.minSurfaceYPx, maxY);
     for (let x = 0; x < widthPx; x++) {
       const base = sampleAt(baseSamples, cfg.baseStride, x);
       const detail = sampleAt(detailSamples, cfg.detailStride, x);
@@ -88,7 +97,7 @@ export const generateHeightmapPass: Pass = {
         const blend = smoothstep(cfg.mountainSmoothstepLo, cfg.mountainSmoothstepHi, t);
         mountain = -blend * mountainAmp;
       }
-      const surfaceY = Math.max(0, Math.min(maxY, Math.floor(baseY + base + detail + mountain)));
+      const surfaceY = Math.max(minY, Math.min(maxY, Math.floor(baseY + base + detail + mountain)));
       world.heightmap[x] = surfaceY;
     }
   },

--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -130,6 +130,8 @@ export interface Tuning {
       /** Smoothstep range over which the mountain octave's contribution ramps from 0 to full. Tuple [lo, hi] in [0, 1]. */
       mountainSmoothstepLo: number;
       mountainSmoothstepHi: number;
+      /** Minimum surfaceY in pixels. Peaks below this get clamped, leaving a sky buffer above the tallest mountain. Sized to worm radius + comfort margin so spawns near the peak don't clip the top edge of the world. */
+      minSurfaceYPx: number;
     };
     materialBands: {
       /** Pixels of dirt material below the surface crust before transitioning to rock. */
@@ -282,6 +284,7 @@ export const tuning: Tuning = {
       mountainAmpFrac: 0.55,
       mountainSmoothstepLo: 0.25,
       mountainSmoothstepHi: 0.55,
+      minSurfaceYPx: 80,
     },
     materialBands: {
       dirtDepthPx: 6,


### PR DESCRIPTION
## Summary

Mountains were pinning at y=0 because \`generateHeightmapPass\` clamped surfaceY to \`[0, maxY]\` while \`mountainAmpFrac=0.55\` math can push peaks to -205 px. \`distributeSpawnPointsPass\` then accepted columns where \`surfY < radiusPx\` as valid, spawning worms with their bodies clipping above the canvas.

Adds \`tuning.worldgen.heightmap.minSurfaceYPx\` (default 80) and tightens the clamp floor. Substrate-level fix that honors \`world-gen-design.md\` Section 8's "open air above" spawn invariant via the substrate shape rather than smarter spawn logic - per Section 6's "conditionality via substrate" principle.

Determinism preserved (no RNG sequence change). Pass ordering unchanged.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`npx vitest run\` - 461 tests pass (new test confirms heightmap[x] >= minSurfaceYPx on a 6144x1280 default-theme world)
- [ ] Manual: regenerate world, press Map button, verify mountain peaks have a visible sky buffer above them and no worms spawn with their bodies clipping the top edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)