### PR TITLE
feat(drill): networked drill via drill_fire (PR4 of parity sweep)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -225,6 +225,12 @@ export interface TerrainCutEvent {
   y: number;
   r: number;
   seq: number;
+  /**
+   * Present for rectangular (drill) cuts; absent for circular
+   * (explosion/tunnel) cuts. When set, clients render via cutRect instead of
+   * cutCircle. x/y are the cut origin (worm position); r is unused for rects.
+   */
+  rect?: { lengthPx: number; widthPx: number; angleRad: number };
 }
 
 /**
@@ -375,5 +381,6 @@ export type ClientMsg =
   | { type: "input_jetpack_thrust"; active: boolean; seq: number }
   | { type: "input_jetpack_horizontal"; dir: -1 | 0 | 1; seq: number }
   | { type: "input_jetpack_vector"; vx: number; vy: number }
+  | { type: "input_drill_fire"; angleRad: number; seq: number }
   | { type: "leave" }
   | { type: "client_log"; scope: string; event: string; data?: unknown; ts: number };

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -641,7 +641,18 @@ export class GameScene extends Phaser.Scene {
       case "terrain_cut":
         // Visual mask cut (networked mode only; offline mode cuts the
         // bodies-aware Terrain directly inside OfflineSimAdapter).
-        this.terrainRenderer?.cutCircle(ev.x, ev.y, ev.r, ev.seq);
+        if (ev.rect) {
+          // Drill rect cut (#201). Pixel erase is idempotent, so no seq dedup.
+          this.terrainRenderer?.cutRect(
+            ev.x,
+            ev.y,
+            ev.rect.lengthPx,
+            ev.rect.widthPx,
+            ev.rect.angleRad,
+          );
+        } else {
+          this.terrainRenderer?.cutCircle(ev.x, ev.y, ev.r, ev.seq);
+        }
         // Radius-scaled camera shake + screen flash. Bigger weapons feel bigger.
         if (ev.r >= tuning.juice.shakeMinRadiusPx) {
           const durMs = Math.min(280, 80 + ev.r * 2);

--- a/src/sim/NetworkedSimAdapter.ts
+++ b/src/sim/NetworkedSimAdapter.ts
@@ -311,9 +311,11 @@ export class NetworkedSimAdapter implements SimAdapter {
     this.send({ type: "input_jetpack_vector", vx, vy });
   }
 
-  executeDrill(_wormId: string, _angleRad: number): void {
-    // Networked drill not yet implemented. See follow-up issue.
-    console.warn("[drill] networked drill not yet implemented");
+  executeDrill(_wormId: string, angleRad: number): void {
+    // Server applies the rect cut to the active worm (wormId implied) and
+    // broadcasts the resulting terrain_cut. Per-turn use + cooldown gating is
+    // client-side (the drill facade), same as offline. (#201)
+    this.send({ type: "input_drill_fire", angleRad, seq: this.nextSeq() });
   }
 
   isJetPacking(): boolean {

--- a/worker/src/entities/terrain.ts
+++ b/worker/src/entities/terrain.ts
@@ -45,7 +45,9 @@ export interface TerrainCut {
   y: number;
   r: number;
   seq: number;
-  source: "explode" | "tunnel";
+  source: "explode" | "tunnel" | "drill";
+  /** Set for drill (rect) cuts so clients render via cutRect, not cutCircle. */
+  rect?: { lengthPx: number; widthPx: number; angleRad: number };
 }
 
 interface TerrainBodyMeta {
@@ -109,6 +111,78 @@ export class Terrain {
 
     this.cutSeq += 1;
     const cut: TerrainCut = { x: xPx, y: yPx, r: rPx, seq: this.cutSeq, source };
+    this.cutLog.push(cut);
+    return cut;
+  }
+
+  /**
+   * Erase a rotated rectangle of mask pixels (the drill cut), rebuild bodies in
+   * the affected Y-band, and log the cut with its rect geometry so the
+   * Simulation broadcasts it for cutRect rendering on clients. Mirrors the
+   * client Terrain.cutRect; origin is the worm position, length extends along
+   * angleRad, width is perpendicular. Material gating uses lengthPx (not halfW)
+   * so the drill cuts through rock/stone, matching the client.
+   */
+  cutRect(
+    originXPx: number,
+    originYPx: number,
+    lengthPx: number,
+    widthPx: number,
+    angleRad: number,
+  ): TerrainCut {
+    const dx = Math.cos(angleRad);
+    const dy = Math.sin(angleRad);
+    const perpX = -dy;
+    const perpY = dx;
+    const halfW = widthPx / 2;
+
+    const corners = [
+      [0, -halfW],
+      [lengthPx, -halfW],
+      [lengthPx, halfW],
+      [0, halfW],
+    ].map(([t, s]) => [
+      originXPx + (t ?? 0) * dx + (s ?? 0) * perpX,
+      originYPx + (t ?? 0) * dy + (s ?? 0) * perpY,
+    ]);
+    const rawMinY = Math.floor(Math.min(...corners.map((c) => c[1] ?? 0)));
+    const rawMaxY = Math.ceil(Math.max(...corners.map((c) => c[1] ?? 0)));
+    const x0 = Math.max(0, Math.floor(Math.min(...corners.map((c) => c[0] ?? 0))));
+    const x1 = Math.min(this.widthPx, Math.ceil(Math.max(...corners.map((c) => c[0] ?? 0))));
+    const y0 = Math.max(0, rawMinY);
+    const y1 = Math.min(this.heightPx, rawMaxY);
+
+    for (let y = y0; y < y1; y++) {
+      const rowOffset = y * this.widthPx;
+      for (let x = x0; x < x1; x++) {
+        const lx = x - originXPx;
+        const ly = y - originYPx;
+        const t = lx * dx + ly * dy;
+        if (t < 0 || t > lengthPx) continue;
+        const s = lx * perpX + ly * perpY;
+        if (s < -halfW || s > halfW) continue;
+        if (this.materialMap !== null) {
+          const mat = this.materialMap[rowOffset + x];
+          if (mat === MATERIAL_ROCK && lengthPx < this.hardness.rockMinRadiusPx) continue;
+          if (mat === MATERIAL_STONE && lengthPx < this.hardness.stoneMinRadiusPx) continue;
+        }
+        this.mask[rowOffset + x] = 0;
+      }
+    }
+
+    const yMin = Math.max(0, Math.floor(rawMinY / this.rowHeight) * this.rowHeight);
+    const yMax = Math.min(this.heightPx, Math.ceil(rawMaxY / this.rowHeight) * this.rowHeight);
+    this.rebuildBodiesInRegion(yMin, yMax);
+
+    this.cutSeq += 1;
+    const cut: TerrainCut = {
+      x: originXPx,
+      y: originYPx,
+      r: 0,
+      seq: this.cutSeq,
+      source: "drill",
+      rect: { lengthPx, widthPx, angleRad },
+    };
     this.cutLog.push(cut);
     return cut;
   }

--- a/worker/src/room.ts
+++ b/worker/src/room.ts
@@ -117,7 +117,8 @@ type PendingInput =
   | { kind: "jetpack_toggle"; sessionId: string }
   | { kind: "jetpack_thrust"; sessionId: string; active: boolean }
   | { kind: "jetpack_horizontal"; sessionId: string; dir: -1 | 0 | 1 }
-  | { kind: "jetpack_vector"; sessionId: string; vx: number; vy: number };
+  | { kind: "jetpack_vector"; sessionId: string; vx: number; vy: number }
+  | { kind: "drill_fire"; sessionId: string; angleRad: number };
 
 /** Sim-kickoff metadata persisted so hibernation can rebuild. */
 interface SimBootstrap {
@@ -506,6 +507,7 @@ export class Room implements DurableObject {
       case "input_jetpack_thrust":
       case "input_jetpack_horizontal":
       case "input_jetpack_vector":
+      case "input_drill_fire":
         this.queueInput(attachment.sessionId, type, msg);
         break;
       case "client_log":
@@ -1103,6 +1105,12 @@ export class Room implements DurableObject {
         this.pendingInputs.push({ kind: "jetpack_vector", sessionId: senderSessionId, vx, vy });
         return;
       }
+      case "input_drill_fire": {
+        const angleRad = raw.angleRad;
+        if (typeof angleRad !== "number" || !Number.isFinite(angleRad)) return;
+        this.pendingInputs.push({ kind: "drill_fire", sessionId: senderSessionId, angleRad });
+        return;
+      }
       case "input_end_turn":
         // Explicit end-turn press from the active player. Force-advance
         // via the arbiter (validates ownership + pause state). Without
@@ -1203,6 +1211,9 @@ export class Room implements DurableObject {
         case "jetpack_vector":
           this.sim.applyJetPackVector(activeWormId, input.vx, input.vy);
           break;
+        case "drill_fire":
+          this.sim.applyDrill(activeWormId, input.angleRad);
+          break;
       }
     }
   }
@@ -1294,6 +1305,7 @@ export class Room implements DurableObject {
           y: ev.y,
           r: ev.r,
           seq: ev.seq,
+          rect: ev.rect,
         });
         return;
       case "fire_event":

