### PR TITLE
fix(world): keep surface dressing + cave ambient out of physics mask

### DIFF
--- a/src/maps/generators/paintDecorationToContext.test.ts
+++ b/src/maps/generators/paintDecorationToContext.test.ts
@@ -1,5 +1,6 @@
 import { createCanvas } from "canvas";
 import { describe, expect, it } from "vitest";
+import { ALPHA_SOLID } from "../../terrain/terrainAlgorithm";
 import { paintDecorationToContext } from "./paintDecorationToContext";
 
 function makeCtx(w: number, h: number) {
@@ -13,55 +14,79 @@ function px(ctx: CanvasRenderingContext2D, x: number, y: number): [number, numbe
   return [d[0], d[1], d[2], d[3]];
 }
 
+/**
+ * Painted decoration uses globalAlpha < 1 so it stays visually solid but is
+ * below ALPHA_SOLID for terrain body building. These helpers express that
+ * contract without locking the tests to exact canvas alpha-blend rounding,
+ * which varies subtly between node-canvas and browsers.
+ */
+function expectDecorationAt(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  expectedRgb: [number, number, number],
+): void {
+  const [r, g, b, a] = px(ctx, x, y);
+  // Color is recognizable - within 2 LSB of expected after alpha pre/un-multiply round-trip.
+  expect(Math.abs(r - expectedRgb[0])).toBeLessThanOrEqual(2);
+  expect(Math.abs(g - expectedRgb[1])).toBeLessThanOrEqual(2);
+  expect(Math.abs(b - expectedRgb[2])).toBeLessThanOrEqual(2);
+  // Crucial invariant: alpha is below ALPHA_SOLID so terrain body builder skips it.
+  expect(a).toBeGreaterThan(0);
+  expect(a).toBeLessThan(ALPHA_SOLID);
+}
+
+function expectUntouched(ctx: CanvasRenderingContext2D, x: number, y: number): void {
+  expect(px(ctx, x, y)).toEqual([0, 0, 0, 0]);
+}
+
 describe("paintDecorationToContext", () => {
-  it("single ambient frost feature paints #caf0ff over a 2x2 area", () => {
+  it("single ambient frost feature paints recognizably blue-white over a 2x2 area", () => {
     const ctx = makeCtx(32, 32);
     paintDecorationToContext(ctx, [{ xPx: 10, yPx: 20, type: "frost" }], []);
-    // #caf0ff = RGB(202, 240, 255)
-    expect(px(ctx, 10, 20)).toEqual([202, 240, 255, 255]);
-    expect(px(ctx, 11, 20)).toEqual([202, 240, 255, 255]);
-    expect(px(ctx, 10, 21)).toEqual([202, 240, 255, 255]);
-    expect(px(ctx, 11, 21)).toEqual([202, 240, 255, 255]);
+    // #caf0ff ~ RGB(202, 240, 255)
+    expectDecorationAt(ctx, 10, 20, [202, 240, 255]);
+    expectDecorationAt(ctx, 11, 20, [202, 240, 255]);
+    expectDecorationAt(ctx, 10, 21, [202, 240, 255]);
+    expectDecorationAt(ctx, 11, 21, [202, 240, 255]);
   });
 
-  it("single dressing grass_tuft feature paints #3a8a3a over fillRect(10, 18, 2, 3)", () => {
+  it("single dressing grass_tuft feature paints green over fillRect(10, 18, 2, 3)", () => {
     const ctx = makeCtx(32, 32);
     paintDecorationToContext(ctx, [], [{ xPx: 10, yPx: 20, sprite: "grass_tuft" }]);
     // fillRect(10, 20-2, 2, 3) = fillRect(10, 18, 2, 3) -> rows 18, 19, 20; cols 10, 11
-    // #3a8a3a = RGB(58, 138, 58)
-    expect(px(ctx, 10, 18)).toEqual([58, 138, 58, 255]);
-    expect(px(ctx, 11, 18)).toEqual([58, 138, 58, 255]);
-    expect(px(ctx, 10, 19)).toEqual([58, 138, 58, 255]);
-    expect(px(ctx, 11, 19)).toEqual([58, 138, 58, 255]);
-    expect(px(ctx, 10, 20)).toEqual([58, 138, 58, 255]);
-    expect(px(ctx, 11, 20)).toEqual([58, 138, 58, 255]);
+    // #3a8a3a ~ RGB(58, 138, 58)
+    expectDecorationAt(ctx, 10, 18, [58, 138, 58]);
+    expectDecorationAt(ctx, 11, 18, [58, 138, 58]);
+    expectDecorationAt(ctx, 10, 19, [58, 138, 58]);
+    expectDecorationAt(ctx, 11, 19, [58, 138, 58]);
+    expectDecorationAt(ctx, 10, 20, [58, 138, 58]);
+    expectDecorationAt(ctx, 11, 20, [58, 138, 58]);
   });
 
   it("unknown ambient type is silently skipped; canvas remains untouched", () => {
     const ctx = makeCtx(32, 32);
     paintDecorationToContext(ctx, [{ xPx: 5, yPx: 5, type: "nope" }], []);
-    // All pixels should remain at their default (transparent black)
-    expect(px(ctx, 5, 5)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 6, 5)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 5, 6)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 6, 6)).toEqual([0, 0, 0, 0]);
+    expectUntouched(ctx, 5, 5);
+    expectUntouched(ctx, 6, 5);
+    expectUntouched(ctx, 5, 6);
+    expectUntouched(ctx, 6, 6);
   });
 
   it("unknown dressing sprite is silently skipped; canvas remains untouched", () => {
     const ctx = makeCtx(32, 32);
     paintDecorationToContext(ctx, [], [{ xPx: 5, yPx: 10, sprite: "nope" }]);
-    expect(px(ctx, 5, 8)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 5, 9)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 5, 10)).toEqual([0, 0, 0, 0]);
+    expectUntouched(ctx, 5, 8);
+    expectUntouched(ctx, 5, 9);
+    expectUntouched(ctx, 5, 10);
   });
 
   it("empty arrays produce no canvas changes", () => {
     const ctx = makeCtx(16, 16);
     paintDecorationToContext(ctx, [], []);
-    // Spot-check several pixels; all should be default transparent black
-    expect(px(ctx, 0, 0)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 8, 8)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 15, 15)).toEqual([0, 0, 0, 0]);
+    expectUntouched(ctx, 0, 0);
+    expectUntouched(ctx, 8, 8);
+    expectUntouched(ctx, 15, 15);
   });
 
   it("mixed valid + invalid entries: valid ones paint, invalid are skipped", () => {
@@ -69,32 +94,35 @@ describe("paintDecorationToContext", () => {
     paintDecorationToContext(
       ctx,
       [
-        { xPx: 2, yPx: 2, type: "moss" }, // valid  -> #2a5a1a = RGB(42, 90, 26)
+        { xPx: 2, yPx: 2, type: "moss" }, // valid - moss is #2a5a1a ~ RGB(42, 90, 26)
         { xPx: 10, yPx: 2, type: "unknown" }, // invalid -> skipped
       ],
       [
-        { xPx: 2, yPx: 15, sprite: "ash_pile" }, // valid  -> #1a1a1a = RGB(26, 26, 26)
+        { xPx: 2, yPx: 15, sprite: "ash_pile" }, // valid - ash_pile is #1a1a1a ~ RGB(26, 26, 26)
         { xPx: 10, yPx: 15, sprite: "bad_sprite" }, // invalid -> skipped
       ],
     );
 
-    // Valid ambient: moss at (2,2) 2x2 -> #2a5a1a = RGB(42, 90, 26)
-    expect(px(ctx, 2, 2)).toEqual([42, 90, 26, 255]);
-    expect(px(ctx, 3, 2)).toEqual([42, 90, 26, 255]);
-    expect(px(ctx, 2, 3)).toEqual([42, 90, 26, 255]);
-    expect(px(ctx, 3, 3)).toEqual([42, 90, 26, 255]);
+    expectDecorationAt(ctx, 2, 2, [42, 90, 26]);
+    expectDecorationAt(ctx, 3, 2, [42, 90, 26]);
+    expectDecorationAt(ctx, 2, 3, [42, 90, 26]);
+    expectDecorationAt(ctx, 3, 3, [42, 90, 26]);
 
-    // Invalid ambient: location untouched
-    expect(px(ctx, 10, 2)).toEqual([0, 0, 0, 0]);
+    expectUntouched(ctx, 10, 2);
 
-    // Valid dressing: ash_pile at sprite=(2,15) -> fillRect(2, 13, 2, 3) -> rows 13,14,15
-    // #1a1a1a = RGB(26, 26, 26)
-    expect(px(ctx, 2, 13)).toEqual([26, 26, 26, 255]);
-    expect(px(ctx, 2, 14)).toEqual([26, 26, 26, 255]);
-    expect(px(ctx, 2, 15)).toEqual([26, 26, 26, 255]);
+    // ash_pile fillRect(2, 13, 2, 3) -> rows 13,14,15
+    expectDecorationAt(ctx, 2, 13, [26, 26, 26]);
+    expectDecorationAt(ctx, 2, 14, [26, 26, 26]);
+    expectDecorationAt(ctx, 2, 15, [26, 26, 26]);
 
-    // Invalid dressing: location untouched
-    expect(px(ctx, 10, 13)).toEqual([0, 0, 0, 0]);
-    expect(px(ctx, 10, 15)).toEqual([0, 0, 0, 0]);
+    expectUntouched(ctx, 10, 13);
+    expectUntouched(ctx, 10, 15);
+  });
+
+  it("restores ctx.globalAlpha after painting", () => {
+    const ctx = makeCtx(8, 8);
+    ctx.globalAlpha = 0.5;
+    paintDecorationToContext(ctx, [{ xPx: 1, yPx: 1, type: "moss" }], []);
+    expect(ctx.globalAlpha).toBe(0.5);
   });
 });

