### PR TITLE
fix(jetpack): activate online (#160) + sync forces to offline tuning (PR3)

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1315,9 +1315,22 @@ function adaptRenderableToWormFacade(
     disarm: () => {},
     resetForNewTurn: () => {},
   };
+  // #160: activate/deactivate were inherited no-op stubs, so pressing J or the
+  // on-screen button never sent input_jetpack_toggle. Map them to the toggle
+  // input, guarded by the authoritative isActive (isJetPackingFn) so the
+  // unconditional deactivate() calls on worm-switch / weapon-select don't
+  // accidentally toggle the jetpack ON.
+  const jetIsActive = isJetPackingFn ?? (() => false);
   const jetPackUtility = simRef
     ? {
         ...stubUtility,
+        isActive: jetIsActive,
+        activate: () => {
+          if (!jetIsActive()) simRef.toggleJetPack();
+        },
+        deactivate: () => {
+          if (jetIsActive()) simRef.toggleJetPack();
+        },
         setHorizontalInput: (dir: -1 | 0 | 1) => simRef.setJetPackHorizontal(dir),
         setVerticalInput: (active: boolean) => simRef.setJetPackThrust(active),
         setThrustVector: (nx: number, ny: number) => simRef.setJetPackThrustVector(nx, ny),

--- a/worker/src/entities/worm.ts
+++ b/worker/src/entities/worm.ts
@@ -263,9 +263,12 @@ export class Worm {
     }
 
     // Mirrors src/tuning.ts jetpack section so offline + networked feel the same.
-    const UP_FORCE = 15; // Newtons (planck units)
-    const SIDE_FORCE = 8;
-    const FUEL_PER_SECOND = 30; // percent per second
+    // Keep these in sync with tuning.jetpack (upwardForce / sideForce /
+    // fuelPerSecond); they drifted to 15/8 while offline moved to 17/10 (#221),
+    // making online jetpack noticeably weaker.
+    const UP_FORCE = 17; // Newtons (planck units); tuning.jetpack.upwardForce
+    const SIDE_FORCE = 10; // tuning.jetpack.sideForce
+    const FUEL_PER_SECOND = 30; // percent per second; tuning.jetpack.fuelPerSecond
 
     let fx: number;
     let fy: number;

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -1136,7 +1136,11 @@ export class Room implements DurableObject {
       // walk-stop (dir 0) bypasses the input-lock so a worm halts when the timer
       // expires post-fire. Without this, walk-stop messages arriving after the
       // retreat window expires are dropped and the worm keeps walking until turn end.
-      if (inputsLocked && !(input.kind === "walk" && input.dir === 0)) continue;
+      // Jetpack inputs (#160) also bypass the lock: the retreat/post-fire window
+      // is exactly when a player jets away, and dropping toggle/thrust here left
+      // the jetpack non-functional.
+      const isJetPackInput = input.kind.startsWith("jetpack_");
+      if (inputsLocked && !((input.kind === "walk" && input.dir === 0) || isJetPackInput)) continue;
       switch (input.kind) {
         case "walk":
           this.sim.applyWalkInput(activeWormId, input.dir);


### PR DESCRIPTION
**PR3 of the multiplayer parity sweep** (plan: `docs/plans/multiplayer-parity-sweep.md`). Builds on PR1/PR2 (merged).

## Closes #160 - jetpack does nothing online
Two bugs, both per the issue's diagnosis:

**Bug 1 - client toggle never sent.** The networked worm facade (`GameScene.adaptRenderableToWormFacade`) wired thrust/horizontal but left `jetPackUtility.activate/deactivate/isActive` as inherited no-op stubs. So J-key (`InputController` `isActive() ? deactivate() : activate()`) and the on-screen button never sent `input_jetpack_toggle`. Now mapped to the adapter's `toggleJetPack`, guarded by the authoritative `isJetPacking` so the unconditional `deactivate()` calls on worm-switch don't accidentally toggle it on. (The thrust path already worked - it reads the real `worm.isJetPacking()`.)

**Bug 2 - server dropped jetpack inputs under the lock.** The input gate let only `walk dir=0` through during the retreat / post-fire window - which is exactly when you jet away. Jetpack inputs were discarded. Now `jetpack_*` inputs bypass the lock too.

## Force tuning sync (the "other update that didn't reach multiplayer")
Worker jetpack forces drifted: `UP_FORCE` 15 -> **17**, `SIDE_FORCE` 8 -> **10** to match `tuning.jetpack` (offline moved in #221). Online jetpack was noticeably weaker. Added a keep-in-sync comment.

## Verification
- typecheck (root + worker src), lint, vite build clean.
- root 465 + worker 113 tests pass (no regressions).
- The fix is input-routing + constants, matching the issue's root-cause analysis; like the original bug, **final confirmation is a playtest** (J / on-screen button activates jetpack, and it works during the retreat window).

Held for review (game behavior + netcode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)