### PR TITLE
tune(world): drop material hardness thresholds to 0 - stone cuttable

### DIFF
--- a/src/tuning.ts
+++ b/src/tuning.ts
@@ -294,8 +294,11 @@ export const tuning: Tuning = {
       depthPx: 3,
     },
     materialHardness: {
-      rockMinRadiusPx: 30,
-      stoneMinRadiusPx: 60,
+      // Both 0 = all materials cuttable by any cut radius. Bazooka is the
+      // only weapon (drill is a utility), so hardness gating was just
+      // complexity. Re-raise these if weapon variety lands and needs tiers.
+      rockMinRadiusPx: 0,
+      stoneMinRadiusPx: 0,
     },
     hygiene: {
       thresholdPx: 1024,

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -244,7 +244,7 @@ export class Simulation {
       heightPx: init.heightPx,
       mask: init.mask,
       materialMap: init.materialMap, // optional, undefined for legacy maps
-      hardness: { rockMinRadiusPx: 30, stoneMinRadiusPx: 60 }, // Mirror of src/tuning.ts worldgen.materialHardness
+      hardness: { rockMinRadiusPx: 0, stoneMinRadiusPx: 0 }, // Mirror of src/tuning.ts worldgen.materialHardness - both 0 makes all materials cuttable by any radius.
     });
 
     const ammoTemplate = defaultAmmoForMatch();


### PR DESCRIPTION
## Summary

Only the bazooka exists as a weapon (terrainRadiusPx=45) and it couldn't break stone (threshold 60). The hardness tiers were designed for weapon-variety gameplay that hasn't shipped; in the meantime they were just gating one material into being undestructible for no reason.

Set both \`rockMinRadiusPx\` and \`stoneMinRadiusPx\` to 0 so every cut clears every material. Mirror change in the worker sim. Leaves \`gateCutByMaterial\` + threading in place so it's a one-line revert if weapons #16/#17 want tiers back.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`npx vitest run\` - 462 client tests pass
- [x] worker tests - 113 pass
- [ ] Manual: fire bazooka at stone substrate (deepest layer); should now cut through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)