### PR TITLE
fix(offline): off-map kill cull mirroring worker

### DIFF
--- a/src/sim/OfflineSimAdapter.ts
+++ b/src/sim/OfflineSimAdapter.ts
@@ -33,6 +33,7 @@ import type Phaser from "phaser";
 import type { Contact, ContactImpulse } from "planck";
 import type { LoadedMap } from "../maps/types";
 import { PhysicsSystem } from "../physics/PhysicsSystem";
+import { PX_PER_M } from "../physics/scale";
 import { TurnManager } from "../state/TurnManager";
 import { Terrain } from "../terrain/Terrain";
 import { tuning } from "../tuning";
@@ -83,7 +84,22 @@ export class OfflineSimAdapter implements SimAdapter {
 
   private inputAllowed = false;
 
+  // Off-map kill bounds (meters). Top boundary intentionally excluded:
+  // gravity returns airborne worms; turn timer caps duration. Mirrors
+  // worker/src/sim/simulation.ts:236-239.
+  private readonly killMinXMeters: number;
+  private readonly killMaxXMeters: number;
+  private readonly killMaxYMeters: number;
+
   constructor(init: OfflineSimAdapterInit) {
+    // Compute kill bounds before anything that could use them. X margin
+    // scales with world width (200px min, 10% otherwise); Y bottom margin
+    // is a fixed 200px below the world floor.
+    const marginXPx = Math.max(200, init.widthPx * 0.1);
+    this.killMinXMeters = -marginXPx / PX_PER_M;
+    this.killMaxXMeters = (init.widthPx + marginXPx) / PX_PER_M;
+    this.killMaxYMeters = (init.heightPx + 200) / PX_PER_M;
+
     // --- Build physics world + terrain (with bodies) ---
     this.physicsSystem = new PhysicsSystem({ gravity: { x: 0, y: tuning.world.gravityY } });
     this.terrainInstance = new Terrain({
@@ -394,6 +410,22 @@ export class OfflineSimAdapter implements SimAdapter {
     this.terrainInstance.flushPendingCuts();
     this.projectileManager.update(dtMs);
     for (const w of this.wormList) w.applyPendingDamage();
+    // Off-map cull. Any worm past the X edges (with margin) or below the
+    // bottom (with margin) is force-killed. Top edge skipped on purpose:
+    // gravity returns airborne worms. Runs before turnManager.update so
+    // an active worm that just fell off is detected as dead this same
+    // tick and the turn rotates.
+    for (const w of this.wormList) {
+      if (!w.isAlive) continue;
+      const pos = w.body.getPosition();
+      if (
+        pos.x < this.killMinXMeters ||
+        pos.x > this.killMaxXMeters ||
+        pos.y > this.killMaxYMeters
+      ) {
+        w.kill();
+      }
+    }
     this.turnManager.update(dtMs);
     for (const w of this.wormList) {
       w.update(dtMs);

--- a/src/worm/Worm.ts
+++ b/src/worm/Worm.ts
@@ -212,6 +212,22 @@ export class Worm {
     this.pendingDamage += amount;
   }
 
+  /**
+   * Force-kill (off-map culling). Mirrors worker Worm.kill(): drops health,
+   * marks dead, dims sprite, and disarms utilities so a roped or jetting
+   * worm doesn't keep its body anchored once it has fallen off the world.
+   * Idempotent.
+   */
+  kill(): void {
+    if (!this.isAlive) return;
+    this.health = 0;
+    this.isAlive = false;
+    this.graphics.setAlpha(0.3);
+    this.ropeUtility?.deactivate();
+    this.jetPackUtility?.deactivate();
+    this.drillUtility?.disarm();
+  }
+
   applyPendingDamage(): void {
     if (!this.isAlive) return;
     if (this.pendingDamage <= 0) return;


### PR DESCRIPTION
## Summary

\`OfflineSimAdapter\` had no off-map kill. The worker has it but the offline sim doesn't, so on \`?offline=1\` play a worm pushed past the left/right edges or falling out the bottom of a cave stayed alive forever, kept its turn, and stalled the next turn rotation because the worm could never settle.

Mirror worker logic (\`worker/src/sim/simulation.ts:236-239,550-569\`):
- X margin: \`max(200px, widthPx * 0.1)\` on each side
- Y bottom margin: fixed 200 px
- Top edge intentionally excluded - gravity returns airborne worms.

Off-map check runs before \`TurnManager.update\` so an active worm that just fell off is detected dead this tick and the turn rotates. Adds \`Worm.kill()\` as a force-kill path that also disarms rope/jet/drill utilities (so a roped worm that falls off doesn't keep its body anchored).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean
- [x] \`npx vitest run\` - 462 tests pass
- [ ] Manual: walk a worm off the left/right edge - dies, turn advances.
- [ ] Manual: drop a worm down a deep cave - dies on hitting kill floor, turn advances.
- [ ] Manual: send a worm flying up high - lives, falls back down, takes fall damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)