### PR TITLE
fix(rope): disable the rope control (button + R key) everywhere

### DIFF
--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -53,7 +53,6 @@ export class InputController {
   private readonly keyW: Phaser.Input.Keyboard.Key;
   private readonly keyS: Phaser.Input.Keyboard.Key;
   private readonly keyTab: Phaser.Input.Keyboard.Key;
-  private readonly keyRope: Phaser.Input.Keyboard.Key; // R
   private readonly keyJetPack: Phaser.Input.Keyboard.Key; // J
   private readonly keyDrill: Phaser.Input.Keyboard.Key; // D (drill toggle - only when worm.isRoped/isJetPacking are false)
   private readonly keyEnter: Phaser.Input.Keyboard.Key;
@@ -90,7 +89,6 @@ export class InputController {
     this.keyW = kb.addKey(Phaser.Input.Keyboard.KeyCodes.W);
     this.keyS = kb.addKey(Phaser.Input.Keyboard.KeyCodes.S);
     this.keyTab = kb.addKey(Phaser.Input.Keyboard.KeyCodes.TAB);
-    this.keyRope = kb.addKey(Phaser.Input.Keyboard.KeyCodes.R);
     this.keyJetPack = kb.addKey(Phaser.Input.Keyboard.KeyCodes.J);
     this.keyDrill = kb.addKey(Phaser.Input.Keyboard.KeyCodes.D);
     this.keyEnter = kb.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
@@ -196,12 +194,8 @@ export class InputController {
     if (!worm) return;
 
     // ---------------------------------------------------------------------------
-    // Rope and JetPack activation toggles (always available regardless of state)
+    // JetPack activation toggle (rope is disabled - see GameScene ropeEnabled)
     // ---------------------------------------------------------------------------
-
-    if (Phaser.Input.Keyboard.JustDown(this.keyRope)) {
-      worm.ropeUtility.isActive() ? worm.ropeUtility.deactivate() : worm.ropeUtility.activate();
-    }
 
     if (Phaser.Input.Keyboard.JustDown(this.keyJetPack)) {
       worm.jetPackUtility.isActive()

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -391,7 +391,10 @@ export class GameScene extends Phaser.Scene {
       this.touchControls = new TouchControls({
         scene: this,
         getActiveWorm: () => this.getActiveWormAdapter(),
-        ropeEnabled: !this.isNetworked,
+        // Rope is disabled everywhere: networked rope is deferred (#82, needs
+        // client-side prediction) and offline-only rope was an inconsistent
+        // half-feature. NinjaRope.ts is retained for future re-intro.
+        ropeEnabled: false,
         jetPackEnabled: true,
         drillEnabled: true,
       });


### PR DESCRIPTION
The rope button was visible in offline mode (it was only hidden in networked mode via `ropeEnabled: !isNetworked`). Since networked rope is deferred (#82) and offline-only rope is an inconsistent half-feature for an MP-first game, disable the control everywhere:

- `GameScene`: `ropeEnabled: false` (was `!isNetworked`) - hides the touch rope button in all modes.
- `InputController`: removed the keyboard **R** rope toggle + its now-unused `keyRope` binding.

`NinjaRope.ts` and the offline `ropeUtility` are left intact for future re-intro (matching the unregister-but-keep pattern) - they are simply unreachable now.

Verified: typecheck, lint, vite build, root 465 tests all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)