--- a/worker/src/sim/simulation.ts
+++ b/worker/src/sim/simulation.ts
@@ -46,6 +46,10 @@ import type { FireResult as WeaponFireResult } from "../weapons/fire.js";
 import { defaultAmmoForMatch, getById } from "../weapons/registry.js";
 
 const MAX_PROJECTILES = 8;
+// Mirror of tuning.drill (src/tuning.ts). The drill cuts a lengthPx x widthPx
+// rectangle along the worm's aim. Keep in sync.
+const DRILL_LENGTH_PX = 220;
+const DRILL_WIDTH_PX = 48;
 
 export interface SimEventTerrainCut {
   type: "terrain_cut";
@@ -53,6 +57,8 @@ export interface SimEventTerrainCut {
   y: number;
   r: number;
   seq: number;
+  /** Set for drill (rect) cuts so clients render via cutRect, not cutCircle. */
+  rect?: { lengthPx: number; widthPx: number; angleRad: number };
 }
 
 export interface SimEventFire {
@@ -384,6 +390,25 @@ export class Simulation {
   }
 
   /**
+   * Drill: cut a rect of terrain along `angleRad` from the worm's position.
+   * The drill is a utility (no ammo, no projectile, does not end the turn);
+   * per-turn use + cooldown gating is client-side. The cut is logged and
+   * broadcast as a terrain_cut event (with rect geometry) in the drain pass.
+   */
+  applyDrill(wormId: string, angleRad: number): void {
+    const worm = this.worms.get(wormId);
+    if (!worm || !worm.alive) return;
+    const pos = worm.body.getPosition();
+    this.terrain.cutRect(
+      toPixels(pos.x),
+      toPixels(pos.y),
+      DRILL_LENGTH_PX,
+      DRILL_WIDTH_PX,
+      angleRad,
+    );
+  }
+
+  /**
    * Fire the worm's active weapon. Returns a SimFireResult so the caller can
    * inspect shotsRemaining / turnEndsImmediately (on success) or forward a
    * rejection reason to the originating client (on failure). Also emits a
@@ -594,14 +619,22 @@ export class Simulation {
       }
     }
 
-    // 7. Drain terrain cut log. Drill tunnel cuts (projectile.tickTunnel
-    //    -> terrain.cutCircle) bypass emitExplodeEvents, so emit them as
-    //    terrain_cut SimEvents here. Explosion cuts already emitted via
-    //    emitExplodeEvents - filter them out to avoid double-emit.
+    // 7. Drain terrain cut log. Projectile tunnel cuts (projectile.tickTunnel
+    //    -> terrain.cutCircle) and drill rect cuts (applyDrill -> terrain.cutRect)
+    //    bypass emitExplodeEvents, so emit them as terrain_cut SimEvents here.
+    //    Explosion cuts already emitted via emitExplodeEvents - filter them out
+    //    to avoid double-emit.
     const drained = this.terrain.consumeCutLog();
     for (const cut of drained) {
-      if (cut.source !== "tunnel") continue;
-      this.events.push({ type: "terrain_cut", x: cut.x, y: cut.y, r: cut.r, seq: cut.seq });
+      if (cut.source !== "tunnel" && cut.source !== "drill") continue;
+      this.events.push({
+        type: "terrain_cut",
+        x: cut.x,
+        y: cut.y,
+        r: cut.r,
+        seq: cut.seq,
+        rect: cut.rect,
+      });
     }
 
     // stateChanged: always true when playing (worms + projectiles

--- a/worker/test/terrain.test.ts
+++ b/worker/test/terrain.test.ts
@@ -173,3 +173,44 @@ describe("Terrain - materialMap hardness gate", () => {
     expect(() => terrain.cutCircle(16, 16, 5, "explode")).not.toThrow();
   });
 });
+
+describe("Terrain - cutRect (drill)", () => {
+  it("erases a rectangle of pixels along the aim angle", () => {
+    const world = new World();
+    const terrain = makeTerrain(world);
+    const before = terrain.solidPixelCount();
+    terrain.cutRect(16, 16, 20, 8, 0); // length 20 rightward, width 8
+    expect(terrain.solidPixelCount()).toBeLessThan(before);
+  });
+
+  it("logs a drill cut carrying its rect geometry", () => {
+    const world = new World();
+    const terrain = makeTerrain(world);
+    const cut = terrain.cutRect(16, 16, 20, 8, 0);
+    expect(cut.source).toBe("drill");
+    expect(cut.rect).toEqual({ lengthPx: 20, widthPx: 8, angleRad: 0 });
+    const drained = terrain.consumeCutLog();
+    expect(drained).toHaveLength(1);
+    expect(drained[0]?.rect?.lengthPx).toBe(20);
+  });
+
+  it("cuts through stone when gated by lengthPx (not the narrow width)", () => {
+    // halfW = 4 is well below stoneMinRadiusPx (60); the gate uses lengthPx so
+    // a full-length drill still erases stone. length 60 >= 60 -> passes.
+    const world = new World();
+    const mat = makeUniformMaterial(W, H, MATERIAL_STONE);
+    const terrain = makeTerrain(world, mat, HARDNESS);
+    const before = terrain.solidPixelCount();
+    terrain.cutRect(16, 16, 60, 8, Math.PI); // leftward, length 60
+    expect(terrain.solidPixelCount()).toBeLessThan(before);
+  });
+
+  it("short drill is gated out of stone (lengthPx < stoneMinRadiusPx)", () => {
+    const world = new World();
+    const mat = makeUniformMaterial(W, H, MATERIAL_STONE);
+    const terrain = makeTerrain(world, mat, HARDNESS);
+    const before = terrain.solidPixelCount();
+    terrain.cutRect(16, 16, 10, 8, 0); // length 10 < stoneMin 60 -> stone survives
+    expect(terrain.solidPixelCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
**PR4 of the multiplayer parity sweep** (plan: `docs/plans/multiplayer-parity-sweep.md`). Builds on PR1-3 (merged).

## Closes #201 - drill was offline-only
Networked `executeDrill` was a `console.warn` stub. Wired end to end with a dedicated `drill_fire` message (drill is an armed *utility*, not the selected weapon, so reusing `input_fire` would fire the bazooka).

**Flow:**
- **protocol**: new `input_drill_fire { angleRad }`; `TerrainCutEvent` gains optional `rect { lengthPx, widthPx, angleRad }` so a cut can render as a rect.
- **client** (`NetworkedSimAdapter.executeDrill`): sends `input_drill_fire`. Per-turn use + cooldown stays client-side (the drill facade), same as offline.
- **worker**: queues it like other inputs → `Simulation.applyDrill(activeWorm, angleRad)` → new `terrain.cutRect` at the worm position. `cutRect` ports the client geometry (rotated-rect erase + Y-band body rebuild) and gates material by `lengthPx` so the drill cuts through rock/stone. Cuts log with `source: "drill"` + `rect`, drain into `terrain_cut` events, broadcast (with `rect`) like explosions.
- **guest** (`GameScene` `terrain_cut` handler): rect cuts → `TerrainRenderer.cutRect`; circular cuts → `cutCircle` as before.

Server validates the active-player turn (same input path as fire); no server-side ammo / turn-end (drill is a utility). Client + worker cut pixel-identical geometry from the shipped angle.

## Notes
- `TerrainRenderer.cutRect` / `Terrain.cutRect` already existed (#203 effectively done).
- Drill emits no camera shake (`r=0`); it is a quiet digging tool, matching offline.

## Verification
- typecheck (root + worker src), lint, vite build clean.
- worker **117** (4 new `cutRect` tests: erase, drill-cut log + rect, lengthPx hardness gate both directions) + root 465 pass.
- Final confirmation is a playtest: arm drill (D), drag-aim + release, confirm the tunnel appears for all clients.

Held for review (netcode + new protocol message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)