### PR TITLE
feat(world): unify world size + go wide to 15360 + compress terrain mask (PR1 of parity sweep)

### DIFF
--- a/docs/plans/multiplayer-parity-sweep.md
+++ b/docs/plans/multiplayer-parity-sweep.md
@@ -1,0 +1,123 @@
+# Multiplayer Parity Sweep + Bigger World & Teams
+
+Brings the online (Cloudflare Durable Object) game up to parity with the
+offline client, applies a wider world (15360x1280), and grows teams from 2 to
+4 worms. Multi-PR epic.
+
+## Root cause
+
+The game has two independent simulations:
+
+- **Offline** (`src/sim/OfflineSimAdapter.ts` + client physics) - the living,
+  fully-featured codebase used via `?offline=1`.
+- **Online** (`worker/src/sim/simulation.ts`, the authoritative DO) - a
+  hand-ported copy that drifted behind.
+
+Updates landed offline and never reached the worker. Every "multiplayer is
+missing X" symptom traces to this fork.
+
+## Gap inventory
+
+| Capability | Offline | Online (worker) | Tracked |
+|---|---|---|---|
+| World size | 6144x1280 (now 15360) | stale 2560x1024 hardcode | (this epic) |
+| Ninja rope | `NinjaRope.ts` works | `toggleRope()` no-op stub | #65 / #82 |
+| Drill | `Drill.ts` utility | not wired to worker | #201 |
+| Jetpack force | up 17 / side 10 (#221) | up 15 / side 8 (drift) | (this epic) |
+| Jetpack activation | reliable | J-key/button bug online | #160 |
+| Teams | 2 (want 4) | 2 | #46 |
+| Terrain sync | stable | guest float/sink at start | #173 |
+
+## Locked decisions
+
+- World: **15360x1280** (go-wide, 2.5x width, height unchanged). Width stays
+  under the ~16384px WebGL max-texture-size ceiling (terrain is one canvas
+  texture this wide, `src/terrain/Terrain.ts`).
+- Teams: **2 -> 4** worms per team.
+- Terrain mask transport is **deflate-compressed** (see PR1). An uncompressed
+  15360 mask is ~3.2MB of base64 and overflows DO storage (`SQLITE_TOOBIG`);
+  compressed it is ~20-45KB. This was a pre-existing ceiling the online/offline
+  split hid (online never grew past 2560).
+
+---
+
+## PR1 - Unify world size + go wide + mask compression  [DONE]
+
+Branch `feat/world-unify-gowide`. Foundation; likely closes #173.
+
+- `shared/worldConfig.ts`: `WORLD_WIDTH_PX` 6144 -> 15360 (+ ceiling note).
+- Removed the stale `2560x1024` hardcodes; `worker/src/room.ts` and
+  `src/scenes/LobbyScene.ts` now import from `worldConfig`. This is the actual
+  split-brain bug (host generated 2560, worker validated 2560, offline used
+  6144) and the most likely cause of #173.
+- Placeholder barrels (`room.ts`) scaled to world width.
+- Mask + material map are deflate-compressed for the wire and DO storage:
+  - shared helpers `packedToWire` / `wireToPacked` (+ `bytesToBase64` /
+    `base64ToBytes`) in `shared/maskPack.ts` using `CompressionStream("deflate-raw")`.
+  - host (`LobbyScene.handleStart`, now async) compresses before `start_game`.
+  - worker (`room.ts` start path, flat fallback, and resume-from-storage)
+    decompresses incoming and stores/forwards the compressed form; resume is
+    legacy-tolerant (`decodeStoredPacked`) so a deploy does not break an
+    in-flight game.
+  - guest (`LobbyScene` `game_started` handler, now async) inflates back to the
+    uncompressed base64 `GameScene` already decodes - GameScene untouched.
+- Tests: `shared/maskPack.test.ts` round-trip + wide-world-under-128KB.
+- Verified: root 462 tests, worker 113 tests, lint, typecheck, vite build all
+  green. Worker game-start tests previously failed `SQLITE_TOOBIG` at 15360;
+  compression fixes them.
+
+**Post-merge gate:** deploy (`npm run deploy`) then a live multiplayer playtest
+to confirm guest worms no longer float/sink (#173) and the 15360 world renders.
+
+## PR2 - Teams 2 -> 4  [touches #46]
+
+- `src/tuning.ts`: `team.wormsPerTeam` 2->4, `worldgen.spawn.minPerTeam` 2->4.
+- `worker/src/room.ts`: `WORMS_PER_TEAM` 2->4.
+- `src/maps/registry.ts`: `maxWorms` 4->8 all entries; add 4 island spawnPoints.
+- Scale worker no-map fallback spawn grid (`room.ts` ~929).
+- Update tests asserting 4 total worms -> 8 (`worker/test/sim.test.ts`,
+  `twoTeams()` helper).
+- Accept: 4/team spawn without overlap on terraworld + geometric maps; turn
+  rotation cycles all 4; win condition count-agnostic (already is).
+
+## PR3 - Jetpack tuning sync + activation bug  [fixes #160]
+
+- `worker/src/entities/worm.ts`: `UP_FORCE` 15->17, `SIDE_FORCE` 8->10 to match
+  offline `tuning.jetpack` (commit #221). Consider a shared constant to prevent
+  re-drift.
+- Investigate + fix #160 (J-key / on-screen button does not activate jetpack
+  online).
+
+## PR4 - Networked drill  [closes #201, touches #203]
+
+- Reuse `input_fire`; worker `applyFire` branches on `weapon.id==="drill"` ->
+  new `applyDrill()` that cuts a rect + emits `terrain_cut`.
+- Port `cutRect()` into `worker/src/entities/terrain.ts`.
+- Extend `TerrainCutEvent` (`shared/protocol.ts`) with optional
+  `angleRad/lengthPx/widthPx`; guest branches rect vs circle in the
+  `terrain_cut` handler.
+- Un-stub `NetworkedSimAdapter.executeDrill`. Client-side cooldown/usesPerTurn
+  gating is sufficient (arbiter already gates turn ownership).
+
+## PR5 - Networked rope  [closes #82/#65, the big one]
+
+- Follow the jetpack netcode pattern: 5 new `input_rope_*` protocol messages,
+  server-authoritative rope (planck `DistanceJoint`) in the worker Worm +
+  step-loop joint hook, new `WormRenderState` rope fields (anchor + active +
+  length) so spectators draw the rope line.
+- Client raycasts locally and sends the anchor; un-stub
+  `NetworkedSimAdapter.toggleRope` + add fire/extend/retract/release.
+- Mutual exclusivity with jetpack; reset on turn start.
+
+---
+
+## Sequencing
+
+PR1 first (foundation, fixes #173). PR2-5 build on it and are mutually
+independent, but all touch `protocol.ts` / `room.ts` / `simulation.ts`, so
+stage those shared-file edits to avoid conflicts (sequence the protocol
+additions, or run on a shared integration branch with a final bugcheck).
+
+These are netcode / game-logic PRs -> held for review (`needs-review`), not
+auto-merged. `/bugcheck` before each PR. Deploy + smoke after PR1 and after the
+rope/drill PRs.

--- a/shared/maskPack.test.ts
+++ b/shared/maskPack.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  base64ToBytes,
+  bytesToBase64,
   packMask,
   packMaterialBytes,
   packedMaskByteLength,
+  packedToWire,
   unpackMask,
   unpackMaterialBytes,
+  wireToPacked,
 } from "./maskPack";
 
 describe("maskPack", () => {
@@ -84,4 +88,50 @@ describe("packMaterialBytes / unpackMaterialBytes", () => {
     expect(packMaterialBytes(new Uint8Array(7)).length).toBe(4);
     expect(packMaterialBytes(new Uint8Array(0)).length).toBe(0);
   });
+});
+
+describe("base64 transport", () => {
+  it("round-trips arbitrary bytes", () => {
+    const input = new Uint8Array(1024);
+    for (let i = 0; i < input.length; i++) input[i] = (i * 53) & 0xff;
+    expect(Array.from(base64ToBytes(bytesToBase64(input)))).toEqual(Array.from(input));
+  });
+});
+
+describe("packedToWire / wireToPacked (deflate transport)", () => {
+  it("round-trips packed bytes through deflate + base64", async () => {
+    const input = new Uint8Array(4096);
+    for (let i = 0; i < input.length; i++) input[i] = (i * 37) & 0xff;
+    const wire = await packedToWire(input);
+    const out = await wireToPacked(wire);
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+
+  it("compresses a wide-world terrain mask far under the DO storage limit", async () => {
+    // 15360x1280 surface-over-solid mask: the go-wide case that overflowed
+    // Durable Object storage uncompressed (~3.2MB of base64, SQLITE_TOOBIG).
+    // Deflate must bring it well under the 128KiB per-value storage limit.
+    const w = 15360;
+    const h = 1280;
+    const mask = new Uint8Array(w * h);
+    for (let x = 0; x < w; x++) {
+      const surf = Math.floor(h * 0.55 + Math.sin(x / 256) * h * 0.12);
+      for (let y = Math.max(0, surf); y < h; y++) mask[y * w + x] = 1;
+    }
+    const packed = packMask(mask);
+    const wire = await packedToWire(packed);
+    expect(wire.length).toBeLessThan(128 * 1024);
+
+    const out = await wireToPacked(wire);
+    expect(out.length).toBe(packed.length);
+    // Spot-check fidelity without a 2.4M-element deep-equal.
+    let mismatch = -1;
+    for (let i = 0; i < packed.length; i++) {
+      if (out[i] !== packed[i]) {
+        mismatch = i;
+        break;
+      }
+    }
+    expect(mismatch).toBe(-1);
+  }, 30000);
 });

--- a/shared/maskPack.ts
+++ b/shared/maskPack.ts
@@ -47,3 +47,57 @@ export function unpackMaterialBytes(packed: Uint8Array, length: number): Uint8Ar
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Wire + Durable-Object-storage transport for packed masks / material maps.
+//
+// A packed terrain mask is mostly long uniform runs (sky above, solid below),
+// so deflate shrinks it ~100-1000x. That keeps a wide world's mask under the
+// Durable Object per-value storage limit (an uncompressed 15360x1280 mask is
+// ~3.2MB of base64 and overflows it with SQLITE_TOOBIG) and tiny on the wire.
+//
+// CompressionStream("deflate-raw") exists in browsers, the Cloudflare Workers
+// runtime, and Node 18+, so the same helpers run host-side, worker-side, and
+// guest-side.
+
+/** Chunked base64 encode (avoids per-byte string concat blowing up on big inputs). */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let s = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(s);
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const raw = atob(b64);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+async function runStream(
+  stream: CompressionStream | DecompressionStream,
+  input: Uint8Array,
+): Promise<Uint8Array> {
+  const writer = stream.writable.getWriter();
+  // Start draining before writing so a single chunk can't deadlock on backpressure.
+  const drained = new Response(stream.readable).arrayBuffer();
+  // Cast: the packed arrays are ArrayBuffer-backed at runtime, but their static
+  // type widens to Uint8Array<ArrayBufferLike>, which the DOM lib's BufferSource
+  // (ArrayBuffer-backed) does not accept directly.
+  await writer.write(input as BufferSource);
+  await writer.close();
+  return new Uint8Array(await drained);
+}
+
+/** Deflate packed bytes and base64-encode them for the wire / DO storage. */
+export async function packedToWire(packed: Uint8Array): Promise<string> {
+  return bytesToBase64(await runStream(new CompressionStream("deflate-raw"), packed));
+}
+
+/** Inverse of packedToWire: base64-decode then inflate back to packed bytes. */
+export async function wireToPacked(wire: string): Promise<Uint8Array> {
+  return runStream(new DecompressionStream("deflate-raw"), base64ToBytes(wire));
+}

--- a/shared/worldConfig.ts
+++ b/shared/worldConfig.ts
@@ -2,6 +2,11 @@
  * Canonical world dimensions shared across client + server + worker.
  * Changing these requires a deploy; the wire mask length validation
  * derives from these via packedMaskByteLength().
+ *
+ * Width is the single biggest knob on "how much world to traverse". It is
+ * kept under the ~16384px WebGL max-texture-size ceiling because the terrain
+ * is one canvas-backed texture this wide (see src/terrain/Terrain.ts). Do not
+ * raise WORLD_WIDTH_PX past ~16000 without tiling the terrain texture first.
  */
-export const WORLD_WIDTH_PX = 6144;
+export const WORLD_WIDTH_PX = 15360;
 export const WORLD_HEIGHT_PX = 1280;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -204,10 +204,10 @@ export class GameScene extends Phaser.Scene {
       // Pick the adapter. Everything sim-related flows through it.
       // ------------------------------------------------------------------
       // World dimensions: networked games get them from game_started; offline
-      // and fallback paths use the canonical WORLD_*_PX constants so the
-      // scrolling world (2560x1024) still applies. Never use this.scale.width
-      // as a fallback - that's the logical viewport (1280x720 for Scale.FIT),
-      // not the world.
+      // and fallback paths use the canonical WORLD_*_PX constants (see
+      // shared/worldConfig.ts) so the scrolling world applies. Never use
+      // this.scale.width as a fallback - that's the logical viewport (1280x720
+      // for Scale.FIT), not the world.
       const worldW = this.serverWidthPx ?? WORLD_WIDTH_PX;
       const worldH = this.serverHeightPx ?? WORLD_HEIGHT_PX;
       dlogUnthrottled("scene", "create.step", {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -1,6 +1,13 @@
 import * as Phaser from "phaser";
 import { CODE_ALPHABET } from "../../shared/codeAlphabet";
-import { packMask, packMaterialBytes } from "../../shared/maskPack";
+import {
+  bytesToBase64,
+  packMask,
+  packMaterialBytes,
+  packedToWire,
+  wireToPacked,
+} from "../../shared/maskPack";
+import { WORLD_HEIGHT_PX, WORLD_WIDTH_PX } from "../../shared/worldConfig";
 import { dlogUnthrottled } from "../debug/logger";
 import { loadMap } from "../maps/loadMap";
 import { firstId, getById, lobbyIds } from "../maps/registry";
@@ -479,20 +486,26 @@ export class LobbyScene extends Phaser.Scene {
     );
 
     this.roomUnsubs.push(
-      room.onMessage("game_started", (msg: GameStartedMessage) => {
+      room.onMessage("game_started", async (msg: GameStartedMessage) => {
         dlogUnthrottled("scene", "LobbyScene.gameStarted", {
           mapId: msg.mapId,
           phase: room.state?.phase,
         });
         // Host clicked Start. Server includes the authoritative mask +
         // spawn points so every client renders pixel-identical terrain
-        // (server's physics and client's visuals match).
+        // (server's physics and client's visuals match). The mask + material
+        // map arrive deflate-compressed (see shared/maskPack); inflate them
+        // back to the uncompressed base64 GameScene decodes.
+        const mask = msg.mask ? bytesToBase64(await wireToPacked(msg.mask)) : msg.mask;
+        const materialMapBase64 = msg.materialMapBase64
+          ? bytesToBase64(await wireToPacked(msg.materialMapBase64))
+          : msg.materialMapBase64;
         this.scene.start("GameScene", {
           mapId: msg.mapId,
           seed: msg.seed,
           teams: msg.teams,
-          mask: msg.mask,
-          materialMapBase64: msg.materialMapBase64,
+          mask,
+          materialMapBase64,
           spawnPoints: msg.spawnPoints,
           widthPx: msg.widthPx,
           heightPx: msg.heightPx,
@@ -744,7 +757,7 @@ export class LobbyScene extends Phaser.Scene {
         60,
         "Start Game",
         () => {
-          this.handleStart();
+          void this.handleStart();
         },
         { enabled: vm.canStart, fill: vm.canStart ? 0x228833 : 0x333344 },
       );
@@ -816,7 +829,7 @@ export class LobbyScene extends Phaser.Scene {
     this.room?.send({ type: "set_ready", ready: next });
   }
 
-  private handleStart(): void {
+  private async handleStart(): Promise<void> {
     const room = this.room;
     if (!room) return;
     const mapId = room.state.selectedMapId || "flat";
@@ -837,21 +850,21 @@ export class LobbyScene extends Phaser.Scene {
       .setDepth(1000);
 
     try {
-      const WORLD_W = 2560;
-      const WORLD_H = 1024;
-      const loaded = loadMap(mapId, WORLD_W, WORLD_H);
+      const loaded = loadMap(mapId, WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
       const ctx = loaded.mask.getContext("2d");
       if (!ctx) throw new Error("mask canvas has no 2d context");
-      const img = ctx.getImageData(0, 0, WORLD_W, WORLD_H);
-      const bytes = new Uint8Array(WORLD_W * WORLD_H);
+      const img = ctx.getImageData(0, 0, WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
+      const bytes = new Uint8Array(WORLD_WIDTH_PX * WORLD_HEIGHT_PX);
       // Alpha > 0 means solid terrain.
       for (let i = 0; i < bytes.length; i++) bytes[i] = img.data[i * 4 + 3] > 0 ? 1 : 0;
       const packed = packMask(bytes);
-      const mask = bytesToBase64(packed);
+      // Deflate-compress the packed mask + material map for the wire and the
+      // server's Durable Object storage. A wide world's raw mask is multiple MB
+      // and overflows DO storage; compressed it is ~20KB. See shared/maskPack.
+      const mask = await packedToWire(packed);
       const spawnPoints = loaded.spawnPoints.map((s) => ({ xPx: s.xPx, yPx: s.yPx }));
-      // Pack and encode the material map if the generator produced one.
       const materialMapBase64 = loaded.materialMap
-        ? bytesToBase64(packMaterialBytes(loaded.materialMap))
+        ? await packedToWire(packMaterialBytes(loaded.materialMap))
         : undefined;
       room.send({ type: "start_game", mask, materialMapBase64, spawnPoints });
     } catch (err) {
@@ -889,17 +902,6 @@ export class LobbyScene extends Phaser.Scene {
       // Already closed.
     }
   }
-}
-
-/** Encode a Uint8Array as base64 for transport in a JSON message. */
-function bytesToBase64(bytes: Uint8Array): string {
-  let s = "";
-  // Chunk to avoid blowing the arg stack on >1MB buffers.
-  const CHUNK = 0x8000;
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    s += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  return btoa(s);
 }
 
 // Re-exported types used by other files importing this module.

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -22,9 +22,12 @@
 import {
   packMask as packMaskBytes,
   packedMaskByteLength,
+  packedToWire,
   unpackMask,
   unpackMaterialBytes,
+  wireToPacked,
 } from "../../shared/maskPack.js";
+import { WORLD_HEIGHT_PX, WORLD_WIDTH_PX } from "../../shared/worldConfig.js";
 
 import { type LogContext, dlog } from "./debug/logger.js";
 import {
@@ -74,9 +77,10 @@ const MAX_CLIENTS = 8;
 const SIM_TICK_MS = 50;
 const EMPTY_ROOM_GRACE_MS = 5 * 60 * 1000;
 
-/** Canonical physics world size. Clients use PX_PER_M=30 to render. */
-const WORLD_WIDTH_PX = 2560;
-const WORLD_HEIGHT_PX = 1024;
+// Canonical physics world size now lives in shared/worldConfig.ts so the
+// host (LobbyScene), the worker, and every guest agree on one number.
+// Clients use PX_PER_M=30 to render. (Previously hardcoded 2560x1024 here,
+// which silently diverged from the client and broke the bigger world online.)
 
 const TEAM_PALETTE: Array<{ id: string; name: string; color: string; prefix: string }> = [
   { id: "red", name: "Team Red", color: "#ff4444", prefix: "Red" },
@@ -246,9 +250,9 @@ export class Room implements DurableObject {
       this.simBootstrap = stored;
     }
     const bootstrap = this.simBootstrap;
-    // maskBase64 stores the 1-bit-packed form (for wire transport efficiency).
-    // Unpack to a full 1-byte-per-pixel mask before handing to Simulation.
-    const packedBytes = base64ToBytes(bootstrap.maskBase64);
+    // maskBase64 stores the deflate-compressed 1-bit-packed form. Inflate +
+    // unpack to a full 1-byte-per-pixel mask before handing to Simulation.
+    const packedBytes = await decodeStoredPacked(bootstrap.maskBase64);
     const pixelCount = bootstrap.widthPx * bootstrap.heightPx;
     const mask =
       packedBytes.length === pixelCount
@@ -256,7 +260,7 @@ export class Room implements DurableObject {
         : unpackMask(packedBytes, pixelCount);
     let reloadMaterialMap: Uint8Array | undefined;
     if (bootstrap.materialMapBase64) {
-      const packedMat = base64ToBytes(bootstrap.materialMapBase64);
+      const packedMat = await decodeStoredPacked(bootstrap.materialMapBase64);
       const expectedPackedMatLen = Math.ceil(pixelCount / 2);
       if (packedMat.length !== expectedPackedMatLen) {
         throw new Error(
@@ -880,7 +884,7 @@ export class Room implements DurableObject {
     let mapSpawns: Array<{ xPx: number; yPx: number }>;
     if (hostMask && hostSpawns && hostSpawns.length > 0) {
       try {
-        const packed = base64ToBytes(hostMask);
+        const packed = await wireToPacked(hostMask);
         const expectedPackedLen = packedMaskByteLength(WORLD_WIDTH_PX * WORLD_HEIGHT_PX);
         if (packed.length !== expectedPackedLen) {
           throw new Error(`packed mask length ${packed.length} != ${expectedPackedLen}`);
@@ -891,7 +895,7 @@ export class Room implements DurableObject {
         mapSpawns = hostSpawns;
         // Unpack the material map if provided by the host.
         if (hostMaterialMapBase64) {
-          const packedMat = base64ToBytes(hostMaterialMapBase64);
+          const packedMat = await wireToPacked(hostMaterialMapBase64);
           const pixelCount = WORLD_WIDTH_PX * WORLD_HEIGHT_PX;
           const expectedPackedMatLen = Math.ceil(pixelCount / 2);
           if (packedMat.length !== expectedPackedMatLen) {
@@ -904,13 +908,13 @@ export class Room implements DurableObject {
       } catch (err) {
         console.warn("[start_game] bad mask from host, using flat fallback:", err);
         mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
-        packedMaskBase64 = bytesToBase64(packMaskBytes(mask));
+        packedMaskBase64 = await packedToWire(packMaskBytes(mask));
         mapSpawns = [];
         materialMap = undefined;
       }
     } else {
       mask = buildFlatMask(WORLD_WIDTH_PX, WORLD_HEIGHT_PX);
-      packedMaskBase64 = bytesToBase64(packMaskBytes(mask));
+      packedMaskBase64 = await packedToWire(packMaskBytes(mask));
       mapSpawns = [];
       materialMap = undefined;
     }
@@ -949,9 +953,9 @@ export class Room implements DurableObject {
     // PR 1 debug: hardcode 3 barrels for end-to-end testing.
     // PR 3 will replace this with worldgen output.
     const initialObjects = [
-      { kind: "barrel", xPx: 600, yPx: 400 },
-      { kind: "barrel", xPx: 1280, yPx: 400 },
-      { kind: "barrel", xPx: 1960, yPx: 400 },
+      { kind: "barrel", xPx: Math.round(WORLD_WIDTH_PX * 0.25), yPx: 400 },
+      { kind: "barrel", xPx: Math.round(WORLD_WIDTH_PX * 0.5), yPx: 400 },
+      { kind: "barrel", xPx: Math.round(WORLD_WIDTH_PX * 0.75), yPx: 400 },
     ];
 
     this.sim = new Simulation({
@@ -1504,15 +1508,24 @@ function buildFlatMask(widthPx: number, heightPx: number): Uint8Array {
   return mask;
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
-  let s = "";
-  for (const b of bytes) s += String.fromCharCode(b);
-  return btoa(s);
-}
-
 function base64ToBytes(b64: string): Uint8Array {
   const raw = atob(b64);
   const out = new Uint8Array(raw.length);
   for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
   return out;
+}
+
+/**
+ * Decode a packed mask/material blob persisted in Durable Object storage. New
+ * bootstraps store the deflate-compressed form (packedToWire); bootstraps
+ * persisted before the compression change stored raw base64. Try inflate
+ * first, fall back to raw base64 so deploying this change does not break an
+ * in-flight game's resume-from-hibernation.
+ */
+async function decodeStoredPacked(stored: string): Promise<Uint8Array> {
+  try {
+    return await wireToPacked(stored);
+  } catch {
+    return base64ToBytes(stored);
+  }
 }


### PR DESCRIPTION
**PR1 of the multiplayer parity sweep** (plan: `docs/plans/multiplayer-parity-sweep.md`). Foundation: makes the bigger world actually reach multiplayer and unblocks PR2-5.

## Why
Online play was stuck at a stale hardcoded `2560x1024` (in `worker/src/room.ts` and `LobbyScene`) while `shared/worldConfig.ts` said `6144x1280`. So:
- The `#218`/`#222` "bigger world" commits only ever applied **offline**.
- Host generated `2560`, worker validated `2560`, offline rendered `6144` - host/guest could disagree on dimensions, the **likely root cause of #173** (guest worms float/sink at game start).

## What
- `WORLD_WIDTH_PX` 6144 -> **15360** (go-wide, 2.5x). Stays under the ~16384px WebGL max-texture-size ceiling (terrain is a single canvas texture this wide).
- Worker + LobbyScene now **import `worldConfig`**; the `2560x1024` hardcodes are gone. One number, three sides agree.
- **Deflate-compress** the packed mask + material map for the wire and DO storage. This is required, not just an optimization: an uncompressed 15360 mask is ~3.2MB of base64 and **overflows Durable Object storage (`SQLITE_TOOBIG`)** - a pre-existing ceiling the online/offline split was hiding. Compressed it is ~20-45KB (and the terrain wire payload drops ~100x).
  - Host (`LobbyScene.handleStart`, now async) compresses before `start_game`.
  - Worker stores/forwards the compressed form; resume-from-hibernation is legacy-tolerant so this deploy won't break in-flight games.
  - Guest inflates in the `game_started` handler back to the base64 `GameScene` already decodes - **GameScene untouched**.
- Placeholder barrels scaled to world width.

## Verification
- root `462` tests, worker `113` tests, `maskPack` `12` tests (incl. new round-trip + wide-world-under-128KB) - all green.
- typecheck (root + worker src), biome lint, vite build - all clean.
- The worker game-start tests previously failed `SQLITE_TOOBIG` at 15360; compression fixes them.

## Post-merge gate (held for review)
Netcode + new transport layer, so **not auto-merged**. After merge: `npm run deploy`, then a **live multiplayer playtest** to confirm (a) guest worms no longer float/sink (`#173`) and (b) the 15360 world renders + plays. I can't fully verify the online integration without a deployed session.

Refs #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)