--- a/src/maps/generators/paintDecorationToContext.ts
+++ b/src/maps/generators/paintDecorationToContext.ts
@@ -26,24 +26,38 @@ const DRESSING_COLORS: Record<string, string> = {
  * row sits one pixel above the topmost substrate pixel - flush against
  * the surface. Color from DRESSING_COLORS keyed by feature.sprite.
  *
+ * Decoration is painted at alpha ~0.996 (254/255) so it stays visually
+ * solid but slips under terrainAlgorithm.ALPHA_SOLID = 255. Without this,
+ * the same canvas feeds Terrain's body builder and every grass tuft / moss
+ * dot becomes a ~3 px box body that worms catch on. Per the world-gen
+ * bible, decoration is decoration; the substrate is the physics surface.
+ *
  * Unknown type or sprite strings are silently skipped (Terraria
  * PlaceTile no-op-on-invalid convention).
  */
+const DECORATION_ALPHA = 254 / 255;
+
 export function paintDecorationToContext(
   ctx: CanvasRenderingContext2D,
   ambient: readonly AmbientFeature[],
   dressing: readonly DressingFeature[],
 ): void {
-  for (const f of ambient) {
-    const color = AMBIENT_COLORS[f.type];
-    if (!color) continue;
-    ctx.fillStyle = color;
-    ctx.fillRect(f.xPx, f.yPx, 2, 2);
-  }
-  for (const f of dressing) {
-    const color = DRESSING_COLORS[f.sprite];
-    if (!color) continue;
-    ctx.fillStyle = color;
-    ctx.fillRect(f.xPx, f.yPx - 2, 2, 3);
+  const priorAlpha = ctx.globalAlpha;
+  ctx.globalAlpha = DECORATION_ALPHA;
+  try {
+    for (const f of ambient) {
+      const color = AMBIENT_COLORS[f.type];
+      if (!color) continue;
+      ctx.fillStyle = color;
+      ctx.fillRect(f.xPx, f.yPx, 2, 2);
+    }
+    for (const f of dressing) {
+      const color = DRESSING_COLORS[f.sprite];
+      if (!color) continue;
+      ctx.fillStyle = color;
+      ctx.fillRect(f.xPx, f.yPx - 2, 2, 3);
+    }
+  } finally {
+    ctx.globalAlpha = priorAlpha;
   }
 }

--- a/src/maps/generators/terraworldV1.integration.test.ts
+++ b/src/maps/generators/terraworldV1.integration.test.ts
@@ -135,9 +135,15 @@ describe("terraworldV1 integration", () => {
     const ctx = makeCtx(W, H);
     terraworldV1Generator(ctx, W, H, { seed: 42, themeTag: "snow" });
     const data = ctx.getImageData(0, 0, W, H).data;
+    // Decoration is painted at globalAlpha < 1 so it stays visually solid but
+    // is below ALPHA_SOLID for the physics mask. The alpha pre/un-multiply
+    // round-trip shifts RGB by up to 2 LSBs, so match within tolerance.
     let frostHits = 0;
     for (let i = 0; i < data.length; i += 4) {
-      if (data[i] === 0xca && data[i + 1] === 0xf0 && data[i + 2] === 0xff) frostHits++;
+      const dr = Math.abs(data[i] - 0xca);
+      const dg = Math.abs(data[i + 1] - 0xf0);
+      const db = Math.abs(data[i + 2] - 0xff);
+      if (dr <= 2 && dg <= 2 && db <= 2) frostHits++;
     }
     expect(frostHits).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

The "single grass pixels" stopping worms while walking are surface dressing painted onto the same canvas Terrain reads to build its physics bodies. At default tuning that's ~150 stray ~3 px-tall boxes per world, each one a tiny obstacle the worm has to climb. Cave ambient (moss/frost dots) has the same problem.

Per \`world-gen-design.md\` Section 3 + 9, decoration is decoration. Substrate is the physics surface. The current architecture leaks decoration into physics because both share the canvas.

Quick architecturally-aligned fix: paint decoration with \`globalAlpha = 254/255\` so the resulting pixel alpha stays below \`terrainAlgorithm.ALPHA_SOLID = 255\`. Visually indistinguishable from before (alpha 0.996 over transparent air); \`scanMaskForBoxes\` skips it; terrain bodies trace only the substrate. Determinism preserved.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`npx vitest run\` - 462 tests pass (decoration tests updated to check the new invariant: alpha < ALPHA_SOLID + RGB within +/-2 LSB)
- [ ] Manual: walk a worm across grassy terrain; should walk smoothly with no stalls on grass tufts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)